### PR TITLE
fix: log non-retryable transcript errors in fetch_transcript_via_api

### DIFF
--- a/src/transcription.py
+++ b/src/transcription.py
@@ -15,7 +15,12 @@ from tenacity import (
     wait_fixed,
 )
 from youtube_transcript_api import YouTubeTranscriptApi
-from youtube_transcript_api._errors import IpBlocked, NoTranscriptFound, RequestBlocked
+from youtube_transcript_api._errors import (
+    CouldNotRetrieveTranscript,
+    IpBlocked,
+    NoTranscriptFound,
+    RequestBlocked,
+)
 from youtube_transcript_api.formatters import TextFormatter
 from youtube_transcript_api.proxies import GenericProxyConfig
 from yt_dlp import YoutubeDL
@@ -95,6 +100,8 @@ def fetch_transcript_via_api(video_id: str) -> str:
 
     Raises:
         NoTranscriptFound: If no transcript is found in any language.
+        CouldNotRetrieveTranscript: Subclasses (TranscriptsDisabled, VideoUnavailable,
+            AgeRestricted, etc.) are logged at WARNING then re-raised.
         RetryError: If IpBlocked, RequestBlocked, or ParseError persist after retries.
 
     """
@@ -109,6 +116,9 @@ def fetch_transcript_via_api(video_id: str) -> str:
         transcript_list = ytt_api.list(video_id)
         language_codes = [transcript.language_code for transcript in transcript_list]
         transcript = ytt_api.fetch(video_id, languages=language_codes)
+    except CouldNotRetrieveTranscript as e:
+        logger.warning("youtube_transcript_api failed for video %s: %s", video_id, e)
+        raise
     return TextFormatter().format_transcript(transcript)
 
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -4,7 +4,7 @@ import pytest
 from replicate.exceptions import ModelError
 from tenacity import RetryError
 from defusedxml.ElementTree import ParseError
-from youtube_transcript_api._errors import IpBlocked, NoTranscriptFound, RequestBlocked
+from youtube_transcript_api._errors import IpBlocked, NoTranscriptFound, RequestBlocked, TranscriptsDisabled
 from yt_dlp.utils import DownloadError
 
 from transcription import fetch_transcript_via_api, fetch_transcript_via_ytdlp, get_yt_transcript, transcribe
@@ -278,6 +278,25 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
     assert exc_info.value.__cause__ is original_exc
+
+def test_fetch_transcript_via_api_logs_and_reraises_non_retryable_error(mocker, caplog):
+    """Test fetch_transcript_via_api logs a warning and re-raises CouldNotRetrieveTranscript subclasses."""
+    import logging
+
+    mocker.patch("transcription.PROXY", None)
+    mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
+    mock_ytt.return_value.fetch.side_effect = TranscriptsDisabled("vid")
+
+    with caplog.at_level(logging.WARNING, logger="transcription"):
+        with pytest.raises(TranscriptsDisabled):
+            fetch_transcript_via_api("vid")
+
+    assert any(
+        "vid" in r.message
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
 
 @pytest.mark.parametrize("exc", [IpBlocked("vid"), RequestBlocked("vid"), ParseError()])
 def test_fetch_transcript_via_api_retries_on_retryable_exception(mocker, exc):


### PR DESCRIPTION
## **User description**
## Summary

- `TranscriptsDisabled` and other `CouldNotRetrieveTranscript` subclasses were propagating silently from `fetch_transcript_via_api` — no log line, no visibility into which video failed or why
- Added a `except CouldNotRetrieveTranscript` clause that logs at `WARNING` with the video id and exception message, then re-raises unchanged so `summary.py` error handling is unaffected
- Added a test verifying the warning is emitted and the exception is re-raised

## What a reviewer should know

`before_sleep_log` (used for tenacity retries) only fires between retry attempts for exceptions matched by `retry_if_exception_type`. Non-retryable errors like `TranscriptsDisabled` bypass tenacity's hooks entirely and were completely invisible in logs. Catching the parent class `CouldNotRetrieveTranscript` covers all current and future subclasses without needing updates when new ones are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Log transcript failures that were previously silent**

### What Changed
- Transcript fetch failures like disabled or unavailable videos now show a warning with the video ID and error message before the error is raised again
- Existing retry behavior stays the same for retryable transcript errors
- Added a test that checks the warning is written and the original error still reaches the caller

### Impact
`✅ Clearer transcript failure logs`
`✅ Faster identification of broken videos`
`✅ No change to retry handling`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=4CzUInnryS7JudRszZXWrF2dHV7dIbsQuBiRey_yLd0&org=vasiliadi)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error logging when transcript retrieval fails with more diagnostic information to aid troubleshooting.

* **Tests**
  * Added test coverage for transcript retrieval error handling and logging behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/737)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->