### PR TITLE
chore: comment out package ecosystem updates in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,19 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 # https://containers.dev/guide/dependabot
 
-version: 2
-updates:
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: weekly
+# version: 2
+# updates:
+#   - package-ecosystem: "uv"
+#     directory: "/"
+#     schedule:
+#       interval: weekly
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: weekly
+#   - package-ecosystem: "docker"
+#     directory: "/"
+#     schedule:
+#       interval: weekly
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: weekly
+#   - package-ecosystem: "github-actions"
+#     directory: "/"
+#     schedule:
+#       interval: weekly


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Temporarily disabled automated dependency update schedules to pause Dependabot activity across multiple ecosystems.
  - Affects repository maintenance workflows only; no changes to application behavior or user experience.
  - No production code was modified; manual updates can still be performed as needed.
  - Security alerts and vulnerability monitoring remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->