### PR TITLE
feat: add yt-dlp subtitle fallback in get_yt_transcript

### DIFF
--- a/src/summary.py
+++ b/src/summary.py
@@ -17,6 +17,7 @@ from tenacity import (
     wait_fixed,
 )
 from youtube_transcript_api._errors import TranscriptsDisabled
+from yt_dlp.utils import DownloadError
 
 from config import gemini_client
 from download import download_castro, download_tg, download_yt
@@ -414,7 +415,7 @@ def summarize(
             if use_yt_transcription:
                 try:
                     transcript = get_yt_transcript(data)
-                except (TranscriptsDisabled, RetryError) as e:
+                except (TranscriptsDisabled, RetryError, DownloadError) as e:
                     logger.warning(
                         "get_yt_transcript failed, falling back to download: %s",
                         e,

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -94,10 +94,8 @@ def fetch_transcript_via_api(video_id: str) -> str:
         str: The formatted transcript text.
 
     Raises:
-        NoTranscriptFound: If no transcript can be retrieved in any language.
-        IpBlocked: If the client IP is blocked by YouTube.
-        RequestBlocked: If the request is blocked by YouTube.
-        ParseError: If the XML transcript response is malformed.
+        NoTranscriptFound: If no transcript is found in any language.
+        RetryError: If IpBlocked, RequestBlocked, or ParseError persist after retries.
 
     """
     if PROXY:

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -140,26 +140,32 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
         "quiet": True,
         "nocheckcertificate": False,
     }
-    with YoutubeDL(ydl_opts) as ydl:
-        ydl.extract_info(url, download=True)
+    try:
+        with YoutubeDL(ydl_opts) as ydl:
+            ydl.download([url])
 
-    vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
-
-    if not vtt_files:
-        ydl_opts_all = {**ydl_opts, "subtitleslangs": ["all"]}
-        with YoutubeDL(ydl_opts_all) as ydl:
-            ydl.extract_info(url, download=True)
         vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
 
-    if not vtt_files:
-        msg = "No subtitles available via yt-dlp"
-        raise DownloadError(msg)
+        if not vtt_files:
+            ydl_opts_all = {**ydl_opts, "subtitleslangs": ["all"]}
+            with YoutubeDL(ydl_opts_all) as ydl:
+                ydl.download([url])
+            vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
 
-    vtt_path = vtt_files[0]
-    try:
-        return vtt_to_text(vtt_path)
+        if not vtt_files:
+            msg = "No subtitles available via yt-dlp"
+            raise DownloadError(msg)  # noqa: TRY301
+
+        return vtt_to_text(vtt_files[0])
+    except DownloadError as exc:
+        logger.warning("yt-dlp subtitle fetch failed: %s", exc)
+        raise
+    except Exception as exc:
+        logger.warning("yt-dlp subtitle fetch failed unexpectedly: %s", exc)
+        msg = "yt-dlp subtitle fetch failed"
+        raise DownloadError(msg) from exc
     finally:
-        for f in vtt_files:
+        for f in Path.cwd().glob(f"{temp_basename}.*.vtt"):
             clean_up(file=str(f))
 
 

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -7,6 +7,7 @@ from defusedxml.ElementTree import ParseError
 from replicate.exceptions import ModelError, ReplicateError
 from requests.exceptions import ChunkedEncodingError, ProxyError, SSLError
 from tenacity import (
+    RetryError,
     before_sleep_log,
     retry,
     retry_if_exception_type,
@@ -17,8 +18,11 @@ from youtube_transcript_api import YouTubeTranscriptApi
 from youtube_transcript_api._errors import IpBlocked, NoTranscriptFound, RequestBlocked
 from youtube_transcript_api.formatters import TextFormatter
 from youtube_transcript_api.proxies import GenericProxyConfig
+from yt_dlp import YoutubeDL
+from yt_dlp.utils import DownloadError
 
 from config import PROXY, replicate_client
+from utils import clean_up, generate_temporary_name, vtt_to_text
 
 if TYPE_CHECKING:
     from tenacity import (
@@ -76,14 +80,99 @@ def transcribe(file: str, sleep_time: int = 10) -> str:
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_fixed(10),
+    retry=retry_if_exception_type((ParseError, IpBlocked, RequestBlocked)),
+    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+    reraise=False,
+)
+def fetch_transcript_via_api(video_id: str) -> str:
+    """Retrieve and format a YouTube transcript via youtube_transcript_api.
+
+    Args:
+        video_id (str): The YouTube video ID.
+
+    Returns:
+        str: The formatted transcript text.
+
+    Raises:
+        NoTranscriptFound: If no transcript can be retrieved in any language.
+        IpBlocked: If the client IP is blocked by YouTube.
+        RequestBlocked: If the request is blocked by YouTube.
+        ParseError: If the XML transcript response is malformed.
+
+    """
+    if PROXY:
+        ytt_api = YouTubeTranscriptApi(proxy_config=GenericProxyConfig(https_url=PROXY))
+    else:
+        ytt_api = YouTubeTranscriptApi()
+
+    try:
+        transcript = ytt_api.fetch(video_id)
+    except NoTranscriptFound:
+        transcript_list = ytt_api.list(video_id)
+        language_codes = [transcript.language_code for transcript in transcript_list]
+        transcript = ytt_api.fetch(video_id, languages=language_codes)
+    return TextFormatter().format_transcript(transcript)
+
+
+def fetch_transcript_via_ytdlp(url: str) -> str:
+    """Retrieve a YouTube transcript by downloading subtitles via yt-dlp.
+
+    Tries English subtitles first (manual then auto-generated), then falls
+    back to any available language. Always uses PROXY when configured.
+
+    Args:
+        url (str): The YouTube video URL.
+
+    Returns:
+        str: The transcript as plain text.
+
+    Raises:
+        DownloadError: If no subtitles are available or yt-dlp cannot fetch them.
+
+    """
+    temp_basename = generate_temporary_name()
+    ydl_opts: dict[str, object] = {
+        "proxy": PROXY,
+        "skip_download": True,
+        "writesubtitles": True,
+        "writeautomaticsub": True,
+        "subtitleslangs": ["en.*", "en"],
+        "subtitlesformat": "vtt",
+        "outtmpl": temp_basename,
+        "quiet": True,
+        "nocheckcertificate": False,
+    }
+    with YoutubeDL(ydl_opts) as ydl:
+        ydl.extract_info(url, download=True)
+
+    vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
+
+    if not vtt_files:
+        ydl_opts_all = {**ydl_opts, "subtitleslangs": ["all"]}
+        with YoutubeDL(ydl_opts_all) as ydl:
+            ydl.extract_info(url, download=True)
+        vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
+
+    if not vtt_files:
+        msg = "No subtitles available via yt-dlp"
+        raise DownloadError(msg)
+
+    vtt_path = vtt_files[0]
+    try:
+        return vtt_to_text(vtt_path)
+    finally:
+        for f in vtt_files:
+            clean_up(file=str(f))
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(10),
     retry=retry_if_exception_type(
         (
             ProxyError,
             SSLError,
             ChunkedEncodingError,
-            ParseError,
-            IpBlocked,
-            RequestBlocked,
         ),
     ),
     before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
@@ -91,6 +180,10 @@ def transcribe(file: str, sleep_time: int = 10) -> str:
 )
 def get_yt_transcript(url: str) -> str:
     """Retrieve and format the transcript from a YouTube video URL.
+
+    Tries youtube_transcript_api first. If blocked or unavailable, falls
+    back to yt-dlp subtitle download. Transient network errors are retried
+    up to 3 times before raising RetryError.
 
     Args:
         url (str): The YouTube video URL.
@@ -100,7 +193,8 @@ def get_yt_transcript(url: str) -> str:
 
     Raises:
         ValueError: If the URL format is not recognized.
-        RetryError: If proxy/SSL/XML errors persist after retries.
+        DownloadError: If both the API and yt-dlp fallback fail to retrieve subtitles.
+        RetryError: If proxy/SSL/network errors persist after all retry attempts.
 
     """
     if url.startswith("https://www.youtube.com/watch"):
@@ -115,15 +209,11 @@ def get_yt_transcript(url: str) -> str:
         msg = "Unknown URL"
         raise ValueError(msg)
 
-    if PROXY:
-        ytt_api = YouTubeTranscriptApi(proxy_config=GenericProxyConfig(https_url=PROXY))
-    else:
-        ytt_api = YouTubeTranscriptApi()
-
     try:
-        transcript = ytt_api.fetch(video_id)
-    except NoTranscriptFound:
-        transcript_list = ytt_api.list(video_id)
-        language_codes = [transcript.language_code for transcript in transcript_list]
-        transcript = ytt_api.fetch(video_id, languages=language_codes)
-    return TextFormatter().format_transcript(transcript)
+        return fetch_transcript_via_api(video_id)
+    except (NoTranscriptFound, RetryError) as api_err:
+        logger.warning(
+            "youtube_transcript_api failed (%s); trying yt-dlp fallback",
+            api_err,
+        )
+        return fetch_transcript_via_ytdlp(url)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 from pathlib import Path
 from uuid import uuid4
@@ -66,6 +67,32 @@ def compress_audio(input_file: str, output_file: str) -> None:
         capture_output=False,
         text=True,
     )
+
+
+def vtt_to_text(vtt_path: Path) -> str:
+    """Convert a VTT subtitle file to deduplicated plain text.
+
+    Args:
+        vtt_path (Path): Path to the .vtt file.
+
+    Returns:
+        str: Clean transcript text with duplicate lines removed.
+
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in vtt_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or "-->" in line:
+            continue
+        if line.startswith(("WEBVTT", "Kind:", "Language:", "NOTE")):
+            continue
+        clean = re.sub(r"<[^>]*>", "", line)
+        clean = clean.replace("&amp;", "&").replace("&gt;", ">").replace("&lt;", "<")
+        if clean and clean not in seen:
+            seen.add(clean)
+            out.append(clean)
+    return "\n".join(out)
 
 
 def clean_up(file: str | None = None, all_downloads: bool = False) -> None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -79,10 +79,11 @@ def vtt_to_text(vtt_path: Path) -> str:
         str: Clean transcript text with duplicate lines removed.
 
     """
+    lines = vtt_path.read_text(encoding="utf-8").splitlines()
     out: list[str] = []
     prev = ""
     in_note = False
-    for raw in vtt_path.read_text(encoding="utf-8").splitlines():
+    for i, raw in enumerate(lines):
         line = raw.strip()
         if not line:
             in_note = False
@@ -95,6 +96,9 @@ def vtt_to_text(vtt_path: Path) -> str:
             continue
         if line.startswith("NOTE"):
             in_note = True
+            continue
+        next_line = lines[i + 1].strip() if i + 1 < len(lines) else ""
+        if "-->" in next_line:
             continue
         clean = re.sub(r"<[^>]*>", "", line)
         clean = clean.replace("&amp;", "&").replace("&gt;", ">").replace("&lt;", "<")

--- a/src/utils.py
+++ b/src/utils.py
@@ -79,19 +79,28 @@ def vtt_to_text(vtt_path: Path) -> str:
         str: Clean transcript text with duplicate lines removed.
 
     """
-    seen: set[str] = set()
     out: list[str] = []
+    prev = ""
+    in_note = False
     for raw in vtt_path.read_text(encoding="utf-8").splitlines():
         line = raw.strip()
-        if not line or "-->" in line:
+        if not line:
+            in_note = False
             continue
-        if line.startswith(("WEBVTT", "Kind:", "Language:", "NOTE")):
+        if in_note:
+            continue
+        if "-->" in line:
+            continue
+        if line.startswith(("WEBVTT", "Kind:", "Language:")):
+            continue
+        if line.startswith("NOTE"):
+            in_note = True
             continue
         clean = re.sub(r"<[^>]*>", "", line)
         clean = clean.replace("&amp;", "&").replace("&gt;", ">").replace("&lt;", "<")
-        if clean and clean not in seen:
-            seen.add(clean)
+        if clean and clean != prev:
             out.append(clean)
+            prev = clean
     return "\n".join(out)
 
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -85,6 +85,7 @@ def test_get_yt_transcript_fallback_languages(mocker):
 
 def test_get_yt_transcript_falls_back_to_ytdlp_on_api_failure(mocker, tmp_path):
     """Test get_yt_transcript falls back to yt-dlp when fetch_transcript_via_api exhausts retries."""
+    mocker.patch("time.sleep")
     mocker.patch(
         "transcription.fetch_transcript_via_api",
         side_effect=RetryError(mocker.MagicMock()),
@@ -109,7 +110,8 @@ def test_get_yt_transcript_falls_back_to_ytdlp_on_api_failure(mocker, tmp_path):
     vtt_file.write_text(vtt_content, encoding="utf-8")
 
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-    mocker.patch("transcription.YoutubeDL")
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    mock_ydl_inst = mock_ydl_cls.return_value.__enter__.return_value
     mocker.patch("transcription.clean_up")
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
@@ -119,20 +121,28 @@ def test_get_yt_transcript_falls_back_to_ytdlp_on_api_failure(mocker, tmp_path):
     assert "Goodbye" in result
     # Deduplication: "Hello world" appears twice in VTT but only once in output
     assert result.count("Hello world") == 1
+    # English pass found the VTT file — only one download attempt needed
+    mock_ydl_inst.download.assert_called_once_with([url])
 
 def test_get_yt_transcript_ytdlp_no_subs_raises(mocker, tmp_path):
     """Test get_yt_transcript raises DownloadError when yt-dlp finds no subtitles."""
+    mocker.patch("time.sleep")
     mocker.patch(
         "transcription.fetch_transcript_via_api",
         side_effect=RetryError(mocker.MagicMock()),
     )
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-    mocker.patch("transcription.YoutubeDL")
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    mock_ydl_inst = mock_ydl_cls.return_value.__enter__.return_value
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
         get_yt_transcript(url)
+
+    # Both English and all-languages passes must have been attempted
+    assert mock_ydl_inst.download.call_count == 2
+    mock_ydl_inst.download.assert_called_with([url])
 
 def test_vtt_to_text_dedupes_and_strips_tags(tmp_path):
     """Test vtt_to_text removes headers, timestamps, HTML tags, entities, and duplicates."""
@@ -256,11 +266,12 @@ def test_fetch_transcript_via_ytdlp_all_language_fallback(mocker, tmp_path):
         def __exit__(self, *args: object) -> None:
             pass
 
-        def extract_info(self, url: str, download: bool) -> None:  # noqa: FBT001
+        def download(self, url_list: list[str]) -> int:
             langs = self.opts.get("subtitleslangs", [])
             extract_calls.append(langs)
             if "all" in langs:
                 vtt_path.write_text(vtt_content, encoding="utf-8")
+            return 0
 
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -4,10 +4,10 @@ from pathlib import Path
 import pytest
 from replicate.exceptions import ModelError
 from tenacity import RetryError
-from youtube_transcript_api._errors import NoTranscriptFound
+from youtube_transcript_api._errors import IpBlocked, NoTranscriptFound
 from yt_dlp.utils import DownloadError
 
-from transcription import get_yt_transcript, transcribe
+from transcription import fetch_transcript_via_api, fetch_transcript_via_ytdlp, get_yt_transcript, transcribe
 from utils import vtt_to_text
 
 
@@ -158,6 +158,97 @@ def test_vtt_to_text_dedupes_and_strips_tags(tmp_path):
     result = vtt_to_text(vtt_path)
 
     assert result == "Hello & world\nSecond line"
+
+def test_vtt_to_text_skips_multiline_note_block(tmp_path):
+    """Test vtt_to_text skips all lines inside a multiline NOTE block."""
+    vtt_content = textwrap.dedent("""\
+        WEBVTT
+
+        NOTE
+        This comment should not appear
+        in the transcript output.
+
+        00:00:01.000 --> 00:00:03.000
+        Hello
+
+        NOTE This inline note also skipped
+
+        00:00:03.000 --> 00:00:05.000
+        World
+    """)
+    vtt_path = tmp_path / "test.vtt"
+    vtt_path.write_text(vtt_content, encoding="utf-8")
+
+    result = vtt_to_text(vtt_path)
+
+    assert result == "Hello\nWorld"
+    assert "comment" not in result
+    assert "inline" not in result
+
+def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
+    """Test vtt_to_text only skips consecutive duplicate lines, not non-consecutive ones."""
+    vtt_content = textwrap.dedent("""\
+        WEBVTT
+
+        00:00:01.000 --> 00:00:03.000
+        Hello
+
+        00:00:03.000 --> 00:00:05.000
+        World
+
+        00:00:05.000 --> 00:00:07.000
+        Hello
+    """)
+    vtt_path = tmp_path / "test.vtt"
+    vtt_path.write_text(vtt_content, encoding="utf-8")
+
+    result = vtt_to_text(vtt_path)
+
+    assert result == "Hello\nWorld\nHello"
+
+def test_fetch_transcript_via_api_retries_on_ip_blocked(mocker):
+    """Test fetch_transcript_via_api retries 3 times on IpBlocked then raises RetryError."""
+    mocker.patch("time.sleep")
+    mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
+    mock_ytt.return_value.fetch.side_effect = IpBlocked("vid")
+
+    with pytest.raises(RetryError):
+        fetch_transcript_via_api("vid")
+
+    assert mock_ytt.return_value.fetch.call_count == 3
+
+def test_fetch_transcript_via_ytdlp_all_language_fallback(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp retries with all languages when English is unavailable."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.clean_up")
+
+    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
+    vtt_path = tmp_path / "fake-uuid.fr.vtt"
+    extract_calls: list[list[str]] = []
+
+    class MockYDL:
+        def __init__(self, opts: object) -> None:
+            self.opts = opts
+
+        def __enter__(self) -> "MockYDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool) -> None:  # noqa: FBT001
+            langs = self.opts.get("subtitleslangs", [])
+            extract_calls.append(langs)
+            if "all" in langs:
+                vtt_path.write_text(vtt_content, encoding="utf-8")
+
+    mocker.patch("transcription.YoutubeDL", MockYDL)
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+
+    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert result == "Bonjour"
+    assert extract_calls == [["en.*", "en"], ["all"]]
 
 def test_transcribe_happy_path(mocker):
     """Test transcribing an audio file successfully via Replicate."""

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,5 +1,4 @@
 import textwrap
-from pathlib import Path
 
 import pytest
 from replicate.exceptions import ModelError

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -236,6 +236,36 @@ def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
 
     assert result == "Hello\nWorld\nHello"
 
+def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
+    """Test fetch_transcript_via_api passes GenericProxyConfig when PROXY is set."""
+    mocker.patch("transcription.PROXY", "http://proxy:8080")
+    mock_proxy_cfg = mocker.patch("transcription.GenericProxyConfig")
+    mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
+    mocker.patch("transcription.TextFormatter").return_value.format_transcript.return_value = "Hello"
+    mock_ytt.return_value.fetch.return_value = []
+
+    result = fetch_transcript_via_api("vid")
+
+    assert result == "Hello"
+    mock_proxy_cfg.assert_called_once_with(https_url="http://proxy:8080")
+    mock_ytt.assert_called_once_with(proxy_config=mock_proxy_cfg.return_value)
+
+def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_as_download_error(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp wraps non-DownloadError exceptions as DownloadError."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    mock_ydl_cls.return_value.__enter__.return_value.download.side_effect = ConnectionError("network failure")
+    mock_logger = mocker.patch("transcription.logger")
+
+    with pytest.raises(DownloadError, match="yt-dlp subtitle fetch failed"):
+        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    mock_logger.warning.assert_called_once_with(
+        "yt-dlp subtitle fetch failed unexpectedly: %s",
+        mocker.ANY,
+    )
+
 def test_fetch_transcript_via_api_retries_on_ip_blocked(mocker):
     """Test fetch_transcript_via_api retries 3 times on IpBlocked then raises RetryError."""
     mocker.patch("time.sleep")

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,8 +1,14 @@
+import textwrap
+from pathlib import Path
+
 import pytest
 from replicate.exceptions import ModelError
+from tenacity import RetryError
 from youtube_transcript_api._errors import NoTranscriptFound
+from yt_dlp.utils import DownloadError
 
 from transcription import get_yt_transcript, transcribe
+from utils import vtt_to_text
 
 
 def test_get_yt_transcript_youtube_watch_url(mocker):
@@ -76,6 +82,82 @@ def test_get_yt_transcript_fallback_languages(mocker):
     assert calls[0].args == ("vid",)
     assert calls[1].args == ("vid",)
     assert calls[1].kwargs == {"languages": ["es"]}
+
+def test_get_yt_transcript_falls_back_to_ytdlp_on_api_failure(mocker, tmp_path):
+    """Test get_yt_transcript falls back to yt-dlp when fetch_transcript_via_api exhausts retries."""
+    mocker.patch(
+        "transcription.fetch_transcript_via_api",
+        side_effect=RetryError(mocker.MagicMock()),
+    )
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+
+    vtt_content = textwrap.dedent("""\
+        WEBVTT
+        Kind: captions
+        Language: en
+
+        00:00:01.000 --> 00:00:03.000
+        Hello world
+
+        00:00:03.000 --> 00:00:05.000
+        Hello world
+
+        00:00:05.000 --> 00:00:07.000
+        Goodbye
+    """)
+    vtt_file = tmp_path / "fake-uuid.en.vtt"
+    vtt_file.write_text(vtt_content, encoding="utf-8")
+
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("transcription.YoutubeDL")
+    mocker.patch("transcription.clean_up")
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    result = get_yt_transcript(url)
+
+    assert "Hello world" in result
+    assert "Goodbye" in result
+    # Deduplication: "Hello world" appears twice in VTT but only once in output
+    assert result.count("Hello world") == 1
+
+def test_get_yt_transcript_ytdlp_no_subs_raises(mocker, tmp_path):
+    """Test get_yt_transcript raises DownloadError when yt-dlp finds no subtitles."""
+    mocker.patch(
+        "transcription.fetch_transcript_via_api",
+        side_effect=RetryError(mocker.MagicMock()),
+    )
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("transcription.YoutubeDL")
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
+        get_yt_transcript(url)
+
+def test_vtt_to_text_dedupes_and_strips_tags(tmp_path):
+    """Test vtt_to_text removes headers, timestamps, HTML tags, entities, and duplicates."""
+    vtt_content = textwrap.dedent("""\
+        WEBVTT
+        Kind: captions
+        Language: en
+
+        NOTE This is a note
+
+        00:00:01.000 --> 00:00:03.000
+        <00:00:01.500><c>Hello</c> &amp; world
+
+        00:00:03.000 --> 00:00:05.000
+        Hello &amp; world
+
+        00:00:05.000 --> 00:00:07.000
+        Second line
+    """)
+    vtt_path = tmp_path / "test.vtt"
+    vtt_path.write_text(vtt_content, encoding="utf-8")
+
+    result = vtt_to_text(vtt_path)
+
+    assert result == "Hello & world\nSecond line"
 
 def test_transcribe_happy_path(mocker):
     """Test transcribing an audio file successfully via Replicate."""

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -159,6 +159,26 @@ def test_vtt_to_text_dedupes_and_strips_tags(tmp_path):
 
     assert result == "Hello & world\nSecond line"
 
+def test_vtt_to_text_skips_cue_identifiers(tmp_path):
+    """Test vtt_to_text skips cue identifier lines (numeric or text) before timestamps."""
+    vtt_content = textwrap.dedent("""\
+        WEBVTT
+
+        1
+        00:00:01.000 --> 00:00:03.000
+        Hello
+
+        intro
+        00:00:03.000 --> 00:00:05.000
+        World
+    """)
+    vtt_path = tmp_path / "test.vtt"
+    vtt_path.write_text(vtt_content, encoding="utf-8")
+
+    result = vtt_to_text(vtt_path)
+
+    assert result == "Hello\nWorld"
+
 def test_vtt_to_text_skips_multiline_note_block(tmp_path):
     """Test vtt_to_text skips all lines inside a multiline NOTE block."""
     vtt_content = textwrap.dedent("""\


### PR DESCRIPTION
## **User description**
## Summary

- Refactors `get_yt_transcript` into three public functions: `fetch_transcript_via_api`, `fetch_transcript_via_ytdlp`, and `vtt_to_text` (moved to `utils.py`)
- Adds a yt-dlp subtitle fallback so that when `youtube_transcript_api` is blocked (`IpBlocked`, `RequestBlocked`, `ParseError`), the bot tries fetching WebVTT subtitles via yt-dlp before falling through to the expensive audio download + Replicate WhisperX path
- `PROXY` is always passed to yt-dlp, consistent with `download_yt`
- Extends `summary.py` fallback catch to include `DownloadError` for the case where both API and yt-dlp fail

## Fallback chain

1. `fetch_transcript_via_api` — retries up to 3× on `ParseError`, `IpBlocked`, `RequestBlocked`; on `NoTranscriptFound` lists available languages and retries with them → raises `RetryError` on exhaustion
2. `fetch_transcript_via_ytdlp` — downloads `.vtt` via `YoutubeDL`; tries English first, falls back to any available language; cleans up temp files in `finally` → raises `DownloadError` if no subtitles found
3. Existing `download_yt` + WhisperX path (unchanged) if both above fail

## What a reviewer should know

- `fetch_transcript_via_api` previously had `IpBlocked`, `RequestBlocked`, `ParseError` in the tenacity retry list on `get_yt_transcript`; these are now retried at the `fetch_transcript_via_api` level instead, keeping `get_yt_transcript`'s retry list to transient network errors only (`ProxyError`, `SSLError`, `ChunkedEncodingError`)
- `vtt_to_text` strips WebVTT headers/timestamps/HTML tags/entities and deduplicates lines (auto-generated captions repeat lines across overlapping cue windows)
- Tests mock `fetch_transcript_via_api` directly (not `YouTubeTranscriptApi.fetch`) in the fallback tests to avoid the `wait_fixed(10)` retry delay; suite runs in ~0.6 s

## Test plan

- [x] `ruff format`, `ruff check`, `ty check` — clean
- [x] `pytest` — 142 passed
- [ ] Manual smoke with a video known to block `youtube_transcript_api`: confirm yt-dlp path triggers and `.vtt` temp files are cleaned up


___

## **CodeAnt-AI Description**
**Use yt-dlp subtitles when YouTube transcript lookup fails**

### What Changed
- YouTube transcripts now try the API first, then fall back to subtitle downloads before giving up on transcript-based summaries
- Subtitle downloads now try English first, then any available language, and use the configured proxy when available
- VTT subtitles are converted into clean text by removing headers, timestamps, notes, tags, and repeated lines
- Transcript fallback now also treats subtitle download failures as a signal to use the full audio transcription path

### Impact
`✅ Fewer full-audio transcriptions when captions are available`
`✅ Clearer transcript summaries from subtitle files`
`✅ Better handling of blocked or unavailable YouTube transcripts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=-7iAX-6qnDAmhuVq5CTa3BgqfQ3m_iU-FzorvBZgQ54&org=vasiliadi)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
