### PR TITLE
Update Dependabot configuration and modify workflow to ignore renovate branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,19 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 # https://containers.dev/guide/dependabot
 
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: weekly
+# version: 2
+# updates:
+#   - package-ecosystem: "pip"
+#     directory: "/"
+#     schedule:
+#       interval: weekly
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: weekly
+#   - package-ecosystem: "docker"
+#     directory: "/"
+#     schedule:
+#       interval: weekly
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: weekly
+#   - package-ecosystem: "github-actions"
+#     directory: "/"
+#     schedule:
+#       interval: weekly

--- a/.github/workflows/opencommit.yml
+++ b/.github/workflows/opencommit.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - "dependabot/**"
+      - "renovate/**"
 
 jobs:
   opencommit:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled the Dependabot configuration for package updates.
	- Updated the OpenCommit Action workflow to ignore branches matching the pattern "renovate/**".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->