### PR TITLE
Remove --no-cache-dir from Dockerfile and comment out isort in pyproject.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 COPY . .
-RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
+RUN pip wheel --wheel-dir /app/wheels -r requirements.txt
 RUN pip install --no-cache-dir -r requirements-build.txt \
     && python db.py \
     && alembic upgrade head

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ exclude = ["temp.*", "migrations.*"]
 [tool.pylint]
 disable = ["C0114", "C0115", "C0116", "C0301"]
 
-[tool.isort]
-py_version = 312
-skip_glob = ["temp/*", "migrations/*"]
-multi_line_output = 3
-include_trailing_comma = true
-line_length = 88
+# [tool.isort]
+# py_version = 312
+# skip_glob = ["temp/*", "migrations/*"]
+# multi_line_output = 3
+# include_trailing_comma = true
+# line_length = 88
 
 [tool.ruff]
 extend-exclude = ["temp", "migrations"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the build process for the Python application by modifying the Dockerfile.
	- Updated `pyproject.toml` to comment out the `isort` settings, while retaining configurations for `mypy`, `pylint`, and `ruff`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->