### PR TITLE
🔧 chore(dependabot.yml): comment out pip and docker package updates t…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,15 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: weekly
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: weekly
 
-#   - package-ecosystem: "docker"
-#     directory: "/"
-#     schedule:
-#       interval: weekly
+  #   - package-ecosystem: "docker"
+  #     directory: "/"
+  #     schedule:
+  #       interval: weekly
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
…o reduce unnecessary checks and focus on GitHub Actions updates only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled Dependabot updates for "pip" and "docker" package ecosystems while retaining updates for "github-actions."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->