### PR TITLE
revert: remove empty-chunk guard now handled by telegramify-markdown==1.1.5

### DIFF
--- a/src/services.py
+++ b/src/services.py
@@ -150,9 +150,8 @@ def send_answer(message: Message, answer: str) -> None:
     current = next(chunks_iter, None)
     while current is not None:
         chunk_text, chunk_entities = current
-        if chunk_text.strip():
-            serialized_entities = [entity.to_dict() for entity in chunk_entities]
-            reply_with_retry(message, chunk_text, entities=serialized_entities)
+        serialized_entities = [entity.to_dict() for entity in chunk_entities]
+        reply_with_retry(message, chunk_text, entities=serialized_entities)
         next_chunk = next(chunks_iter, None)
         if next_chunk is not None:
             time.sleep(1)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -79,22 +79,6 @@ def test_send_answer_multi_chunk(mocker):
     assert mock_reply.call_count == 2
 
 
-def test_send_answer_skips_empty_chunks(mocker):
-    """Empty or whitespace-only chunks from split_entities must not be sent."""
-    mocker.patch("services.convert", return_value=("text", []))
-    mocker.patch(
-        "services.split_entities",
-        return_value=[("", []), ("  ", []), ("real content", [])],
-    )
-    mock_reply = mocker.patch("services.reply_with_retry")
-    mocker.patch("services.time.sleep")
-
-    mock_msg = mocker.MagicMock()
-    send_answer(mock_msg, "answer")
-
-    mock_reply.assert_called_once_with(mock_msg, "real content", entities=[])
-
-
 def test_get_gemini_config_content():
     """Test get_gemini_config includes the correct language in instruction."""
     config = get_gemini_config("French")


### PR DESCRIPTION
## Summary

- Reverts the `chunk_text.strip()` guard in `send_answer` added by #733
- Removes the accompanying `test_send_answer_skips_empty_chunks` test
- The root cause (empty chunks from `split_entities`) is fixed upstream in `telegramify-markdown==1.1.5`, already pinned in `uv.lock`

## What changed

- **`src/services.py`** — removed the `if chunk_text.strip():` guard; `reply_with_retry` is called unconditionally again
- **`tests/test_services.py`** — deleted `test_send_answer_skips_empty_chunks`

## Reviewer notes

`telegramify-markdown==1.1.5` was released 2026-05-10 and fixes the upstream issue. The defensive workaround is no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Message chunks are now consistently processed and sent, including those with minimal content, ensuring more reliable message delivery.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/736)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->