### PR TITLE
Add Dependabot config, disable Renovate, and allow gemini-2.5-pro model

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,6 @@
 {
+  "enabled": false,
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "schedule": [
-    "on sunday"
-  ]
+  "extends": ["config:recommended"],
+  "schedule": ["on sunday"]
 }

--- a/src/config.py
+++ b/src/config.py
@@ -54,6 +54,7 @@ gemini_client = genai.Client(api_key=GEMINI_API_KEY)
 MODEL_ID_FOR_TRANSLATION = "gemini-2.0-flash"
 ALLOWED_MODELS_FOR_SUMMARY = [
     "gemini-2.5-flash",
+    "gemini-2.5-pro",
 ]
 # if change DEFAULT_MODEL_ID_FOR_SUMMARY, also change in models.py
 DEFAULT_MODEL_ID_FOR_SUMMARY = "gemini-2.5-flash"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated dependency updates with Dependabot for package, Docker, and GitHub Actions dependencies.
  * Disabled Renovate as a dependency management tool.

* **New Features**
  * Added support for the "gemini-2.5-pro" model in available summary options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->