### PR TITLE
fix(docker): add --no-dev flag to uv sync command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/
 COPY pyproject.toml uv.lock ./
 RUN uv sync \
     --frozen \
+    --no-dev \
     --compile-bytecode \
     --python-preference only-system \
     && rm -f pyproject.toml uv.lock


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production build process to exclude development dependencies, ensuring only necessary packages are installed for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->