### PR TITLE
Fix YouTube transcript fallback leakage

### DIFF
--- a/src/summary.py
+++ b/src/summary.py
@@ -372,6 +372,9 @@ def summarize(  # noqa: PLR0913
             if use_yt_transcription:
                 try:
                     transcript = get_yt_transcript(data)
+                except (TranscriptsDisabled, RetryError):
+                    pass
+                else:
                     return format_prefixed_summary(
                         "📹",
                         summarize_with_transcript(
@@ -381,11 +384,6 @@ def summarize(  # noqa: PLR0913
                             target_language=target_language,
                         ),
                     )
-                except (
-                    TranscriptsDisabled,
-                    RetryError,
-                ):
-                    pass
             data = download_yt(data)
     if isinstance(data, File):
         data = download_tg(data, ext=".ogg")

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -283,6 +283,31 @@ def test_summarize_youtube_direct_transcript_uses_blank_line_separator(mocker):
     assert result == "📹\n\n- first point\n- second point"
 
 
+def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
+    """Test transcript summary retry errors do not trigger audio fallback paths."""
+    url = "https://youtube.com/watch?v=123"
+    retry_error = RetryError(mocker.MagicMock())
+    mocker.patch("summary.get_yt_transcript", return_value="YT Transcript content")
+    mock_download = mocker.patch("summary.download_yt")
+    mock_file_summary = mocker.patch("summary.summarize_with_file")
+    mock_transcribe = mocker.patch("summary.transcribe")
+    mocker.patch("summary.summarize_with_transcript", side_effect=retry_error)
+
+    with pytest.raises(RetryError):
+        summarize(
+            data=url,
+            use_transcription=True,
+            model="test-model",
+            prompt_key="basic_prompt_for_transcript",
+            target_language="English",
+            use_yt_transcription=True,
+        )
+
+    mock_download.assert_not_called()
+    mock_file_summary.assert_not_called()
+    mock_transcribe.assert_not_called()
+
+
 def test_summarize_youtube_transcript_failure_falls_back_to_download(mocker):
     """Test summarize() falls back to downloading YouTube audio when transcript fetch fails."""
     url = "https://youtube.com/watch?v=123"


### PR DESCRIPTION
## Summary
- Stop YouTube transcript summarization from falling through to audio download when `summarize_with_transcript` exhausts retries
- Keep fallback limited to transcript fetch failures, which preserves the expected quota behavior
- Add a regression test to ensure transcript retry exhaustion does not trigger `download_yt`, file summary, or audio transcription

## Testing
- `uv run pytest tests/test_summary.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error handling during YouTube transcript summarization to ensure proper fallback behavior is prevented when errors occur.

* **Refactor**
  * Improved error handling flow logic in transcript processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->