### PR TITLE
fix: log warning when get_yt_transcript fails before download fallback

### DIFF
--- a/src/summary.py
+++ b/src/summary.py
@@ -414,8 +414,11 @@ def summarize(
             if use_yt_transcription:
                 try:
                     transcript = get_yt_transcript(data)
-                except TranscriptsDisabled, RetryError:
-                    pass
+                except (TranscriptsDisabled, RetryError) as e:
+                    logger.warning(
+                        "get_yt_transcript failed, falling back to download: %s",
+                        e,
+                    )
                 else:
                     return format_prefixed_summary(
                         "📹",

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -359,7 +359,10 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(mocker):
     assert result == "File summary"
     mock_download.assert_called_once_with(url)
     mock_clean_up.assert_called_once_with(file="downloaded.ogg")
-    mock_logger.warning.assert_called_once()
+    mock_logger.warning.assert_called_once_with(
+        "get_yt_transcript failed, falling back to download: %s",
+        mocker.ANY,
+    )
 
 
 def test_summarize_youtube_transcript_retry_error_falls_back_to_download(mocker):
@@ -386,7 +389,10 @@ def test_summarize_youtube_transcript_retry_error_falls_back_to_download(mocker)
     assert result == "File summary"
     mock_download.assert_called_once_with(url)
     mock_clean_up.assert_called_once_with(file="downloaded.ogg")
-    mock_logger.warning.assert_called_once()
+    mock_logger.warning.assert_called_once_with(
+        "get_yt_transcript failed, falling back to download: %s",
+        mocker.ANY,
+    )
 
 
 def test_summarize_fallback_to_transcription(mocker):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -343,6 +343,7 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(mocker):
     mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
     mocker.patch("summary.summarize_with_file", return_value="File summary")
     mock_clean_up = mocker.patch("summary.clean_up")
+    mock_logger = mocker.patch("summary.logger")
 
     result = summarize(
         data=url,
@@ -358,6 +359,34 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(mocker):
     assert result == "File summary"
     mock_download.assert_called_once_with(url)
     mock_clean_up.assert_called_once_with(file="downloaded.ogg")
+    mock_logger.warning.assert_called_once()
+
+
+def test_summarize_youtube_transcript_retry_error_falls_back_to_download(mocker):
+    """Test summarize() falls back to downloading YouTube audio when get_yt_transcript raises RetryError."""
+    url = "https://youtube.com/watch?v=123"
+    mocker.patch("summary.check_quota", return_value=True)
+    mocker.patch("summary.get_yt_transcript", side_effect=RetryError(mocker.MagicMock()))
+    mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
+    mocker.patch("summary.summarize_with_file", return_value="File summary")
+    mock_clean_up = mocker.patch("summary.clean_up")
+    mock_logger = mocker.patch("summary.logger")
+
+    result = summarize(
+        data=url,
+        use_transcription=True,
+        model="test-model",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        user_id=123,
+        daily_limit=10,
+        use_yt_transcription=True,
+    )
+
+    assert result == "File summary"
+    mock_download.assert_called_once_with(url)
+    mock_clean_up.assert_called_once_with(file="downloaded.ogg")
+    mock_logger.warning.assert_called_once()
 
 
 def test_summarize_fallback_to_transcription(mocker):


### PR DESCRIPTION
## Summary

- `get_yt_transcript` failures (`TranscriptsDisabled`, `RetryError`) were silently swallowed with `pass`, leaving no trace in logs that transcript retrieval was attempted before the download fallback
- Added `logger.warning("get_yt_transcript failed, falling back to download: %s", e)` so the failure reason is visible
- The `before_sleep_log` on the `@retry` decorator doesn't cover these cases: `TranscriptsDisabled` is not in the retry list (propagates immediately), and `RetryError` is raised only after all retries are exhausted (no further sleep occurs)

## Changes

- `src/summary.py`: replace bare `pass` in the `except` block with `logger.warning(...)`
- `tests/test_summary.py`: assert `logger.warning` is called in the existing `TranscriptsDisabled` test; add a new test for the `RetryError` fallback path which had no coverage

## Reviewer notes

No behaviour change beyond the added log line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when YouTube transcript retrieval fails by emitting a warning and reliably falling back to downloading content.

* **Tests**
  * Added/updated tests to ensure the warning is logged and the fallback download-and-summarize flow (including cleanup) behaves as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->