### PR TITLE
build: add retry mechanism for SSLError in download_castro function

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import requests
 from bs4 import BeautifulSoup
+from requests.exceptions import SSLError
 from tenacity import (
     before_sleep_log,
     retry,
@@ -67,6 +68,13 @@ def download_yt(url: str) -> str:
     return temprorary_file_name
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(10),
+    retry=retry_if_exception_type(SSLError),
+    before_sleep=before_sleep_log(logger, log_level=logging.WARNING),
+    reraise=False,
+)
 def download_castro(url: str) -> str:
     """Download audio from a Castro podcast URL and save it as an MP3 file.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability by automatically retrying up to three times when temporary SSL connection errors occur, with a short wait between attempts. This reduces unexpected failures from transient network issues and provides a smoother, more resilient download experience. No action or configuration changes are required from users; the behavior is automatic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->