### PR TITLE
Remove gemini-1.5-pro model and update YouTube proxy configuration logic

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -54,7 +54,6 @@ GEMINI_API_KEY = os.environ["GEMINI_API_KEY"]
 gemini_client = genai.Client(api_key=GEMINI_API_KEY)
 MODEL_ID_FOR_TRANSLATION = "gemini-2.0-flash"
 ALLOWED_MODELS_FOR_SUMMARY = [
-    "gemini-1.5-pro",
     "gemini-1.5-flash",
     "gemini-2.0-flash",
     "gemini-2.5-flash-preview-05-20",

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -81,7 +81,10 @@ def get_yt_transcript(url: str) -> str:
         msg = "Unknown URL"
         raise ValueError(msg)
 
-    ytt_api = YouTubeTranscriptApi(proxy_config=GenericProxyConfig(https_url=PROXY))
+    if PROXY:
+        ytt_api = YouTubeTranscriptApi(proxy_config=GenericProxyConfig(https_url=PROXY))
+    else:
+        ytt_api = YouTubeTranscriptApi()
 
     try:
         transcript = ytt_api.fetch(video_id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved YouTube transcript retrieval by only using a proxy when one is configured, enhancing reliability for users without proxy settings.

- **Chores**
  - Updated configuration to remove "gemini-1.5-pro" from the list of available models for summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->