### PR TITLE
chore(deps): disable GitHub Actions updates in Dependabot and Renovat…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,9 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 # https://containers.dev/guide/dependabot
 
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: weekly
+# version: 2
+# updates:
+#   - package-ecosystem: "github-actions"
+#     directory: "/"
+#     schedule:
+#       interval: weekly

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,13 +5,5 @@
   ],
   "schedule": [
     "on sunday"
-  ],
-  "packageRules": [
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "enabled": false
-    }
   ]
 }


### PR DESCRIPTION
…e configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled Dependabot configuration
	- Removed GitHub Actions package rules from Renovate configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->