### PR TITLE
Update project structure docs to expand docs/context contents

### DIFF
--- a/docs/context/project-structure.md
+++ b/docs/context/project-structure.md
@@ -24,6 +24,14 @@ project-root/
 ├── scripts/                          ← Utility scripts (db init, etc.)
 ├── docs/                             ← Documentation
 │   ├── context/                      ← Reusable domain knowledge
+│   │   ├── archive-rules.md         # Summary lifecycle and archival rules
+│   │   ├── git-guide.md             # Git workflow and repository conventions
+│   │   ├── processing-protocol.md   # Document processing workflow
+│   │   ├── project-structure.md     # Repository layout reference
+│   │   ├── style-guide.md           # Writing and coding conventions
+│   │   ├── subagent-rules.md        # Rules for sub-agent usage and outputs
+│   │   ├── tech-stack.md            # Architecture and technology decisions
+│   │   └── tooling-guide.md         # Tooling and local workflow guidance
 │   ├── summaries/                    ← Session state and handoffs
 │   └── archive/                      ← Processed raw files
 ├── pyproject.toml                    ← Project configuration


### PR DESCRIPTION
## Summary
- Expand `docs/context/` in `docs/context/project-structure.md`
- List the current context files with short descriptions so the documented tree matches the repository

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced repository documentation with new reference guides covering project structure, Git workflows, document processing, coding conventions, technology stack, and local development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->