### PR TITLE
STG-41 🔧 fix(transcription.py): add ParseError to retry conditions for trans…

### DIFF
--- a/src/transcription.py
+++ b/src/transcription.py
@@ -1,5 +1,6 @@
 import time
 from pathlib import Path
+from xml.etree.ElementTree import ParseError
 
 from replicate.exceptions import ModelError
 from requests.exceptions import ProxyError
@@ -43,7 +44,7 @@ def transcribe(file: str, sleep_time: int = 10) -> str:
 
 @retry(
     wait=wait_fixed(10),
-    retry=retry_if_exception_type(ProxyError),
+    retry=retry_if_exception_type((ProxyError, ParseError)),
     reraise=True,
     stop=stop_after_attempt(3),
 )  # type: ignore[call-overload]


### PR DESCRIPTION
…cribe function to handle XML parsing errors during transcription process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the transcription function to include retries for `ParseError` in addition to `ProxyError`.

- **Bug Fixes**
	- Improved resilience of the transcript retrieval process by allowing for retries on specific parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->