### PR TITLE
fix: refine retry logic to handle only DownloadError in download_yt f…

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 @retry(
     stop=stop_after_attempt(2),
     wait=wait_fixed(10),
-    retry=retry_if_exception_type((DownloadError, SSLError)),
+    retry=retry_if_exception_type(DownloadError),
     before_sleep=before_sleep_log(logger, log_level=logging.WARNING),
     reraise=False,
 )

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -73,6 +73,8 @@ def get_yt_transcript(url: str) -> str:
     """
     if url.startswith("https://www.youtube.com/watch"):
         video_id = url.replace("https://www.youtube.com/watch?v=", "").split("?")[0]
+    elif url.startswith("https://youtube.com/watch"):
+        video_id = url.replace("https://youtube.com/watch?v=", "").split("?")[0]
     elif url.startswith("https://youtu.be/"):
         video_id = url.replace("https://youtu.be/", "").split("?")[0]
     elif url.startswith("https://www.youtube.com/live/"):


### PR DESCRIPTION
…unction

fix: enhance URL handling for YouTube links in get_yt_transcript function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube transcript handling to support URLs starting with https://youtube.com/watch in addition to https://www.youtube.com/watch.
  * Adjusted download retry behavior to no longer retry on SSL errors, reducing unnecessary wait times on unrecoverable failures while preserving retry timing for other errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->