### PR TITLE
fix: skip empty chunks in send_answer to prevent Telegram 400 error (STG-117)

### DIFF
--- a/src/services.py
+++ b/src/services.py
@@ -150,8 +150,9 @@ def send_answer(message: Message, answer: str) -> None:
     current = next(chunks_iter, None)
     while current is not None:
         chunk_text, chunk_entities = current
-        serialized_entities = [entity.to_dict() for entity in chunk_entities]
-        reply_with_retry(message, chunk_text, entities=serialized_entities)
+        if chunk_text.strip():
+            serialized_entities = [entity.to_dict() for entity in chunk_entities]
+            reply_with_retry(message, chunk_text, entities=serialized_entities)
         next_chunk = next(chunks_iter, None)
         if next_chunk is not None:
             time.sleep(1)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -79,6 +79,22 @@ def test_send_answer_multi_chunk(mocker):
     assert mock_reply.call_count == 2
 
 
+def test_send_answer_skips_empty_chunks(mocker):
+    """Empty or whitespace-only chunks from split_entities must not be sent."""
+    mocker.patch("services.convert", return_value=("text", []))
+    mocker.patch(
+        "services.split_entities",
+        return_value=[("", []), ("  ", []), ("real content", [])],
+    )
+    mock_reply = mocker.patch("services.reply_with_retry")
+    mocker.patch("services.time.sleep")
+
+    mock_msg = mocker.MagicMock()
+    send_answer(mock_msg, "answer")
+
+    mock_reply.assert_called_once_with(mock_msg, "real content", entities=[])
+
+
 def test_get_gemini_config_content():
     """Test get_gemini_config includes the correct language in instruction."""
     config = get_gemini_config("French")


### PR DESCRIPTION
## **User description**
## Summary

- `send_answer` in `src/services.py` calls `reply_with_retry` for every chunk produced by `split_entities` without checking whether the chunk text is non-empty
- When `split_entities` produces an empty or whitespace-only chunk at a split boundary, Telegram rejects the request with `400 Bad Request: message text is empty`
- Added a `chunk_text.strip()` guard so empty/whitespace chunks are silently skipped

## What changed

- **`src/services.py`** — one-line guard `if chunk_text.strip():` wraps the serialization and send call inside the `send_answer` loop
- **`tests/test_services.py`** — new test `test_send_answer_skips_empty_chunks` verifies that `reply_with_retry` is not called for `""` or `"  "` chunks

## Reviewer notes

The root cause is upstream in `telegramify_markdown.split_entities`; the fix is a defensive guard on our side rather than relying on the library to never yield empty chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Skip empty reply chunks to avoid Telegram send failures**

### What Changed
- Empty or whitespace-only chunks are no longer sent when long answers are split, so Telegram does not reject them as blank messages
- Real message chunks still send normally in order, including their formatting
- Added a test to confirm blank chunks are skipped and only actual content is sent

### Impact
`✅ Fewer Telegram 400 errors`
`✅ More reliable long-message replies`
`✅ Fewer failed bot responses`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=ClsuphP30C1OmgmJ-hHQ_QTWosFv3pD_eqwILEJ9a24&org=vasiliadi)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
