### PR TITLE
Update webpage summarization to use UrlContext system instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,14 +175,16 @@ poetry.toml
 !.env.vault
 !.env.example
 
-# Ruff
+# Cache
 .ruff_cache
+.uv-cache
 
-# Kiro
+# IDE
 .kiro/
 .zed/
 .vscode/
 .codex/
+.kilo/
 
 # AI
 docs/discovery
@@ -192,6 +194,3 @@ docs/strategy
 docs/archive
 docs/summaries
 output/
-
-# Kilo
-.kilo/

--- a/src/services.py
+++ b/src/services.py
@@ -168,13 +168,21 @@ def check_quota(quantity: int = 1) -> bool:
     return True
 
 
-def get_gemini_config(target_language: str) -> types.GenerateContentConfig:
+def get_gemini_config(
+    target_language: str,
+    extra_system_instruction: str | None = None,
+) -> types.GenerateContentConfig:
     """Get Gemini config with system instruction."""
+    system_instruction = dedent(
+        SYSTEM_INSTRUCTION.format(language=target_language),
+    ).strip()
+    if extra_system_instruction is not None:
+        system_instruction = (
+            f"{system_instruction}\n\n{extra_system_instruction.strip()}"
+        )
     return GEMINI_CONFIG.model_copy(
         update={
-            "system_instruction": dedent(
-                SYSTEM_INSTRUCTION.format(language=target_language),
-            ).strip(),
+            "system_instruction": system_instruction,
         },
     )
 

--- a/src/summary.py
+++ b/src/summary.py
@@ -208,13 +208,20 @@ def summarize_webpage(
     """
     prompt = (f"{dedent(PROMPTS[prompt_key])} {content}").strip()
     check_quota(quantity=1)
-    tools = [types.Tool(url_context=types.UrlContext())]
     response = gemini_client.models.generate_content(
         model=model,
         contents=prompt,
-        config=get_gemini_config(target_language).model_copy(
+        config=get_gemini_config(
+            target_language,
+            extra_system_instruction=(
+                "MANDATORY TOOL USAGE: You MUST always use the `UrlContext` "
+                "tool to fetch and read the information from the provided "
+                "link before generating your summary. Do not attempt to "
+                "summarize the content without calling this tool first."
+            ),
+        ).model_copy(
             update={
-                "tools": tools,
+                "tools": [types.Tool(url_context=types.UrlContext())],
             },
         ),
     )

--- a/src/summary.py
+++ b/src/summary.py
@@ -189,7 +189,7 @@ def summarize_webpage(
     and uses the Gemini API to generate a summary.
 
     Args:
-        content (str): The webpage content to be summarized
+        content (str): The webpage URL to be summarized
         model (str): The Gemini model identifier to use for generation
         prompt_key (str): Key to retrieve the prompt template from PROMPTS
         target_language (str): The language to translate the text into.

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -73,6 +73,15 @@ def test_get_gemini_config_content():
     config = get_gemini_config("French")
     assert "French" in config.system_instruction
 
+def test_get_gemini_config_with_extra_system_instruction():
+    """Test get_gemini_config appends extra system instruction when provided."""
+    config = get_gemini_config(
+        "English",
+        extra_system_instruction="Use UrlContext before answering.",
+    )
+    assert "English" in config.system_instruction
+    assert "Use UrlContext before answering." in config.system_instruction
+
 def test_upload_and_wait_for_audio_file_happy(mocker):
     """Test uploading file to Gemini when it's immediately ACTIVE."""
     mock_client = mocker.patch("services.gemini_client")

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -135,7 +135,13 @@ def test_summarize_webpage(mocker):
     )
 
     assert result == "Webpage summary."
-    assert "config" in mock_client.models.generate_content.call_args.kwargs
+    config = mock_client.models.generate_content.call_args.kwargs["config"]
+    assert config.tools is not None
+    assert len(config.tools) == 1
+    assert config.tools[0].url_context is not None
+    assert config.system_instruction is not None
+    assert "MANDATORY TOOL USAGE" in config.system_instruction
+    assert "UrlContext" in config.system_instruction
 
 
 def test_summarize_with_file_upload_failure(mocker):


### PR DESCRIPTION
## Summary
- extend Gemini config creation to accept per-call extra system instructions
- move `UrlContext` usage requirements for webpage summaries into system instruction handling
- keep webpage generation configured with the `url_context` tool only
- add test coverage for extra system instructions and webpage summary config

## Testing
- `.venv/bin/pytest tests/test_services.py tests/test_summary.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow adding a custom extra system instruction to AI model configuration.

* **Improvements**
  * Webpage summarization now enforces use of a URL-context tool for more context-aware summaries.

* **Tests**
  * Added tests for custom system instruction handling.
  * Strengthened tests to verify summarization config includes required tool usage and instructions.

* **Chores**
  * Updated project ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->