### PR TITLE
chore: update Renovate configuration to ignore unstable versions and …

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,15 +5,16 @@
   "lockFileMaintenance": { "enabled": true, "automerge": true },
   "packageRules": [
     {
-      "description": "Force Renovate to evaluate patches independently of minors for Python",
+      "description": "Force Renovate to evaluate patches independently, but strictly IGNORE alphas/betas",
       "matchDepNames": ["python"],
       "separateMinorPatch": true,
-      "respectLatest": false
+      "respectLatest": false,
+      "ignoreUnstable": true
     },
     {
-      "description": "Disable minor and major updates for Python",
+      "description": "Disable minor, major, and prerelease updates for Python",
       "matchPackageNames": ["python"],
-      "matchUpdateTypes": ["minor", "major"],
+      "matchUpdateTypes": ["minor", "major", "prerelease"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
…disable prerelease updates for Python

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to exclude unstable prerelease versions from automatic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->