### PR TITLE
Add audio format selection for YouTube downloads and refactor tests

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -17,6 +17,7 @@ from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
 from config import PROXY, TG_API_TOKEN, headers
+from services import choose_yt_audio_format
 from utils import generate_temporary_name
 
 if TYPE_CHECKING:
@@ -56,8 +57,13 @@ def download_yt(url: str) -> str:
 
     """
     temporary_file_name = generate_temporary_name(ext=".mp3")
+    # Resolve a real format id first because the abstract `worstaudio` selector
+    # can fail on videos whose available formats do not satisfy yt-dlp's alias.
+    with YoutubeDL({"proxy": PROXY, "nocheckcertificate": False}) as ydl:
+        info = ydl.extract_info(url, download=False)
+    audio_format = choose_yt_audio_format(info)
     ydl_opts = {
-        "format": "worstaudio",
+        "format": audio_format,
         "outtmpl": temporary_file_name.split(".", maxsplit=1)[0],
         "nocheckcertificate": False,
         "proxy": PROXY,

--- a/src/services.py
+++ b/src/services.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import mimetypes
 import time
 from textwrap import dedent
@@ -58,9 +59,12 @@ def choose_yt_audio_format(info: dict[str, Any]) -> str:
         return "bestaudio/worst[acodec!=none]"
 
     def sort_key(fmt: dict[str, Any]) -> tuple[float, float]:
-        abr = fmt.get("abr") or 0
-        tbr = fmt.get("tbr") or 0
-        return (float(abr), float(tbr))
+        abr = fmt.get("abr")
+        tbr = fmt.get("tbr")
+        return (
+            float(abr) if abr is not None else math.inf,
+            float(tbr) if tbr is not None else math.inf,
+        )
 
     return str(min(audio_only_formats, key=sort_key)["format_id"])
 

--- a/src/services.py
+++ b/src/services.py
@@ -2,7 +2,7 @@ import logging
 import mimetypes
 import time
 from textwrap import dedent
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from google.genai import types
 from requests.exceptions import ReadTimeout
@@ -38,6 +38,31 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
+
+
+def choose_yt_audio_format(info: dict[str, Any]) -> str:
+    """Return the most suitable audio format id for a YouTube video.
+
+    Prefer audio-only formats when yt-dlp exposes them. Fall back to the
+    combined format selector when the extractor does not provide a concrete
+    audio-only id.
+
+    """
+    formats = info.get("formats") or []
+    audio_only_formats = [
+        fmt
+        for fmt in formats
+        if fmt.get("acodec") not in (None, "none") and fmt.get("vcodec") == "none"
+    ]
+    if not audio_only_formats:
+        return "bestaudio/worst[acodec!=none]"
+
+    def sort_key(fmt: dict[str, Any]) -> tuple[float, float]:
+        abr = fmt.get("abr") or 0
+        tbr = fmt.get("tbr") or 0
+        return (float(abr), float(tbr))
+
+    return str(min(audio_only_formats, key=sort_key)["format_id"])
 
 
 @retry(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -126,6 +126,21 @@ def test_choose_yt_audio_format_falls_back_when_no_audio_only_formats():
 
     assert result == "bestaudio/worst[acodec!=none]"
 
+
+def test_choose_yt_audio_format_ranks_unknown_bitrates_last():
+    """Test formats with unknown bitrates lose to known low bitrate audio."""
+    info = {
+        "formats": [
+            {"format_id": "unknown", "acodec": "opus", "vcodec": "none"},
+            {"format_id": "zero", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 0, "tbr": 0},
+            {"format_id": "known", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+        ],
+    }
+
+    result = choose_yt_audio_format(info)
+
+    assert result == "zero"
+
 def test_download_castro_happy_path(mocker):
     """Test downloading a Castro podcast successfully."""
     mocker.patch("download.generate_temporary_name", return_value="temp_castro.mp3")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,8 +1,7 @@
-
-
 import pytest
 
 from download import download_castro, download_tg, download_yt
+from services import choose_yt_audio_format
 
 
 def test_download_tg_happy_path(mocker):
@@ -80,10 +79,52 @@ def test_download_yt_happy_path(mocker):
     mock_ydl = mocker.patch("download.YoutubeDL")
     mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
 
+    info_ydl = mocker.MagicMock()
+    info_ydl.extract_info.return_value = {
+        "formats": [
+            {"format_id": "251", "acodec": "opus", "vcodec": "none", "abr": 111, "tbr": 111},
+            {"format_id": "139", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+        ],
+    }
+    download_ydl = mocker.MagicMock()
+    mock_ydl.side_effect = [
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
+    ]
+
     result = download_yt("https://youtube.com/watch?v=123")
 
     assert result == "temp_yt.mp3"
-    mock_ydl.return_value.__enter__.return_value.download.assert_called_once_with("https://youtube.com/watch?v=123")
+    info_ydl.extract_info.assert_called_once_with("https://youtube.com/watch?v=123", download=False)
+    mock_ydl.assert_any_call({"proxy": mocker.ANY, "nocheckcertificate": False})
+    mock_ydl.assert_any_call(
+        {
+            "format": "139",
+            "outtmpl": "temp_yt",
+            "nocheckcertificate": False,
+            "proxy": mocker.ANY,
+            "postprocessors": [
+                {
+                    "key": "FFmpegExtractAudio",
+                    "preferredcodec": "mp3",
+                },
+            ],
+        },
+    )
+    download_ydl.download.assert_called_once_with("https://youtube.com/watch?v=123")
+
+
+def test_choose_yt_audio_format_falls_back_when_no_audio_only_formats():
+    """Test selector fallback when yt-dlp has no audio-only format ids."""
+    info = {
+        "formats": [
+            {"format_id": "18", "acodec": "mp4a.40.2", "vcodec": "avc1.42001E", "abr": 44, "tbr": 365},
+        ],
+    }
+
+    result = choose_yt_audio_format(info)
+
+    assert result == "bestaudio/worst[acodec!=none]"
 
 def test_download_castro_happy_path(mocker):
     """Test downloading a Castro podcast successfully."""

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -127,8 +127,8 @@ def test_choose_yt_audio_format_falls_back_when_no_audio_only_formats():
     assert result == "bestaudio/worst[acodec!=none]"
 
 
-def test_choose_yt_audio_format_ranks_unknown_bitrates_last():
-    """Test formats with unknown bitrates lose to known low bitrate audio."""
+def test_choose_yt_audio_format_ranks_missing_bitrates_last():
+    """Test choose_yt_audio_format keeps numeric 0 bitrates ahead of missing values."""
     info = {
         "formats": [
             {"format_id": "unknown", "acodec": "opus", "vcodec": "none"},

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from database import UsersOrm, check_auth

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,5 +1,3 @@
-
-
 import pytest
 from replicate.exceptions import ModelError
 from youtube_transcript_api._errors import NoTranscriptFound


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * YouTube audio downloads now probe available formats and pick a resolved audio format id instead of using a static alias, improving format accuracy and compatibility.

* **Tests**
  * Expanded tests for audio format selection, including ranking behavior and fallback when no audio-only formats exist; updated download flow assertions.

* **Style**
  * Minor whitespace/formatting cleanup in test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->