### PR TITLE
Modify OpenCommit Action to Ignore 'dependabot/**' Branches

### DIFF
--- a/.github/workflows/opencommit.yml
+++ b/.github/workflows/opencommit.yml
@@ -2,7 +2,9 @@ name: "OpenCommit Action"
 
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore:
+      - main
+      - 'dependabot/**'
 
 jobs:
   opencommit:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration to ignore pushes to branches matching the pattern 'dependabot/**', ensuring cleaner commit history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->