### PR TITLE
refactor: replace abandoned rush with limits for rate limiting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ requires-python = ">=3.14"
 dependencies = [
     "beautifulsoup4>=4.13.4,<5",
     "google-genai>=1.25.0,<3",
+    "limits[redis]>=5,<6",
     "psycopg2-binary>=2.9.10,<3",
     "pytelegrambotapi>=4.27.0,<5",
     "replicate>=1.0.7,<2",
     "requests[socks]>=2.32.4,<3",
-    "rush[redis]==2021.4.0",
     "sentry-sdk>=2.33.0,<3",
     "sqlalchemy>=2.0.41,<3",
     "telegramify-markdown>=1.0.0,<2",

--- a/scripts/cron.py
+++ b/scripts/cron.py
@@ -20,7 +20,13 @@ with image.imports():
     retries=modal.Retries(max_retries=3),
 )
 def clear_limit() -> int:
-    """Delete all per-user daily limit keys (LIMITER/RPD:*) from Redis."""
+    """Delete all per-user daily limit keys (LIMITER/RPD:*) from Redis.
+
+    The ``LIMITER/`` prefix is the default key_prefix used by
+    ``limits.storage.RedisStorage`` (limits>=5). If the library or its
+    configuration ever changes that prefix, this pattern must be updated
+    to match.
+    """
     daily_limit_key = "LIMITER/RPD"
     rate_limiter_url = f"{os.environ['REDIS_URL']}/0"
     client = redis_lib.StrictRedis.from_url(url=rate_limiter_url, decode_responses=True)

--- a/scripts/cron.py
+++ b/scripts/cron.py
@@ -20,8 +20,8 @@ with image.imports():
     retries=modal.Retries(max_retries=3),
 )
 def clear_limit() -> int:
-    """Delete all per-user daily limit keys (RPD:*) from Redis."""
-    daily_limit_key = "RPD"
+    """Delete all per-user daily limit keys (LIMITER/RPD:*) from Redis."""
+    daily_limit_key = "LIMITER/RPD"
     rate_limiter_url = f"{os.environ['REDIS_URL']}/0"
     client = redis_lib.StrictRedis.from_url(url=rate_limiter_url, decode_responses=True)
 

--- a/src/config.py
+++ b/src/config.py
@@ -8,9 +8,9 @@ import sentry_sdk
 import telebot
 from google import genai
 from google.genai import types
-from rush import quota, throttle
-from rush.limiters import periodic
-from rush.stores import redis as redis_store
+from limits import parse as parse_rate_limit
+from limits.storage import RedisStorage
+from limits.strategies import FixedWindowRateLimiter
 
 if os.environ.get("ENV") != "PROD":
     from dotenv import load_dotenv
@@ -121,22 +121,9 @@ headers = {
 MINUTE_LIMIT_KEY = "RPM"
 DAILY_LIMIT_KEY = "RPD"
 MINUTE_LIMIT = 5
-rate_limiter_redis = redis_store.redis.StrictRedis.from_url(
-    url=RATE_LIMITER_URL,
-    decode_responses=True,
-)
-rate_limiter_store = redis_store.RedisStore(
-    url=RATE_LIMITER_URL,
-    client=rate_limiter_redis,
-)
-per_minute_limit = throttle.Throttle(
-    limiter=periodic.PeriodicLimiter(
-        store=rate_limiter_store,
-    ),
-    rate=quota.Quota.per_minute(
-        count=MINUTE_LIMIT,
-    ),
-)
+rate_limiter_store = RedisStorage(RATE_LIMITER_URL)
+rate_limiter = FixedWindowRateLimiter(rate_limiter_store)
+per_minute_rate = parse_rate_limit(f"{MINUTE_LIMIT} per minute")
 
 
 # For cleanup

--- a/src/config.py
+++ b/src/config.py
@@ -121,8 +121,7 @@ headers: dict[str, str | bytes] = {
 MINUTE_LIMIT_KEY = "RPM"
 DAILY_LIMIT_KEY = "RPD"
 MINUTE_LIMIT = 5
-rate_limiter_store = RedisStorage(RATE_LIMITER_URL)
-rate_limiter = FixedWindowRateLimiter(rate_limiter_store)
+rate_limiter = FixedWindowRateLimiter(RedisStorage(RATE_LIMITER_URL))
 per_minute_rate = parse_rate_limit(f"{MINUTE_LIMIT} per minute")
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -112,7 +112,7 @@ replicate_client = replicate.Client(api_token=REPLICATE_API_TOKEN)
 
 
 # Headers for requests https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome
-headers = {
+headers: dict[str, str | bytes] = {
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",  # noqa: E501
 }
 

--- a/src/services.py
+++ b/src/services.py
@@ -186,10 +186,9 @@ def check_quota(user_id: int, daily_limit: int, quantity: int = 1) -> bool:
     if not rate_limiter.hit(daily_rate, f"{DAILY_LIMIT_KEY}:{user_id}", cost=quantity):
         msg = "The daily limit for requests has been exceeded"
         raise LimitExceededError(msg)
-    if not rate_limiter.hit(per_minute_rate, MINUTE_LIMIT_KEY, cost=quantity):
+    while not rate_limiter.hit(per_minute_rate, MINUTE_LIMIT_KEY, cost=quantity):
         stats = rate_limiter.get_window_stats(per_minute_rate, MINUTE_LIMIT_KEY)
-        time_to_reset = max(0.0, stats.reset_time - time.time())
-        time.sleep(time_to_reset)
+        time.sleep(max(0.0, stats.reset_time - time.time()))
     return True
 
 

--- a/src/services.py
+++ b/src/services.py
@@ -2,11 +2,12 @@ import logging
 import math
 import mimetypes
 import time
+from functools import lru_cache
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, cast
 
 from google.genai import types
-from limits import parse as parse_rate_limit
+from limits import parse as _parse_rate_limit
 from requests.exceptions import ReadTimeout
 from telebot.apihelper import ApiTelegramException
 from telegramify_markdown import convert, split_entities
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
+parse_rate_limit = lru_cache(maxsize=64)(_parse_rate_limit)
 
 
 def choose_yt_audio_format(info: dict[str, Any]) -> str:

--- a/src/services.py
+++ b/src/services.py
@@ -6,10 +6,8 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Any, cast
 
 from google.genai import types
+from limits import parse as parse_rate_limit
 from requests.exceptions import ReadTimeout
-from rush import quota, throttle
-from rush.exceptions import DataChangedInStoreError, MismatchedDataError
-from rush.limiters import periodic
 from telebot.apihelper import ApiTelegramException
 from telegramify_markdown import convert, split_entities
 from tenacity import (
@@ -27,8 +25,8 @@ from config import (
     MODELS_WITH_THINKING_SUPPORT,
     bot,
     gemini_client,
-    per_minute_limit,
-    rate_limiter_store,
+    per_minute_rate,
+    rate_limiter,
 )
 from exceptions import LimitExceededError
 from prompts import SYSTEM_INSTRUCTION
@@ -158,15 +156,6 @@ def send_answer(message: Message, answer: str) -> None:
         current = next_chunk
 
 
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(1),
-    retry=retry_if_exception_type(
-        (DataChangedInStoreError, MismatchedDataError),
-    ),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
 def check_quota(user_id: int, daily_limit: int, quantity: int = 1) -> bool:
     """Check if the request is within rate limits and handle any delays.
 
@@ -184,7 +173,6 @@ def check_quota(user_id: int, daily_limit: int, quantity: int = 1) -> bool:
 
     Raises:
         LimitExceededError: If the daily request limit has been exceeded.
-        RetryError: If store data errors persist after all retry attempts.
 
     Note:
         - The function will automatically sleep if the per-minute limit is reached
@@ -194,21 +182,13 @@ def check_quota(user_id: int, daily_limit: int, quantity: int = 1) -> bool:
     if daily_limit <= 0:
         msg = "The daily limit for requests has been exceeded"
         raise LimitExceededError(msg)
-    per_day_limit = throttle.Throttle(
-        limiter=periodic.PeriodicLimiter(
-            store=rate_limiter_store,
-        ),
-        rate=quota.Quota.per_day(
-            count=daily_limit,
-        ),
-    )
-    rpd = per_day_limit.check(f"{DAILY_LIMIT_KEY}:{user_id}", quantity=quantity)
-    if rpd.limited:
+    daily_rate = parse_rate_limit(f"{daily_limit} per day")
+    if not rate_limiter.hit(daily_rate, f"{DAILY_LIMIT_KEY}:{user_id}", cost=quantity):
         msg = "The daily limit for requests has been exceeded"
         raise LimitExceededError(msg)
-    rpm = per_minute_limit.check(MINUTE_LIMIT_KEY, quantity=quantity)
-    if rpm.limited:
-        time_to_reset = max(0, rpm.reset_after.total_seconds())
+    if not rate_limiter.hit(per_minute_rate, MINUTE_LIMIT_KEY, cost=quantity):
+        stats = rate_limiter.get_window_stats(per_minute_rate, MINUTE_LIMIT_KEY)
+        time_to_reset = max(0.0, stats.reset_time - time.time())
         time.sleep(time_to_reset)
     return True
 
@@ -226,16 +206,9 @@ def get_remaining_quota(user_id: int, daily_limit: int) -> int:
     """
     if daily_limit <= 0:
         return 0
-    per_day_limit = throttle.Throttle(
-        limiter=periodic.PeriodicLimiter(
-            store=rate_limiter_store,
-        ),
-        rate=quota.Quota.per_day(
-            count=daily_limit,
-        ),
-    )
-    result = per_day_limit.check(f"{DAILY_LIMIT_KEY}:{user_id}", quantity=0)
-    return max(0, result.remaining)
+    daily_rate = parse_rate_limit(f"{daily_limit} per day")
+    stats = rate_limiter.get_window_stats(daily_rate, f"{DAILY_LIMIT_KEY}:{user_id}")
+    return max(0, stats.remaining)
 
 
 def get_gemini_config(

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from defusedxml.ElementTree import ParseError
 from replicate.exceptions import ModelError, ReplicateError
@@ -140,7 +140,7 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
 
     """
     temp_basename = generate_temporary_name()
-    ydl_opts: dict[str, object] = {
+    ydl_opts: dict[str, Any] = {
         "proxy": PROXY,
         "skip_download": True,
         "writesubtitles": True,
@@ -152,14 +152,14 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
         "nocheckcertificate": False,
     }
     try:
-        with YoutubeDL(ydl_opts) as ydl:
+        with YoutubeDL(ydl_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
             ydl.download([url])
 
         vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
 
         if not vtt_files:
             ydl_opts_all = {**ydl_opts, "subtitleslangs": ["all"]}
-            with YoutubeDL(ydl_opts_all) as ydl:
+            with YoutubeDL(ydl_opts_all) as ydl:  # pyrefly: ignore[bad-argument-type]
                 ydl.download([url])
             vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 
-import fakeredis
 import pytest
 from telebot import TeleBot, types
 
@@ -47,14 +46,6 @@ def mock_db_session(mocker):
     # Also mock engine if accessed
     mocker.patch("database.engine", mocker.MagicMock())
     return session_mock
-
-
-@pytest.fixture
-def redis_client(mocker):
-    """Fixture to provide a fakeredis instance and mock the limits Redis storage."""
-    fake_redis = fakeredis.FakeRedis(decode_responses=True)
-    mocker.patch("limits.storage.redis.Redis.from_url", return_value=fake_redis)
-    return fake_redis
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,10 +51,9 @@ def mock_db_session(mocker):
 
 @pytest.fixture
 def redis_client(mocker):
-    """Fixture to provide a fakeredis instance and mock the actual redis client."""
-    fake_redis = fakeredis.FakeRedis()
-    # It mocks the redis client initialization in rush/config where appropriate
-    mocker.patch("rush.stores.redis.redis.StrictRedis.from_url", return_value=fake_redis)
+    """Fixture to provide a fakeredis instance and mock the limits Redis storage."""
+    fake_redis = fakeredis.FakeRedis(decode_responses=True)
+    mocker.patch("limits.storage.redis.Redis.from_url", return_value=fake_redis)
     return fake_redis
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,4 +1,5 @@
 import pytest
+from limits.util import WindowStats
 
 from config import MODELS_WITH_THINKING_SUPPORT
 from exceptions import LimitExceededError
@@ -205,8 +206,6 @@ def test_upload_and_wait_for_audio_file_missing_uri(mocker):
 
 def test_get_remaining_quota(mocker):
     """get_remaining_quota returns remaining count from window stats."""
-    from limits.util import WindowStats
-
     mocker.patch(
         "services.rate_limiter.get_window_stats",
         return_value=WindowStats(reset_time=9999999999.0, remaining=7),
@@ -257,8 +256,6 @@ def test_check_quota_raises_when_daily_redis_counter_exhausted(mocker):
 
 def test_check_quota_sleeps_when_per_minute_limited(mocker):
     """check_quota sleeps until the window resets and retries the per-minute hit."""
-    from limits.util import WindowStats
-
     fixed_now = 1_000_000.0
     mocker.patch("services.time.time", return_value=fixed_now)
     mocker.patch(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -244,9 +244,7 @@ def test_check_quota_uses_per_user_redis_key(mocker):
     result = check_quota(user_id=456, daily_limit=5)
 
     assert result is True
-    # First call is the daily key; identifiers are positional args after the rate item
-    daily_call_args = mock_hit.call_args_list[0][0]
-    assert "RPD:456" in daily_call_args
+    assert mock_hit.call_args_list[0].args[1] == "RPD:456"
 
 
 def test_check_quota_raises_when_daily_redis_counter_exhausted(mocker):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -256,14 +256,14 @@ def test_check_quota_raises_when_daily_redis_counter_exhausted(mocker):
 
 
 def test_check_quota_sleeps_when_per_minute_limited(mocker):
-    """check_quota sleeps until window reset when the per-minute limit is hit."""
+    """check_quota sleeps until the window resets and retries the per-minute hit."""
     from limits.util import WindowStats
 
     fixed_now = 1_000_000.0
     mocker.patch("services.time.time", return_value=fixed_now)
     mocker.patch(
         "services.rate_limiter.hit",
-        side_effect=[True, False],  # daily passes, per-minute blocked
+        side_effect=[True, False, True],  # daily passes, per-minute blocked, retry ok
     )
     mocker.patch(
         "services.rate_limiter.get_window_stats",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -204,78 +204,78 @@ def test_upload_and_wait_for_audio_file_missing_uri(mocker):
 
 
 def test_get_remaining_quota(mocker):
-    """get_remaining_quota probes Redis with quantity=0 and returns remaining count."""
-    mock_throttle_cls = mocker.patch("services.throttle.Throttle")
-    mock_throttle_instance = mock_throttle_cls.return_value
-    mock_throttle_instance.check.return_value = mocker.MagicMock(remaining=7)
+    """get_remaining_quota returns remaining count from window stats."""
+    from limits.util import WindowStats
+
+    mocker.patch(
+        "services.rate_limiter.get_window_stats",
+        return_value=WindowStats(reset_time=9999999999.0, remaining=7),
+    )
 
     result = get_remaining_quota(user_id=123, daily_limit=10)
 
     assert result == 7
-    mock_throttle_instance.check.assert_called_once_with("RPD:123", quantity=0)
 
 
 def test_check_quota_raises_immediately_when_daily_limit_zero(mocker):
     """check_quota raises LimitExceededError without touching Redis when limit is 0."""
-    mock_throttle_cls = mocker.patch("services.throttle.Throttle")
+    mock_hit = mocker.patch("services.rate_limiter.hit")
 
     with pytest.raises(LimitExceededError):
         check_quota(user_id=1, daily_limit=0)
 
-    mock_throttle_cls.assert_not_called()
+    mock_hit.assert_not_called()
 
 
 def test_get_remaining_quota_returns_zero_when_daily_limit_zero(mocker):
     """get_remaining_quota returns 0 without touching Redis when limit is 0."""
-    mock_throttle_cls = mocker.patch("services.throttle.Throttle")
+    mock_stats = mocker.patch("services.rate_limiter.get_window_stats")
 
     result = get_remaining_quota(user_id=1, daily_limit=0)
 
     assert result == 0
-    mock_throttle_cls.assert_not_called()
+    mock_stats.assert_not_called()
 
 
 def test_check_quota_uses_per_user_redis_key(mocker):
-    """check_quota checks the Redis key scoped to the user (RPD:{user_id})."""
-    mock_throttle_cls = mocker.patch("services.throttle.Throttle")
-    mock_throttle_instance = mock_throttle_cls.return_value
-    mock_throttle_instance.check.return_value = mocker.MagicMock(limited=False)
-    mocker.patch(
-        "services.per_minute_limit.check",
-        return_value=mocker.MagicMock(limited=False),
-    )
+    """check_quota hits the Redis key scoped to the user (RPD:{user_id})."""
+    mock_hit = mocker.patch("services.rate_limiter.hit", return_value=True)
 
     result = check_quota(user_id=456, daily_limit=5)
 
     assert result is True
-    mock_throttle_instance.check.assert_called_once_with("RPD:456", quantity=1)
+    # First call is the daily key; identifiers are positional args after the rate item
+    daily_call_args = mock_hit.call_args_list[0][0]
+    assert "RPD:456" in daily_call_args
 
 
 def test_check_quota_raises_when_daily_redis_counter_exhausted(mocker):
-    """check_quota raises LimitExceededError when Redis counter is at the cap."""
-    mock_throttle_cls = mocker.patch("services.throttle.Throttle")
-    mock_throttle_instance = mock_throttle_cls.return_value
-    mock_throttle_instance.check.return_value = mocker.MagicMock(limited=True)
+    """check_quota raises LimitExceededError when the daily counter is exhausted."""
+    mocker.patch("services.rate_limiter.hit", return_value=False)
 
     with pytest.raises(LimitExceededError):
         check_quota(user_id=789, daily_limit=3)
 
 
 def test_check_quota_sleeps_when_per_minute_limited(mocker):
-    """check_quota sleeps for reset_after seconds when the per-minute limit is hit."""
-    mock_throttle_cls = mocker.patch("services.throttle.Throttle")
-    mock_throttle_instance = mock_throttle_cls.return_value
-    mock_throttle_instance.check.return_value = mocker.MagicMock(limited=False)
-    mock_reset_after = mocker.MagicMock()
-    mock_reset_after.total_seconds.return_value = 7.5
+    """check_quota sleeps until window reset when the per-minute limit is hit."""
+    import time as time_mod
+
+    from limits.util import WindowStats
+
+    future_reset = time_mod.time() + 7.5
     mocker.patch(
-        "services.per_minute_limit.check",
-        return_value=mocker.MagicMock(limited=True, reset_after=mock_reset_after),
+        "services.rate_limiter.hit",
+        side_effect=[True, False],  # daily passes, per-minute blocked
+    )
+    mocker.patch(
+        "services.rate_limiter.get_window_stats",
+        return_value=WindowStats(reset_time=future_reset, remaining=0),
     )
     mock_sleep = mocker.patch("services.time.sleep")
 
     result = check_quota(user_id=321, daily_limit=5)
 
     assert result is True
-    mock_sleep.assert_called_once_with(7.5)
-    mock_throttle_instance.check.assert_called_once_with("RPD:321", quantity=1)
+    slept = mock_sleep.call_args[0][0]
+    assert 7.0 <= slept <= 8.0

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -257,23 +257,21 @@ def test_check_quota_raises_when_daily_redis_counter_exhausted(mocker):
 
 def test_check_quota_sleeps_when_per_minute_limited(mocker):
     """check_quota sleeps until window reset when the per-minute limit is hit."""
-    import time as time_mod
-
     from limits.util import WindowStats
 
-    future_reset = time_mod.time() + 7.5
+    fixed_now = 1_000_000.0
+    mocker.patch("services.time.time", return_value=fixed_now)
     mocker.patch(
         "services.rate_limiter.hit",
         side_effect=[True, False],  # daily passes, per-minute blocked
     )
     mocker.patch(
         "services.rate_limiter.get_window_stats",
-        return_value=WindowStats(reset_time=future_reset, remaining=0),
+        return_value=WindowStats(reset_time=fixed_now + 7.5, remaining=0),
     )
     mock_sleep = mocker.patch("services.time.sleep")
 
     result = check_quota(user_id=321, daily_limit=5)
 
     assert result is True
-    slept = mock_sleep.call_args[0][0]
-    assert 7.0 <= slept <= 8.0
+    mock_sleep.assert_called_once_with(7.5)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -43,25 +43,23 @@ def test_redis_rate_limiting_success(mocker):
 
 def test_redis_rate_limiting_minute_throttle(mocker):
     """Test that if a user exceeds the minute limit, it sleeps/throttles."""
-    import time as time_mod
-
     from limits.util import WindowStats
 
-    future_reset = time_mod.time() + 1.5
+    fixed_now = 1_000_000.0
+    mocker.patch("services.time.time", return_value=fixed_now)
     mocker.patch(
         "services.rate_limiter.hit",
         side_effect=[True, False],  # daily passes, per-minute blocked
     )
     mocker.patch(
         "services.rate_limiter.get_window_stats",
-        return_value=WindowStats(reset_time=future_reset, remaining=0),
+        return_value=WindowStats(reset_time=fixed_now + 1.5, remaining=0),
     )
     mock_sleep = mocker.patch("services.time.sleep")
 
     assert check_quota(user_id=123, daily_limit=10) is True
 
-    slept = mock_sleep.call_args[0][0]
-    assert 1.0 <= slept <= 2.0
+    mock_sleep.assert_called_once_with(1.5)
 
 
 def test_redis_rate_limiting_daily_exceeded(mocker):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,4 +1,5 @@
 import pytest
+from limits.util import WindowStats
 
 from database import UsersOrm, check_auth
 from exceptions import LimitExceededError
@@ -43,8 +44,6 @@ def test_redis_rate_limiting_success(mocker):
 
 def test_redis_rate_limiting_minute_throttle(mocker):
     """Test that if a user exceeds the minute limit, it sleeps/throttles."""
-    from limits.util import WindowStats
-
     fixed_now = 1_000_000.0
     mocker.patch("services.time.time", return_value=fixed_now)
     mocker.patch(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -36,33 +36,37 @@ def test_db_unknown_user_permission(mock_db_session):
 
 def test_redis_rate_limiting_success(mocker):
     """Test that a user within limits can proceed."""
-    mock_throttle_cls = mocker.patch("services.throttle.Throttle")
-    mock_throttle_cls.return_value.check.return_value = mocker.MagicMock(limited=False)
-    mocker.patch("services.per_minute_limit.check", return_value=mocker.MagicMock(limited=False))
+    mocker.patch("services.rate_limiter.hit", return_value=True)
 
     assert check_quota(user_id=123, daily_limit=10) is True
 
 
 def test_redis_rate_limiting_minute_throttle(mocker):
     """Test that if a user exceeds the minute limit, it sleeps/throttles."""
-    mock_throttle_cls = mocker.patch("services.throttle.Throttle")
-    mock_throttle_cls.return_value.check.return_value = mocker.MagicMock(limited=False)
+    import time as time_mod
 
-    mock_rpm = mocker.MagicMock(limited=True)
-    mock_rpm.reset_after.total_seconds.return_value = 1.5
-    mocker.patch("services.per_minute_limit.check", return_value=mock_rpm)
+    from limits.util import WindowStats
 
+    future_reset = time_mod.time() + 1.5
+    mocker.patch(
+        "services.rate_limiter.hit",
+        side_effect=[True, False],  # daily passes, per-minute blocked
+    )
+    mocker.patch(
+        "services.rate_limiter.get_window_stats",
+        return_value=WindowStats(reset_time=future_reset, remaining=0),
+    )
     mock_sleep = mocker.patch("services.time.sleep")
 
     assert check_quota(user_id=123, daily_limit=10) is True
 
-    mock_sleep.assert_called_once_with(1.5)
+    slept = mock_sleep.call_args[0][0]
+    assert 1.0 <= slept <= 2.0
 
 
 def test_redis_rate_limiting_daily_exceeded(mocker):
     """Test that if a user's daily counter is exhausted, it raises LimitExceededError."""
-    mock_throttle_cls = mocker.patch("services.throttle.Throttle")
-    mock_throttle_cls.return_value.check.return_value = mocker.MagicMock(limited=True)
+    mocker.patch("services.rate_limiter.hit", return_value=False)
 
     with pytest.raises(LimitExceededError, match="The daily limit for requests has been exceeded"):
         check_quota(user_id=123, daily_limit=5)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -49,7 +49,7 @@ def test_redis_rate_limiting_minute_throttle(mocker):
     mocker.patch("services.time.time", return_value=fixed_now)
     mocker.patch(
         "services.rate_limiter.hit",
-        side_effect=[True, False],  # daily passes, per-minute blocked
+        side_effect=[True, False, True],  # daily passes, per-minute blocked, retry ok
     )
     mocker.patch(
         "services.rate_limiter.get_window_stats",

--- a/uv.lock
+++ b/uv.lock
@@ -13,11 +13,11 @@ source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "google-genai" },
+    { name = "limits", extra = ["redis"] },
     { name = "psycopg2-binary" },
     { name = "pytelegrambotapi" },
     { name = "replicate" },
     { name = "requests", extra = ["socks"] },
-    { name = "rush", extra = ["redis"] },
     { name = "sentry-sdk" },
     { name = "sqlalchemy" },
     { name = "telegramify-markdown" },
@@ -55,11 +55,11 @@ test = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.4,<5" },
     { name = "google-genai", specifier = ">=1.25.0,<3" },
+    { name = "limits", extras = ["redis"], specifier = ">=5,<6" },
     { name = "psycopg2-binary", specifier = ">=2.9.10,<3" },
     { name = "pytelegrambotapi", specifier = ">=4.27.0,<5" },
     { name = "replicate", specifier = ">=1.0.7,<2" },
     { name = "requests", extras = ["socks"], specifier = ">=2.32.4,<3" },
-    { name = "rush", extras = ["redis"], specifier = "==2021.4.0" },
     { name = "sentry-sdk", specifier = ">=2.33.0,<3" },
     { name = "sqlalchemy", specifier = ">=2.0.41,<3" },
     { name = "telegramify-markdown", specifier = ">=1.0.0,<2" },
@@ -556,6 +556,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -777,6 +789,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
 ]
 
 [[package]]
@@ -1354,15 +1385,6 @@ socks = [
 ]
 
 [[package]]
-name = "rfc3986"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
-]
-
-[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1373,24 +1395,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
-name = "rush"
-version = "2021.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/f8/3be2826ee081aeaf47f61bce24d56e4dbf32cb841a2f2708554d4b471ed4/rush-2021.4.0.tar.gz", hash = "sha256:818624075f0313f64a4c38ba62bc4a6526ee31b463990c8aebf03a98f5aaf264", size = 15378, upload-time = "2021-04-01T17:58:37.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/08/f38d9f6a3c6d9b5ea2a79414c9a65a7dd7bbe97ee1554396ffe1811a0fad/rush-2021.4.0-py3-none-any.whl", hash = "sha256:0f775f35a951b7874442c78eaa312bbd442be130dee9508f8d05b2f43dbd3acc", size = 18556, upload-time = "2021-04-01T17:58:36.628Z" },
-]
-
-[package.optional-dependencies]
-redis = [
-    { name = "redis" },
-    { name = "rfc3986" },
 ]
 
 [[package]]
@@ -1632,6 +1636,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## **User description**
## Summary

- Replaces `rush[redis]==2021.4.0` (last release April 2021, declares only Python 3.6/3.7 support, never updated) with `limits[redis]>=5,<6` (v5.8.0, actively maintained, Python 3.14 declared)
- Rewrites `check_quota` and `get_remaining_quota` in `services.py` using the `limits` API (`limiter.hit()` / `limiter.get_window_stats()`)
- Removes the tenacity CAS-retry decorator from `check_quota` — `limits` uses server-side Lua/INCR so `DataChangedInStoreError`/`MismatchedDataError` can no longer occur
- Updates the daily key scan pattern in `scripts/cron.py` from `RPD:*` to `LIMITER/RPD:*` to match the new library's Redis key scheme
- Updates all tests: `conftest.py` fixture and rush-specific mocks in `test_services.py` and `test_state.py`

## Behaviour

Like-for-like migration: same fixed-window strategy, same `RPM`/`RPD` identifier namespacing, same sleep-on-minute-limit behaviour. No quota values changed.

## Test plan

- [x] 153 tests pass (`uv run pytest`)
- [x] `ruff format` + `ruff check` clean
- [x] `ty check` unchanged (2 pre-existing errors in `download.py`, unrelated)
- [x] Pre-commit hooks pass (secrets, ruff, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Rate-limiting migrated to a new implementation, updating daily and per‑minute quota enforcement and related call sites.
* **Chore**
  * Project dependencies updated to add the new rate-limiter package and remove the previous limiter.
* **Bug Fixes**
  * Scheduled cleanup now targets limiter-prefixed keys for correct Redis key cleanup.
* **Tests**
  * Tests and fixtures updated to mock and validate the new rate-limiter APIs and behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Switch rate limiting to the maintained Redis-backed limiter**

### What Changed
- Daily request checks now use the new Redis rate limiter while keeping the same per-user daily cap and per-minute pause behavior
- When the minute limit is hit, the app now waits for the reset time and retries instead of failing
- Remaining daily quota is now read from the new limiter’s current window stats
- The daily cleanup job now removes the new Redis keys used by the limiter
- Tests and shared test setup were updated to match the new rate limit behavior and Redis key format

### Impact
`✅ Fewer rate-limit failures`
`✅ Same request caps with maintained Redis support`
`✅ Cleaner daily quota cleanup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
