### PR TITLE
fix: update retry logic to handle both DownloadError and SSLError

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 @retry(
     stop=stop_after_attempt(2),
     wait=wait_fixed(10),
-    retry=retry_if_exception_type(DownloadError),
+    retry=retry_if_exception_type(DownloadError, SSLError),
     before_sleep=before_sleep_log(logger, log_level=logging.WARNING),
     reraise=False,
 )

--- a/src/download.py
+++ b/src/download.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 @retry(
     stop=stop_after_attempt(2),
     wait=wait_fixed(10),
-    retry=retry_if_exception_type(DownloadError, SSLError),
+    retry=retry_if_exception_type((DownloadError, SSLError)),
     before_sleep=before_sleep_log(logger, log_level=logging.WARNING),
     reraise=False,
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download reliability by retrying when SSL errors occur, reducing failures from certificate or handshake issues.
  - Broadened retry coverage beyond previous error types to better handle intermittent network and connection problems.
  - Users should experience fewer failed downloads and less need to manually retry during temporary SSL or network glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->