### PR TITLE
Update AGENTS context documentation references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@ You work with Andrii Vasiliadi, a software engineer building ai-summarizer-teleg
   - archive-rules.md — summary lifecycle and file archival rules
   - tech-stack.md — architecture decisions
   - style-guide.md — writing or coding conventions
+  - project-structure.md — repository layout reference
+  - git-guide.md — git workflow and repository conventions
+  - tooling-guide.md — tooling and local workflow guidance
+  - subagent-rules.md — rules for sub-agent usage and outputs
 - docs/archive/ — processed raw files. Do not read unless explicitly told.
 - output/deliverables/ — final outputs
 

--- a/docs/context/project-structure.md
+++ b/docs/context/project-structure.md
@@ -24,14 +24,6 @@ project-root/
 ├── scripts/                          ← Utility scripts (db init, etc.)
 ├── docs/                             ← Documentation
 │   ├── context/                      ← Reusable domain knowledge
-│   │   ├── archive-rules.md         # Summary lifecycle and archival rules
-│   │   ├── git-guide.md             # Git workflow and repository conventions
-│   │   ├── processing-protocol.md   # Document processing workflow
-│   │   ├── project-structure.md     # Repository layout reference
-│   │   ├── style-guide.md           # Writing and coding conventions
-│   │   ├── subagent-rules.md        # Rules for sub-agent usage and outputs
-│   │   ├── tech-stack.md            # Architecture and technology decisions
-│   │   └── tooling-guide.md         # Tooling and local workflow guidance
 │   ├── summaries/                    ← Session state and handoffs
 │   └── archive/                      ← Processed raw files
 ├── pyproject.toml                    ← Project configuration


### PR DESCRIPTION
## Summary
- add the `docs/context/` file inventory to the `Where Things Live` section in `AGENTS.md`
- keep `docs/context/project-structure.md` focused on the high-level directory tree by removing the expanded nested file list

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation references and directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->