### PR TITLE
fix: update Renovate configuration for Python pyenv to avoid Docker H…

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,17 +13,17 @@
   "lockFileMaintenance": { "enabled": true, "automerge": true },
   "packageRules": [
     {
+      "description": "Python pyenv (.python-version): don't gate on Docker Hub republish time",
+      "matchManagers": ["pyenv"],
+      "matchPackageNames": ["python"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "description": "Force Renovate to evaluate patches independently, but strictly IGNORE alphas/betas",
       "matchDepNames": ["python"],
       "separateMinorPatch": true,
       "respectLatest": false,
       "ignoreUnstable": true
-    },
-    {
-      "description": "Python Docker tag: don't gate on Docker Hub republish time — the language release (PEP 745) is the real stability signal",
-      "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["python"],
-      "minimumReleaseAge": "0 days"
     },
     {
       "description": "Disable minor, major, and prerelease updates for Python (pep621/pyenv managers)",


### PR DESCRIPTION
## **User description**
…ub republish time gating


___

## **CodeAnt-AI Description**
Update Renovate so Python version bumps in `.python-version` wait for the normal stability window instead of being held back by Docker Hub republish timing.

### What Changed
- Python updates from `.python-version` now use the standard 3-day release delay
- The Dockerfile-specific Python rule was removed, so Docker image updates no longer control this release timing
- Renovate now treats Python version updates in the pyenv file separately from Docker image updates

### Impact
`✅ Fewer missed Python updates`
`✅ More predictable dependency PR timing`
`✅ Less waiting on Docker Hub republish delays`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configuration for automated dependency management has been updated for Python packages. Release evaluation timing has been changed to include a 3-day waiting period before applying updates. Configuration continues to exclude unstable versions and evaluates patch updates independently from major/minor releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->