### PR TITLE
refactor: simplify codebase

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,14 +58,14 @@
       "automerge": true
     },
     {
-      "description": "CalVer packages (yt-dlp YYYY.M.D, rush YYYY.M.D): pin exactly so lockFileMaintenance cannot silently update them; use pep440 for correct version comparison",
-      "matchPackageNames": ["yt-dlp", "rush"],
+      "description": "CalVer packages (yt-dlp YYYY.M.D): pin exactly so lockFileMaintenance cannot silently update them; use pep440 for correct version comparison",
+      "matchPackageNames": ["yt-dlp"],
       "versioning": "pep440",
       "rangeStrategy": "pin"
     },
     {
       "description": "CalVer packages: all updates require manual review regardless of version component",
-      "matchPackageNames": ["yt-dlp", "rush"],
+      "matchPackageNames": ["yt-dlp"],
       "automerge": false,
       "addLabels": ["dep:calver"]
     }

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ While text transcripts can provide a solid foundation for understanding the cont
 [youtube-transcript-api](https://github.com/jdepoix/youtube-transcript-api) \
 [Tenacity](https://tenacity.readthedocs.io/en/latest/) \
 [Sentry](https://docs.sentry.io/platforms/python/) \
-[rush](https://rush.readthedocs.io/en/latest/)
+~~[rush](https://rush.readthedocs.io/en/latest/)~~ \
+[limits](https://github.com/alisaifee/limits)
 
 [Telegram Bot API](https://core.telegram.org/bots/api) \
 [Docker | Set build-time variables (--build-arg)](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg) \

--- a/src/config.py
+++ b/src/config.py
@@ -145,7 +145,7 @@ SUPPORTED_DOCUMENT_MIME_TYPES = (
 
 
 # YouTube host allow-list for URL routing.
-YT_HOSTS = frozenset({"youtu.be", "youtube.com", "www.youtube.com"})
+YT_HOSTS = frozenset({"youtu.be", "youtube.com"})
 CASTRO_HOST = "castro.fm"
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -65,6 +65,7 @@ MODEL_LABELS: dict[str, str] = {
     "gemini-3-flash-preview": "Gemini 3 Flash",
     "gemini-2.5-flash": "Gemini 2.5 Flash",
 }
+MODEL_LABELS_REVERSE: dict[str, str] = {v: k for k, v in MODEL_LABELS.items()}
 ALLOWED_MODELS_FOR_SUMMARY = list(MODEL_LABELS.keys())
 MODELS_WITH_THINKING_SUPPORT = [
     "gemini-3-flash-preview",
@@ -103,6 +104,9 @@ PROMPT_STRATEGY_LABELS: dict[str, str] = {
     "basic_prompt_for_transcript": "Detailed Summary",
     "key_points_for_transcript": "Key Points",
 }
+PROMPT_STRATEGY_LABELS_REVERSE: dict[str, str] = {
+    v: k for k, v in PROMPT_STRATEGY_LABELS.items()
+}
 ALLOWED_PROMPT_KEYS = list(PROMPT_STRATEGY_LABELS.keys())
 
 
@@ -125,26 +129,29 @@ rate_limiter = FixedWindowRateLimiter(RedisStorage(RATE_LIMITER_URL))
 per_minute_rate = parse_rate_limit(f"{MINUTE_LIMIT} per minute")
 
 
-# For cleanup
-PROTECTED_FILES = (
-    os.listdir(Path.cwd())  # noqa: PTH208
-    if os.environ.get("ENV") != "PROD"
-    else [
-        "config.py",
-        "database.py",
-        "download.py",
-        "exceptions.py",
-        "handlers.py",
-        "main.py",
-        "models.py",
-        "parse.py",
-        "prompts.py",
-        "services.py",
-        "summary.py",
-        "transcription.py",
-        "utils.py",
-    ]
+# Telegram bot API caps incoming-file downloads at 20MB.
+# https://core.telegram.org/bots/api#getfile
+TG_MAX_FILE_SIZE = 20 * 1024 * 1024
+
+
+# MIME types accepted by /document handler.
+SUPPORTED_DOCUMENT_MIME_TYPES = (
+    "application/pdf",
+    "text/plain",
+    "text/rtf",
+    "text/csv",
+    "audio/ogg",
 )
+
+
+# YouTube host allow-list for URL routing.
+YT_HOSTS = frozenset({"youtu.be", "youtube.com", "www.youtube.com"})
+CASTRO_HOST = "castro.fm"
+
+
+# For cleanup: snapshot of files present at startup; treated as do-not-delete.
+# In PROD the container's working dir IS src/, so this also covers source files.
+PROTECTED_FILES = os.listdir(Path.cwd())  # noqa: PTH208
 
 
 # Translation

--- a/src/config.py
+++ b/src/config.py
@@ -138,7 +138,7 @@ TG_MAX_FILE_SIZE = 20 * 1024 * 1024
 SUPPORTED_DOCUMENT_MIME_TYPES = (
     "application/pdf",
     "text/plain",
-    "text/rtf",
+    "application/rtf",
     "text/csv",
     "audio/ogg",
 )

--- a/src/download.py
+++ b/src/download.py
@@ -116,19 +116,23 @@ def _stream_to_file(
                 msg = f"Remote file too large: Content-Length {content_length} > {max_size}"  # noqa: E501
                 raise ValueError(msg)
         total = 0
-        with Path(dest).open("wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                if chunk:
-                    total += len(chunk)
-                    if max_size is not None and total > max_size:
-                        logger.warning(
-                            "Download exceeded limit %s after %s bytes, aborting",
-                            max_size,
-                            total,
-                        )
-                        msg = f"Remote file too large: exceeded {max_size} bytes"
-                        raise ValueError(msg)
-                    f.write(chunk)
+        try:
+            with Path(dest).open("wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        total += len(chunk)
+                        if max_size is not None and total > max_size:
+                            logger.warning(
+                                "Download exceeded limit %s after %s bytes, aborting",
+                                max_size,
+                                total,
+                            )
+                            msg = f"Remote file too large: exceeded {max_size} bytes"
+                            raise ValueError(msg)  # noqa: TRY301
+                        f.write(chunk)
+        except ValueError:
+            Path(dest).unlink(missing_ok=True)
+            raise
 
 
 @retry(

--- a/src/download.py
+++ b/src/download.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -16,7 +18,7 @@ from tenacity import (
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
-from config import PROXY, TG_API_TOKEN, headers
+from config import PROXY, TG_API_TOKEN, TG_MAX_FILE_SIZE, headers
 from services import choose_yt_audio_format
 from utils import generate_temporary_name
 
@@ -84,7 +86,12 @@ def download_yt(url: str) -> str:
     return temporary_file_name
 
 
-def _stream_to_file(url: str, dest: str, timeout: int = 120) -> None:
+def _stream_to_file(
+    url: str,
+    dest: str,
+    timeout: int = 120,
+    max_size: int | None = None,
+) -> None:
     """GET `url` and stream the body to `dest` in 8KB chunks."""
     with requests.get(
         url,
@@ -98,9 +105,29 @@ def _stream_to_file(url: str, dest: str, timeout: int = 120) -> None:
         except requests.exceptions.HTTPError:
             logger.exception("%s: status code", response.status_code)
             raise
+        if max_size is not None:
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None and int(content_length) > max_size:
+                logger.warning(
+                    "Content-Length %s exceeds limit %s, aborting",
+                    content_length,
+                    max_size,
+                )
+                msg = f"Remote file too large: Content-Length {content_length} > {max_size}"  # noqa: E501
+                raise ValueError(msg)
+        total = 0
         with Path(dest).open("wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
                 if chunk:
+                    total += len(chunk)
+                    if max_size is not None and total > max_size:
+                        logger.warning(
+                            "Download exceeded limit %s after %s bytes, aborting",
+                            max_size,
+                            total,
+                        )
+                        msg = f"Remote file too large: exceeded {max_size} bytes"
+                        raise ValueError(msg)
                     f.write(chunk)
 
 
@@ -179,5 +206,5 @@ def download_tg(file_id: File, ext: str = "") -> str:
         msg = "Telegram file path is missing."
         raise ValueError(msg)
     file_url = f"https://api.telegram.org/file/bot{TG_API_TOKEN}/{file_id.file_path}"
-    _stream_to_file(file_url, temporary_file_name)
+    _stream_to_file(file_url, temporary_file_name, max_size=TG_MAX_FILE_SIZE)
     return temporary_file_name

--- a/src/download.py
+++ b/src/download.py
@@ -84,6 +84,26 @@ def download_yt(url: str) -> str:
     return temporary_file_name
 
 
+def _stream_to_file(url: str, dest: str, timeout: int = 120) -> None:
+    """GET `url` and stream the body to `dest` in 8KB chunks."""
+    with requests.get(
+        url,
+        stream=True,
+        headers=headers,
+        verify=True,
+        timeout=timeout,
+    ) as response:
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.exception("%s: status code", response.status_code)
+            raise
+        with Path(dest).open("wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_fixed(10),
@@ -132,22 +152,7 @@ def download_castro(url: str) -> str:
         msg = "Audio URL is not a string."
         raise TypeError(msg)
     logger.debug("URL parsed! Starting download...")
-    with requests.get(
-        requests.utils.requote_uri(audio_url),
-        stream=True,
-        headers=headers,
-        verify=True,
-        timeout=120,
-    ) as r:
-        try:
-            r.raise_for_status()
-        except requests.exceptions.HTTPError:
-            logger.exception("%s: status code", r.status_code)
-            raise
-        with Path(temporary_file_name).open("wb") as f:
-            for chunk in r.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
+    _stream_to_file(requests.utils.requote_uri(audio_url), temporary_file_name)
     logger.debug("File downloaded...")
     return temporary_file_name
 
@@ -174,20 +179,5 @@ def download_tg(file_id: File, ext: str = "") -> str:
         msg = "Telegram file path is missing."
         raise ValueError(msg)
     file_url = f"https://api.telegram.org/file/bot{TG_API_TOKEN}/{file_id.file_path}"
-    with requests.get(
-        file_url,
-        stream=True,
-        headers=headers,
-        verify=True,
-        timeout=120,
-    ) as response:
-        try:
-            response.raise_for_status()
-        except requests.exceptions.HTTPError:
-            logger.exception("%s: status code", response.status_code)
-            raise
-        with Path(temporary_file_name).open("wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
+    _stream_to_file(file_url, temporary_file_name)
     return temporary_file_name

--- a/src/download.py
+++ b/src/download.py
@@ -115,9 +115,10 @@ def _stream_to_file(
                 )
                 msg = f"Remote file too large: Content-Length {content_length} > {max_size}"  # noqa: E501
                 raise ValueError(msg)
+        dest_path = Path(dest)
         total = 0
         try:
-            with Path(dest).open("wb") as f:
+            with dest_path.open("wb") as f:
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:
                         total += len(chunk)
@@ -131,7 +132,7 @@ def _stream_to_file(
                             raise ValueError(msg)  # noqa: TRY301
                         f.write(chunk)
         except ValueError:
-            Path(dest).unlink(missing_ok=True)
+            dest_path.unlink(missing_ok=True)
             raise
 
 

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -49,10 +49,7 @@ def _fetch_media(
     the Telegram 20MB getFile cap.
 
     """
-    # file_id is declared non-Optional by telebot's stubs but can be missing
-    # at runtime for partially-deserialized messages; check defensively.
-    file_id = getattr(media, "file_id", None)
-    if media is None or media.file_size is None or file_id is None:
+    if media is None or media.file_size is None:
         bot.reply_to(message, missing_msg)
         return None
     if media.file_size > TG_MAX_FILE_SIZE:

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -1,112 +1,92 @@
-import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
+from urllib.parse import urlsplit
 
-from config import bot
+from config import CASTRO_HOST, TG_MAX_FILE_SIZE, YT_HOSTS, bot
 from download import download_tg
 from services import get_file_with_retry, send_answer
 from summary import summarize, summarize_webpage, summarize_with_document
 from utils import clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
-    from telebot.types import Message
+    from telebot.types import Audio, Document, File, Message, Video, VideoNote, Voice
 
     from models import UsersOrm
+
+    _SizedMedia = Audio | Voice | Video | VideoNote | Document
+
+
+class SummaryKwargs(TypedDict):
+    """Shared summarize() kwargs sourced from a user record."""
+
+    model: str
+    prompt_key: str
+    target_language: str
+    user_id: int
+    daily_limit: int
+
+
+def _summary_kwargs(user: UsersOrm) -> SummaryKwargs:
+    """Build the recurring summarize() kwargs sourced from a user record."""
+    return {
+        "model": user.summarizing_model,
+        "prompt_key": user.prompt_key_for_summary,
+        "target_language": user.target_language,
+        "user_id": user.user_id,
+        "daily_limit": user.daily_limit,
+    }
+
+
+def _fetch_media(
+    message: Message,
+    media: _SizedMedia | None,
+    missing_msg: str,
+) -> File | None:
+    """Validate a Telegram media object and return its downloaded File handle.
+
+    Replies to the user and returns None when the media is missing or exceeds
+    the Telegram 20MB getFile cap.
+
+    """
+    # file_id is declared non-Optional by telebot's stubs but can be missing
+    # at runtime for partially-deserialized messages; check defensively.
+    file_id = getattr(media, "file_id", None)
+    if media is None or media.file_size is None or file_id is None:
+        bot.reply_to(message, missing_msg)
+        return None
+    if media.file_size >= TG_MAX_FILE_SIZE:
+        bot.reply_to(message, "File is too big.")
+        return None
+    return get_file_with_retry(media.file_id)
 
 
 def handle_audio(message: Message, user: UsersOrm) -> None:
     """Handle audio file processing."""
-    audio = message.audio
-    if audio is None or audio.file_size is None or audio.file_id is None:
-        bot.reply_to(message, "No audio file found.")
+    data = _fetch_media(message, message.audio, "No audio file found.")
+    if data is None:
         return
-    if audio.file_size >= 20971520:  # 20MB  # noqa: PLR2004
-        bot.reply_to(message, "File is too big.")
-        return
-
-    data = get_file_with_retry(
-        audio.file_id,
-    )  # Max 20MB https://core.telegram.org/bots/api#getfile
     answer = summarize(
         data=data,
         use_transcription=user.use_transcription,
-        model=user.summarizing_model,
-        prompt_key=user.prompt_key_for_summary,
-        target_language=user.target_language,
-        user_id=user.user_id,
-        daily_limit=user.daily_limit,
+        **_summary_kwargs(user),
     )
     send_answer(message, answer)
-
-
-def handle_video_note(message: Message, user: UsersOrm) -> None:
-    """Handle video note file processing."""
-    video_note = message.video_note
-    if video_note is None or video_note.file_size is None or video_note.file_id is None:
-        bot.reply_to(message, "No video note found.")
-        return
-    if video_note.file_size >= 20971520:  # 20MB  # noqa: PLR2004
-        bot.reply_to(message, "File is too big.")
-        return
-
-    data = get_file_with_retry(
-        video_note.file_id,
-    )  # Max 20MB https://core.telegram.org/bots/api#getfile
-    downloaded_file = download_tg(data, ext=".mp4")
-    compressed_file = generate_temporary_name(ext=".ogg")
-    try:
-        compress_audio(input_file=downloaded_file, output_file=compressed_file)
-        answer = summarize(
-            data=compressed_file,
-            use_transcription=user.use_transcription,
-            model=user.summarizing_model,
-            prompt_key=user.prompt_key_for_summary,
-            target_language=user.target_language,
-            user_id=user.user_id,
-            daily_limit=user.daily_limit,
-        )
-        send_answer(message, answer)
-    finally:
-        clean_up(file=downloaded_file)
 
 
 def handle_voice(message: Message, user: UsersOrm) -> None:
     """Handle voice file processing."""
-    voice = message.voice
-    if voice is None or voice.file_size is None or voice.file_id is None:
-        bot.reply_to(message, "No voice message found.")
+    data = _fetch_media(message, message.voice, "No voice message found.")
+    if data is None:
         return
-    if voice.file_size >= 20971520:  # 20MB  # noqa: PLR2004
-        bot.reply_to(message, "File is too big.")
-        return
-
-    data = get_file_with_retry(
-        voice.file_id,
-    )  # Max 20MB https://core.telegram.org/bots/api#getfile
     answer = summarize(
         data=data,
         use_transcription=user.use_transcription,
-        model=user.summarizing_model,
-        prompt_key=user.prompt_key_for_summary,
-        target_language=user.target_language,
-        user_id=user.user_id,
-        daily_limit=user.daily_limit,
+        **_summary_kwargs(user),
     )
     send_answer(message, answer)
 
 
-def handle_video(message: Message, user: UsersOrm) -> None:
-    """Handle video file processing."""
-    video = message.video
-    if video is None or video.file_size is None or video.file_id is None:
-        bot.reply_to(message, "No video file found.")
-        return
-    if video.file_size >= 20971520:  # 20MB  # noqa: PLR2004
-        bot.reply_to(message, "File is too big.")
-        return
-
-    data = get_file_with_retry(
-        video.file_id,
-    )  # Max 20MB https://core.telegram.org/bots/api#getfile
+def _handle_video_like(message: Message, user: UsersOrm, data: File) -> None:
+    """Shared video / video-note pipeline: download, compress, summarize."""
     downloaded_file = download_tg(data, ext=".mp4")
     compressed_file = generate_temporary_name(ext=".ogg")
     try:
@@ -114,72 +94,75 @@ def handle_video(message: Message, user: UsersOrm) -> None:
         answer = summarize(
             data=compressed_file,
             use_transcription=user.use_transcription,
-            model=user.summarizing_model,
-            prompt_key=user.prompt_key_for_summary,
-            target_language=user.target_language,
-            user_id=user.user_id,
-            daily_limit=user.daily_limit,
+            **_summary_kwargs(user),
         )
         send_answer(message, answer)
     finally:
         clean_up(file=downloaded_file)
+
+
+def handle_video_note(message: Message, user: UsersOrm) -> None:
+    """Handle video note file processing."""
+    data = _fetch_media(message, message.video_note, "No video note found.")
+    if data is None:
+        return
+    _handle_video_like(message, user, data)
+
+
+def handle_video(message: Message, user: UsersOrm) -> None:
+    """Handle video file processing."""
+    data = _fetch_media(message, message.video, "No video file found.")
+    if data is None:
+        return
+    _handle_video_like(message, user, data)
 
 
 def handle_document(message: Message, user: UsersOrm) -> None:
     """Handle document file processing."""
     document = message.document
-    if document is None or document.file_size is None or document.file_id is None:
-        bot.reply_to(message, "No document found.")
+    data = _fetch_media(message, document, "No document found.")
+    if data is None or document is None:
         return
-    if document.file_size >= 20971520:  # 20MB  # noqa: PLR2004
-        bot.reply_to(message, "File is too big.")
-        return
-
-    data = get_file_with_retry(
-        document.file_id,
-    )  # Max 20MB https://core.telegram.org/bots/api#getfile
     answer = summarize_with_document(
         file=data,
-        model=user.summarizing_model,
-        prompt_key=user.prompt_key_for_summary,
-        target_language=user.target_language,
         mime_type=document.mime_type or "application/octet-stream",
-        user_id=user.user_id,
-        daily_limit=user.daily_limit,
+        **_summary_kwargs(user),
     )
     send_answer(message, answer)
 
 
+def _classify_url(url: str) -> str | None:
+    """Return 'media' for https YT/Castro URLs, 'web' for any http(s) URL, else None."""
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        return None
+    host = parts.hostname
+    if host is None:
+        return None
+    if parts.scheme == "https" and host in YT_HOSTS:
+        return "media"
+    if (
+        parts.scheme == "https"
+        and host == CASTRO_HOST
+        and parts.path.startswith("/episode/")
+    ):
+        return "media"
+    return "web"
+
+
 def handle_url(message: Message, user: UsersOrm, url: str) -> None:
     """Handle URL processing."""
-    # YouTube/Castro pattern
-    yt_castro_pattern = (
-        r"^https:\/\/(www\.youtube\.com\/*|youtu\.be\/|castro\.fm\/episode\/)[\S]*"
-    )
-    # Other URLs pattern
-    other_url_pattern = r"^(?!https:\/\/(www\.youtube\.com\/|youtu\.be\/|castro\.fm\/episode\/)[\S]*)https?[\S]*"  # noqa: E501
-
-    if re.match(yt_castro_pattern, url):
+    kind = _classify_url(url)
+    if kind == "media":
         answer = summarize(
             data=url,
             use_transcription=user.use_transcription,
-            model=user.summarizing_model,
-            prompt_key=user.prompt_key_for_summary,
-            target_language=user.target_language,
-            user_id=user.user_id,
-            daily_limit=user.daily_limit,
             use_yt_transcription=user.use_yt_transcription,
+            **_summary_kwargs(user),
         )
         send_answer(message, answer)
-    elif re.match(other_url_pattern, url):
-        answer = summarize_webpage(
-            content=url,
-            model=user.summarizing_model,
-            prompt_key=user.prompt_key_for_summary,
-            target_language=user.target_language,
-            user_id=user.user_id,
-            daily_limit=user.daily_limit,
-        )
+    elif kind == "web":
+        answer = summarize_webpage(content=url, **_summary_kwargs(user))
         send_answer(message, answer)
     else:
         bot.send_message(message.chat.id, "No data to proceed.")

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, TypedDict
 from urllib.parse import urlsplit
 
@@ -53,7 +55,7 @@ def _fetch_media(
     if media is None or media.file_size is None or file_id is None:
         bot.reply_to(message, missing_msg)
         return None
-    if media.file_size >= TG_MAX_FILE_SIZE:
+    if media.file_size > TG_MAX_FILE_SIZE:
         bot.reply_to(message, "File is too big.")
         return None
     return get_file_with_retry(media.file_id)
@@ -99,6 +101,7 @@ def _handle_video_like(message: Message, user: UsersOrm, data: File) -> None:
         send_answer(message, answer)
     finally:
         clean_up(file=downloaded_file)
+        clean_up(file=compressed_file)
 
 
 def handle_video_note(message: Message, user: UsersOrm) -> None:

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -101,7 +101,6 @@ def _handle_video_like(message: Message, user: UsersOrm, data: File) -> None:
         send_answer(message, answer)
     finally:
         clean_up(file=downloaded_file)
-        clean_up(file=compressed_file)
 
 
 def handle_video_note(message: Message, user: UsersOrm) -> None:
@@ -139,8 +138,8 @@ def _classify_url(url: str) -> str | None:
     parts = urlsplit(url)
     if parts.scheme not in ("http", "https"):
         return None
-    host = parts.hostname
-    if host is None:
+    host = (parts.hostname or "").lower().removeprefix("www.")
+    if not host:
         return None
     if parts.scheme == "https" and host in YT_HOSTS:
         return "media"

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,10 @@ from tenacity import RetryError
 
 from config import (
     MODEL_LABELS,
+    MODEL_LABELS_REVERSE,
     PROMPT_STRATEGY_LABELS,
+    PROMPT_STRATEGY_LABELS_REVERSE,
+    SUPPORTED_DOCUMENT_MIME_TYPES,
     SUPPORTED_LANGUAGES,
     bot,
 )
@@ -39,6 +42,8 @@ from services import get_remaining_quota
 from utils import clean_up
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from telebot.types import Message
 
     from models import UsersOrm
@@ -249,6 +254,19 @@ def handle_toggle_yt_transcription(message: Message) -> None:
     )
 
 
+def _prompt_choice(
+    message: Message,
+    prompt: str,
+    labels: list[str],
+    next_step: Callable[[Message], None],
+) -> None:
+    """Send a one-time reply keyboard of `labels` and queue a next-step handler."""
+    markup = ReplyKeyboardMarkup(resize_keyboard=True, one_time_keyboard=True)
+    markup.add(*(KeyboardButton(label) for label in labels))
+    bot.send_message(message.chat.id, prompt, reply_markup=markup)
+    bot.register_next_step_handler(message, next_step)
+
+
 # /set_target_language
 @bot.message_handler(
     commands=["set_target_language"],
@@ -257,27 +275,13 @@ def handle_toggle_yt_transcription(message: Message) -> None:
     ),
 )
 def handle_set_target_language(message: Message) -> None:
-    """Handle the /set_target_language command for the bot.
-
-    This function presents the user with a keyboard of supported languages
-    to choose from. Once the user selects a language, the bot proceeds to
-    set the target language for the user. The function ensures that the user
-    is authenticated before allowing them to set a target language.
-
-    Args:
-        message (Message): The message object from Telegram containing user information
-                           and chat details.
-
-    Returns:
-        None
-
-    """
-    markup = ReplyKeyboardMarkup(resize_keyboard=True, one_time_keyboard=True)
-    languages = [KeyboardButton(lang.title()) for lang in SUPPORTED_LANGUAGES]
-    markup.add(*languages)
-
-    bot.send_message(message.chat.id, "Select target language 👇", reply_markup=markup)
-    bot.register_next_step_handler(message, proceed_set_target_language)
+    """Handle the /set_target_language command for the bot."""
+    _prompt_choice(
+        message,
+        "Select target language 👇",
+        [lang.title() for lang in SUPPORTED_LANGUAGES],
+        proceed_set_target_language,
+    )
 
 
 def proceed_set_target_language(message: Message) -> None:
@@ -322,31 +326,13 @@ def proceed_set_target_language(message: Message) -> None:
     ),
 )
 def handle_set_summarizing_model(message: Message) -> None:
-    """Handle the /set_summarizing_model command for the bot.
-
-    This function presents the user with a keyboard of allowed summarizing models
-    to choose from. Once the user selects a model, the bot proceeds to set the
-    summarizing model for the user. The function ensures that the user is
-    authenticated before allowing them to set a model.
-
-    Args:
-        message (Message): The message object from Telegram containing user information
-                          and chat details.
-
-    Returns:
-        None
-
-    """
-    markup = ReplyKeyboardMarkup(resize_keyboard=True, one_time_keyboard=True)
-    models = [KeyboardButton(label) for label in MODEL_LABELS.values()]
-    markup.add(*models)
-
-    bot.send_message(
-        message.chat.id,
+    """Handle the /set_summarizing_model command for the bot."""
+    _prompt_choice(
+        message,
         "Select summarizing model 👇",
-        reply_markup=markup,
+        list(MODEL_LABELS.values()),
+        proceed_set_summarizing_model,
     )
-    bot.register_next_step_handler(message, proceed_set_summarizing_model)
 
 
 def proceed_set_summarizing_model(message: Message) -> None:
@@ -367,8 +353,7 @@ def proceed_set_summarizing_model(message: Message) -> None:
     if message.from_user is None or message.text is None:
         bot.reply_to(message, "User information or model is missing.")
         return
-    label_to_model = {v: k for k, v in MODEL_LABELS.items()}
-    model_id = label_to_model.get(message.text)
+    model_id = MODEL_LABELS_REVERSE.get(message.text)
     if model_id is None:
         bot.send_message(message.chat.id, "Unknown model")
         return
@@ -391,31 +376,13 @@ def proceed_set_summarizing_model(message: Message) -> None:
     ),
 )
 def handle_set_prompt_strategy(message: Message) -> None:
-    """Handle the /set_prompt_strategy command for the bot.
-
-    This function presents the user with a keyboard of allowed prompt strategies
-    to choose from. Once the user selects a strategy, the bot proceeds to set the
-    prompt strategy for the user. The function ensures that the user is
-    authenticated before allowing them to set a strategy.
-
-    Args:
-        message (Message): The message object from Telegram containing user information
-                          and chat details.
-
-    Returns:
-        None
-
-    """
-    markup = ReplyKeyboardMarkup(resize_keyboard=True, one_time_keyboard=True)
-    strategies = [KeyboardButton(label) for label in PROMPT_STRATEGY_LABELS.values()]
-    markup.add(*strategies)
-
-    bot.send_message(
-        message.chat.id,
+    """Handle the /set_prompt_strategy command for the bot."""
+    _prompt_choice(
+        message,
         "Select summarization strategy 👇",
-        reply_markup=markup,
+        list(PROMPT_STRATEGY_LABELS.values()),
+        proceed_set_prompt_strategy,
     )
-    bot.register_next_step_handler(message, proceed_set_prompt_strategy)
 
 
 def proceed_set_prompt_strategy(message: Message) -> None:
@@ -436,8 +403,7 @@ def proceed_set_prompt_strategy(message: Message) -> None:
     if message.from_user is None or message.text is None:
         bot.reply_to(message, "User information or strategy is missing.")
         return
-    label_to_key = {v: k for k, v in PROMPT_STRATEGY_LABELS.items()}
-    prompt_key = label_to_key.get(message.text)
+    prompt_key = PROMPT_STRATEGY_LABELS_REVERSE.get(message.text)
     if prompt_key is None:
         bot.send_message(message.chat.id, "Unknown strategy")
         return
@@ -468,14 +434,7 @@ def process_message_content(message: Message, user: UsersOrm) -> None:
     elif (
         message.content_type == "document"
         and message.document is not None
-        and message.document.mime_type
-        in (
-            "application/pdf",
-            "text/plain",
-            "text/rtf",
-            "text/csv",
-            "audio/ogg",
-        )
+        and message.document.mime_type in SUPPORTED_DOCUMENT_MIME_TYPES
     ):
         handle_document(message, user)
     elif message.content_type == "video_note":

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from textwrap import dedent
 from typing import TYPE_CHECKING

--- a/src/services.py
+++ b/src/services.py
@@ -78,7 +78,7 @@ def choose_yt_audio_format(info: dict[str, Any]) -> str:
     before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
     reraise=True,
 )
-def reply_with_retry(
+def _reply_with_retry(
     message: Message,
     text: str,
     entities: list[dict[str, object]] | None = None,
@@ -151,7 +151,7 @@ def send_answer(message: Message, answer: str) -> None:
     while current is not None:
         chunk_text, chunk_entities = current
         serialized_entities = [entity.to_dict() for entity in chunk_entities]
-        reply_with_retry(message, chunk_text, entities=serialized_entities)
+        _reply_with_retry(message, chunk_text, entities=serialized_entities)
         next_chunk = next(chunks_iter, None)
         if next_chunk is not None:
             time.sleep(1)
@@ -241,20 +241,24 @@ def get_gemini_config(
     )
 
 
+_EXT_MIME_FALLBACK = {
+    ".ogg": "audio/ogg",
+    ".opus": "audio/ogg",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".mp4": "video/mp4",
+}
+
+
 def resolve_mime_type(file: str) -> str:
     """Resolve the MIME type for a file path, with fallbacks."""
     mime_type = mimetypes.guess_type(file)[0]
-    if mime_type is None:
-        if file.endswith((".ogg", ".opus")):
-            return "audio/ogg"
-        if file.endswith(".mp3"):
-            return "audio/mpeg"
-        if file.endswith(".wav"):
-            return "audio/wav"
-        if file.endswith(".mp4"):
-            return "video/mp4"
-        return "application/octet-stream"
-    return mime_type
+    if mime_type is not None:
+        return mime_type
+    for ext, mt in _EXT_MIME_FALLBACK.items():
+        if file.endswith(ext):
+            return mt
+    return "application/octet-stream"
 
 
 def format_prefixed_summary(prefix: str, summary: str) -> str:
@@ -262,21 +266,21 @@ def format_prefixed_summary(prefix: str, summary: str) -> str:
     return f"{prefix}\n\n{summary.strip()}"
 
 
-def upload_and_wait_for_audio_file(
+def upload_and_wait_for_file(
     file: str,
     mime_type: str,
     sleep_time: int,
 ) -> types.File:
     """Upload a file to Gemini and wait for processing to finish."""
-    audio_file = gemini_client.files.upload(file=file, config={"mime_type": mime_type})
-    if audio_file.name is None:
+    uploaded = gemini_client.files.upload(file=file, config={"mime_type": mime_type})
+    if uploaded.name is None:
         raise AttributeError
-    audio_file_name = audio_file.name
-    while audio_file.state == "PROCESSING":
+    file_name = uploaded.name
+    while uploaded.state == "PROCESSING":
         time.sleep(sleep_time)
-        audio_file = gemini_client.files.get(name=audio_file_name)
-    if audio_file.state == "FAILED":
-        raise ValueError(audio_file.state)
-    if audio_file.uri is None or audio_file.mime_type is None:
+        uploaded = gemini_client.files.get(name=file_name)
+    if uploaded.state == "FAILED":
+        raise ValueError(uploaded.state)
+    if uploaded.uri is None or uploaded.mime_type is None:
         raise AttributeError
-    return audio_file
+    return uploaded

--- a/src/services.py
+++ b/src/services.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import math
 import mimetypes

--- a/src/summary.py
+++ b/src/summary.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from textwrap import dedent
 from typing import TYPE_CHECKING, cast
@@ -416,7 +418,12 @@ def summarize(
             if use_yt_transcription:
                 try:
                     transcript = get_yt_transcript(data)
-                except (TranscriptsDisabled, RetryError, DownloadError) as e:
+                except (
+                    TranscriptsDisabled,
+                    RetryError,
+                    DownloadError,
+                    ValueError,
+                ) as e:
                     logger.warning(
                         "get_yt_transcript failed, falling back to download: %s",
                         e,

--- a/src/summary.py
+++ b/src/summary.py
@@ -324,8 +324,6 @@ def summarize_with_document(
             sleep_time=sleep_time,
         )
         document_file_name = document_file.name
-        if document_file.uri is None or document_file.mime_type is None:
-            raise AttributeError
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
         response = gemini_client.models.generate_content(
             model=model,
@@ -335,8 +333,8 @@ def summarize_with_document(
                     parts=[
                         types.Part.from_text(text=prompt),
                         types.Part.from_uri(
-                            file_uri=document_file.uri,
-                            mime_type=document_file.mime_type,
+                            file_uri=cast("str", document_file.uri),
+                            mime_type=cast("str", document_file.mime_type),
                         ),
                     ],
                 ),

--- a/src/summary.py
+++ b/src/summary.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from textwrap import dedent
 from typing import TYPE_CHECKING, cast
 
@@ -27,7 +26,7 @@ from services import (
     format_prefixed_summary,
     get_gemini_config,
     resolve_mime_type,
-    upload_and_wait_for_audio_file,
+    upload_and_wait_for_file,
 )
 from transcription import get_yt_transcript, transcribe
 from utils import clean_up, compress_audio, generate_temporary_name
@@ -89,7 +88,7 @@ def summarize_with_file(
     check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
     prompt = dedent(PROMPTS[prompt_key]).strip()
     mime_type = resolve_mime_type(file)
-    audio_file = upload_and_wait_for_audio_file(
+    audio_file = upload_and_wait_for_file(
         file=file,
         mime_type=mime_type,
         sleep_time=sleep_time,
@@ -128,6 +127,32 @@ def summarize_with_file(
                     audio_file_name,
                     e,
                 )
+
+
+def _generate_text(
+    prompt: str,
+    model: str,
+    target_language: str,
+    *,
+    extra_system_instruction: str | None = None,
+    tools: list[types.Tool] | None = None,
+) -> str:
+    """Run a single Gemini text-prompt generation with the standard config."""
+    config = get_gemini_config(
+        target_language,
+        model=model,
+        extra_system_instruction=extra_system_instruction,
+    )
+    if tools is not None:
+        config = config.model_copy(update={"tools": tools})
+    response = gemini_client.models.generate_content(
+        model=model,
+        contents=prompt,
+        config=config,
+    )
+    if response.text is None:
+        raise AttributeError
+    return response.text
 
 
 @retry(
@@ -174,14 +199,7 @@ def summarize_with_transcript(
     """
     prompt = (f"{dedent(PROMPTS[prompt_key])} {transcript}").strip()
     check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-    response = gemini_client.models.generate_content(
-        model=model,
-        contents=prompt,
-        config=get_gemini_config(target_language, model=model),
-    )
-    if response.text is None:
-        raise AttributeError
-    return response.text
+    return _generate_text(prompt, model, target_language)
 
 
 @retry(
@@ -228,27 +246,18 @@ def summarize_webpage(
     """
     prompt = (f"{dedent(PROMPTS[prompt_key])} {content}").strip()
     check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-    response = gemini_client.models.generate_content(
-        model=model,
-        contents=prompt,
-        config=get_gemini_config(
-            target_language,
-            model=model,
-            extra_system_instruction=(
-                "MANDATORY TOOL USAGE: You MUST always use the `UrlContext` "
-                "tool to fetch and read the information from the provided "
-                "link before generating your summary. Do not attempt to "
-                "summarize the content without calling this tool first."
-            ),
-        ).model_copy(
-            update={
-                "tools": [types.Tool(url_context=types.UrlContext())],
-            },
+    return _generate_text(
+        prompt,
+        model,
+        target_language,
+        extra_system_instruction=(
+            "MANDATORY TOOL USAGE: You MUST always use the `UrlContext` "
+            "tool to fetch and read the information from the provided "
+            "link before generating your summary. Do not attempt to "
+            "summarize the content without calling this tool first."
         ),
+        tools=[types.Tool(url_context=types.UrlContext())],
     )
-    if response.text is None:
-        raise AttributeError
-    return response.text
 
 
 @retry(
@@ -307,21 +316,13 @@ def summarize_with_document(
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
         data = download_tg(file)
         prompt = dedent(PROMPTS[prompt_key]).strip()
-        document_file = gemini_client.files.upload(
+        document_file = upload_and_wait_for_file(
             file=data,
-            config={"mime_type": mime_type},
+            mime_type=mime_type,
+            sleep_time=sleep_time,
         )
-        if document_file.name is None:
-            raise AttributeError
         document_file_name = document_file.name
-        while document_file.state == "PROCESSING":
-            time.sleep(sleep_time)
-            document_file = gemini_client.files.get(name=document_file_name)
-        if document_file.state == "FAILED":
-            raise ValueError(document_file.state)
-        if document_file.uri is None:
-            raise AttributeError
-        if document_file.mime_type is None:
+        if document_file.uri is None or document_file.mime_type is None:
             raise AttributeError
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
         response = gemini_client.models.generate_content(

--- a/src/summary.py
+++ b/src/summary.py
@@ -97,7 +97,7 @@ def summarize_with_file(
     )
     audio_file_name = audio_file.name
     try:
-        if audio_file.name is None or audio_file.uri is None:
+        if audio_file.uri is None or audio_file.mime_type is None:
             raise AttributeError
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
         response = gemini_client.models.generate_content(

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 from pathlib import Path

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -27,7 +27,12 @@ from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
 from config import PROXY, replicate_client
-from utils import clean_up, generate_temporary_name, vtt_to_text
+from utils import (
+    clean_up,
+    extract_youtube_video_id,
+    generate_temporary_name,
+    vtt_to_text,
+)
 
 if TYPE_CHECKING:
     from tenacity import (
@@ -61,7 +66,7 @@ def transcribe(file: str, sleep_time: int = 10) -> str:
 
     """
     model = replicate_client.models.get("victor-upmeet/whisperx")
-    version = model.versions.get(model.versions.list()[0].id)
+    version = model.versions.list()[0]
     with Path(file).open("rb") as audio:
         prediction = replicate_client.predictions.create(
             version=version,
@@ -212,15 +217,8 @@ def get_yt_transcript(url: str) -> str:
         RetryError: If proxy/SSL/network errors persist after all retry attempts.
 
     """
-    if url.startswith("https://www.youtube.com/watch"):
-        video_id = url.replace("https://www.youtube.com/watch?v=", "").split("?")[0]
-    elif url.startswith("https://youtube.com/watch"):
-        video_id = url.replace("https://youtube.com/watch?v=", "").split("?")[0]
-    elif url.startswith("https://youtu.be/"):
-        video_id = url.replace("https://youtu.be/", "").split("?")[0]
-    elif url.startswith("https://www.youtube.com/live/"):
-        video_id = url.replace("https://www.youtube.com/live/", "").split("?")[0]
-    else:
+    video_id = extract_youtube_video_id(url)
+    if video_id is None:
         msg = "Unknown URL"
         raise ValueError(msg)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,32 @@
 import re
 import subprocess
 from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
 from uuid import uuid4
 
-from config import PROTECTED_FILES
+from config import PROTECTED_FILES, YT_HOSTS
+
+
+def extract_youtube_video_id(url: str) -> str | None:
+    """Extract the 11-char video id from any supported YouTube URL form.
+
+    Returns None when the host is not a known YouTube host or the id cannot
+    be located in the path/query.
+
+    """
+    parts = urlsplit(url)
+    if parts.hostname not in YT_HOSTS:
+        return None
+    if parts.hostname == "youtu.be":
+        video_id = parts.path.lstrip("/").split("/", 1)[0]
+        return video_id or None
+    path_parts = [p for p in parts.path.split("/") if p]
+    prefixed_paths = ("live", "shorts", "embed")
+    if len(path_parts) >= 2 and path_parts[0] in prefixed_paths:  # noqa: PLR2004
+        return path_parts[1]
+    if path_parts and path_parts[0] == "watch":
+        return parse_qs(parts.query).get("v", [None])[0]
+    return None
 
 
 def generate_temporary_name(ext: str = "") -> str:

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,6 +10,7 @@ _YT_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
 
 
 def _valid_yt_id(candidate: str | None) -> str | None:
+    """Return candidate if it is a well-formed 11-char YouTube video ID, else None."""
     if candidate is None:
         return None
     return candidate if _YT_ID_RE.fullmatch(candidate) else None

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,6 +6,14 @@ from uuid import uuid4
 
 from config import PROTECTED_FILES, YT_HOSTS
 
+_YT_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
+
+
+def _valid_yt_id(candidate: str | None) -> str | None:
+    if candidate is None:
+        return None
+    return candidate if _YT_ID_RE.fullmatch(candidate) else None
+
 
 def extract_youtube_video_id(url: str) -> str | None:
     """Extract the 11-char video id from any supported YouTube URL form.
@@ -15,17 +23,19 @@ def extract_youtube_video_id(url: str) -> str | None:
 
     """
     parts = urlsplit(url)
-    if parts.hostname not in YT_HOSTS:
+    hostname = (parts.hostname or "").lower()
+    hostname = hostname.removeprefix("www.")
+    if hostname not in YT_HOSTS:
         return None
-    if parts.hostname == "youtu.be":
+    if hostname == "youtu.be":
         video_id = parts.path.lstrip("/").split("/", 1)[0]
-        return video_id or None
+        return _valid_yt_id(video_id or None)
     path_parts = [p for p in parts.path.split("/") if p]
     prefixed_paths = ("live", "shorts", "embed")
     if len(path_parts) >= 2 and path_parts[0] in prefixed_paths:  # noqa: PLR2004
-        return path_parts[1]
+        return _valid_yt_id(path_parts[1])
     if path_parts and path_parts[0] == "watch":
-        return parse_qs(parts.query).get("v", [None])[0]
+        return _valid_yt_id(parse_qs(parts.query).get("v", [None])[0])
     return None
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,18 +6,9 @@ from uuid import uuid4
 
 from config import PROTECTED_FILES, YT_HOSTS
 
-_YT_ID_RE = re.compile(r"[A-Za-z0-9_-]{11}")
-
-
-def _valid_yt_id(candidate: str | None) -> str | None:
-    """Return candidate if it is a well-formed 11-char YouTube video ID, else None."""
-    if candidate is None:
-        return None
-    return candidate if _YT_ID_RE.fullmatch(candidate) else None
-
 
 def extract_youtube_video_id(url: str) -> str | None:
-    """Extract the 11-char video id from any supported YouTube URL form.
+    """Extract the video id from any supported YouTube URL form.
 
     Returns None when the host is not a known YouTube host or the id cannot
     be located in the path/query.
@@ -30,13 +21,13 @@ def extract_youtube_video_id(url: str) -> str | None:
         return None
     if hostname == "youtu.be":
         video_id = parts.path.lstrip("/").split("/", 1)[0]
-        return _valid_yt_id(video_id or None)
+        return video_id or None
     path_parts = [p for p in parts.path.split("/") if p]
     prefixed_paths = ("live", "shorts", "embed")
     if len(path_parts) >= 2 and path_parts[0] in prefixed_paths:  # noqa: PLR2004
-        return _valid_yt_id(path_parts[1])
+        return path_parts[1]
     if path_parts and path_parts[0] == "watch":
-        return _valid_yt_id(parse_qs(parts.query).get("v", [None])[0])
+        return parse_qs(parts.query).get("v", [None])[0]
     return None
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import requests
 
@@ -272,3 +274,53 @@ def test_download_tg_http_error(mocker):
         download_tg(mock_file, ext=".ext")
 
     mock_logger.exception.assert_called_once_with("%s: status code", 403)
+
+
+def test_stream_to_file_content_length_exceeded(mocker, tmp_path):
+    """_stream_to_file raises ValueError and no file is created when Content-Length exceeds max_size."""
+    from download import _stream_to_file
+
+    dest = str(tmp_path / "out.bin")
+    mock_resp = mocker.MagicMock()
+    mock_resp.headers = {"Content-Length": "100"}
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.__enter__.return_value = mock_resp
+    mocker.patch("download.requests.get", return_value=mock_resp)
+
+    with pytest.raises(ValueError, match="Content-Length"):
+        _stream_to_file("https://example.com/file", dest, max_size=50)
+
+    assert not Path(dest).exists()
+
+
+def test_stream_to_file_mid_stream_exceeded_cleans_up(mocker, tmp_path):
+    """_stream_to_file raises ValueError and removes the partial file when streaming exceeds max_size."""
+    from download import _stream_to_file
+
+    dest = str(tmp_path / "out.bin")
+    mock_resp = mocker.MagicMock()
+    mock_resp.headers = {}
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.iter_content.return_value = [b"A" * 30, b"B" * 30]
+    mock_resp.__enter__.return_value = mock_resp
+    mocker.patch("download.requests.get", return_value=mock_resp)
+
+    with pytest.raises(ValueError, match="exceeded"):
+        _stream_to_file("https://example.com/file", dest, max_size=50)
+
+    assert not Path(dest).exists()
+
+
+def test_classify_url_uppercase_youtube_host(mocker):
+    """_classify_url normalises uppercase YouTube hostnames to 'media'."""
+    from handlers import _classify_url
+
+    assert _classify_url("https://YOUTU.BE/dQw4w9WgXcQ") == "media"
+    assert _classify_url("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "media"
+
+
+def test_classify_url_malformed_no_host():
+    """_classify_url returns None for URLs with no parseable hostname."""
+    from handlers import _classify_url
+
+    assert _classify_url("https://") is None

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -237,7 +237,9 @@ def test_handle_video_happy_path_cleans_up_download(message_factory, mocker):
 
     handle_message(msg)
 
-    mock_clean_up.assert_called_once_with(file="downloaded.mp4")
+    mock_clean_up.assert_any_call(file="downloaded.mp4")
+    mock_clean_up.assert_any_call(file="compressed.ogg")
+    assert mock_clean_up.call_count == 2
 
 
 def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker):
@@ -264,7 +266,9 @@ def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker
 
     handle_message(msg)
 
-    mock_clean_up.assert_called_once_with(file="downloaded.mp4")
+    mock_clean_up.assert_any_call(file="downloaded.mp4")
+    mock_clean_up.assert_any_call(file="compressed.ogg")
+    assert mock_clean_up.call_count == 2
 
 
 def test_handle_message_limit_exceeded(message_factory, mocker):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -237,9 +237,7 @@ def test_handle_video_happy_path_cleans_up_download(message_factory, mocker):
 
     handle_message(msg)
 
-    mock_clean_up.assert_any_call(file="downloaded.mp4")
-    mock_clean_up.assert_any_call(file="compressed.ogg")
-    assert mock_clean_up.call_count == 2
+    mock_clean_up.assert_called_once_with(file="downloaded.mp4")
 
 
 def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker):
@@ -266,9 +264,7 @@ def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker
 
     handle_message(msg)
 
-    mock_clean_up.assert_any_call(file="downloaded.mp4")
-    mock_clean_up.assert_any_call(file="compressed.ogg")
-    assert mock_clean_up.call_count == 2
+    mock_clean_up.assert_called_once_with(file="downloaded.mp4")
 
 
 def test_handle_message_limit_exceeded(message_factory, mocker):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -99,17 +99,40 @@ def test_handle_audio_file_too_large(message_factory, mocker):
     mock_summarize.assert_not_called()
 
 
-def test_handle_document_missing_file_info(message_factory, mocker):
-    """Test that documents missing required file info are rejected."""
+def test_handle_audio_happy_path(message_factory, mocker):
+    """Test successful audio file processing."""
+    msg = message_factory(content_type="audio")
+    mocker.patch(
+        "main.select_user",
+        return_value=mocker.MagicMock(
+            approved=True,
+            use_transcription=False,
+            summarizing_model="model",
+            prompt_key_for_summary="prompt",
+            target_language="English",
+        ),
+    )
+    mock_file = mocker.MagicMock(spec=types.File)
+    mocker.patch("handlers.get_file_with_retry", return_value=mock_file)
+    mock_summarize = mocker.patch("handlers.summarize")
+    mocker.patch("handlers.send_answer")
+
+    handle_message(msg)
+
+    assert mock_summarize.call_args.kwargs["data"] == mock_file
+
+
+def test_handle_document_missing_file_size(message_factory, mocker):
+    """Test that a document with no file_size is rejected."""
     msg = message_factory(content_type="document")
-    msg.document.file_id = None
+    msg.document.file_size = None
     mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_reply_to = mocker.patch("main.bot.reply_to")
+    mock_bot_handlers = mocker.patch("handlers.bot")
     mock_summarize_with_document = mocker.patch("handlers.summarize_with_document")
 
     handle_message(msg)
 
-    mock_reply_to.assert_called_once_with(msg, "No document found.")
+    mock_bot_handlers.reply_to.assert_called_once_with(msg, "No document found.")
     mock_summarize_with_document.assert_not_called()
 
 
@@ -265,6 +288,30 @@ def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker
     handle_message(msg)
 
     mock_clean_up.assert_called_once_with(file="downloaded.mp4")
+
+
+def test_handle_video_note_file_too_large(message_factory, mocker):
+    """Test video note rejection when file exceeds 20MB limit."""
+    msg = message_factory(content_type="video_note")
+    msg.video_note.file_size = 21 * 1024 * 1024
+    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
+    mock_bot_handlers = mocker.patch("handlers.bot")
+
+    handle_message(msg)
+
+    mock_bot_handlers.reply_to.assert_called_once_with(msg, "File is too big.")
+
+
+def test_handle_video_file_too_large(message_factory, mocker):
+    """Test video rejection when file exceeds 20MB limit."""
+    msg = message_factory(content_type="video")
+    msg.video.file_size = 21 * 1024 * 1024
+    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
+    mock_bot_handlers = mocker.patch("handlers.bot")
+
+    handle_message(msg)
+
+    mock_bot_handlers.reply_to.assert_called_once_with(msg, "File is too big.")
 
 
 def test_handle_message_limit_exceeded(message_factory, mocker):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -135,7 +135,7 @@ def test_upload_and_wait_for_file_happy(mocker):
 def test_upload_and_wait_for_file_polling(mocker):
     """Test uploading file to Gemini with polling (PROCESSING -> ACTIVE)."""
     mock_client = mocker.patch("services.gemini_client")
-    mocker.patch("services.time.sleep")
+    mock_sleep = mocker.patch("services.time.sleep")
 
     mock_file_proc = mocker.MagicMock()
     mock_file_proc.name = "name"
@@ -153,6 +153,7 @@ def test_upload_and_wait_for_file_polling(mocker):
     result = upload_and_wait_for_file("path", "audio/ogg", 1)
 
     assert result == mock_file_active
+    mock_sleep.assert_called_once_with(1)
     mock_client.files.get.assert_called_once_with(name="name")
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,30 +8,30 @@ from services import (
     get_file_with_retry,
     get_gemini_config,
     get_remaining_quota,
-    reply_with_retry,
+    _reply_with_retry,
     resolve_mime_type,
     send_answer,
-    upload_and_wait_for_audio_file,
+    upload_and_wait_for_file,
 )
 
 
-def test_reply_with_retry_happy_path(mocker):
-    """Test reply_with_retry sends message successfully."""
+def test__reply_with_retry_happy_path(mocker):
+    """Test _reply_with_retry sends message successfully."""
     mock_bot = mocker.patch("services.bot")
     mock_msg = mocker.MagicMock()
 
-    reply_with_retry(mock_msg, "hello")
+    _reply_with_retry(mock_msg, "hello")
 
     mock_bot.reply_to.assert_called_once_with(mock_msg, "hello")
 
 
-def test_reply_with_retry_with_entities(mocker):
-    """Test reply_with_retry sends message with entities."""
+def test__reply_with_retry_with_entities(mocker):
+    """Test _reply_with_retry sends message with entities."""
     mock_bot = mocker.patch("services.bot")
     mock_msg = mocker.MagicMock()
     entities = [{"type": "bold"}]
 
-    reply_with_retry(mock_msg, "hello", entities=entities)
+    _reply_with_retry(mock_msg, "hello", entities=entities)
 
     mock_bot.reply_to.assert_called_once_with(mock_msg, "hello", entities=entities)
 
@@ -57,7 +57,7 @@ def test_send_answer_single_chunk(mocker):
         "services.split_entities", return_value=[("text", [mock_entity])]
     )
 
-    mock_reply = mocker.patch("services.reply_with_retry")
+    mock_reply = mocker.patch("services._reply_with_retry")
     mock_msg = mocker.MagicMock()
 
     send_answer(mock_msg, "short answer")
@@ -71,7 +71,7 @@ def test_send_answer_multi_chunk(mocker):
     """Test send_answer with a long message (multiple chunks)."""
     mocker.patch("services.convert", return_value=("text", []))
     mocker.patch("services.split_entities", return_value=[("part1", []), ("part2", [])])
-    mock_reply = mocker.patch("services.reply_with_retry")
+    mock_reply = mocker.patch("services._reply_with_retry")
     mocker.patch("services.time.sleep")
 
     mock_msg = mocker.MagicMock()
@@ -115,7 +115,7 @@ def test_get_gemini_config_thinking_disabled_when_no_model_given():
     assert config.thinking_config is None
 
 
-def test_upload_and_wait_for_audio_file_happy(mocker):
+def test_upload_and_wait_for_file_happy(mocker):
     """Test uploading file to Gemini when it's immediately ACTIVE."""
     mock_client = mocker.patch("services.gemini_client")
     mock_file = mocker.MagicMock()
@@ -126,13 +126,13 @@ def test_upload_and_wait_for_audio_file_happy(mocker):
 
     mock_client.files.upload.return_value = mock_file
 
-    result = upload_and_wait_for_audio_file("path", "audio/ogg", 1)
+    result = upload_and_wait_for_file("path", "audio/ogg", 1)
 
     assert result == mock_file
     mock_client.files.upload.assert_called_once()
 
 
-def test_upload_and_wait_for_audio_file_polling(mocker):
+def test_upload_and_wait_for_file_polling(mocker):
     """Test uploading file to Gemini with polling (PROCESSING -> ACTIVE)."""
     mock_client = mocker.patch("services.gemini_client")
     mocker.patch("services.time.sleep")
@@ -150,14 +150,14 @@ def test_upload_and_wait_for_audio_file_polling(mocker):
     mock_client.files.upload.return_value = mock_file_proc
     mock_client.files.get.return_value = mock_file_active
 
-    result = upload_and_wait_for_audio_file("path", "audio/ogg", 1)
+    result = upload_and_wait_for_file("path", "audio/ogg", 1)
 
     assert result == mock_file_active
     mock_client.files.get.assert_called_once_with(name="name")
 
 
-def test_upload_and_wait_for_audio_file_failed(mocker):
-    """Test upload_and_wait_for_audio_file raises ValueError on FAILED state."""
+def test_upload_and_wait_for_file_failed(mocker):
+    """Test upload_and_wait_for_file raises ValueError on FAILED state."""
     mock_client = mocker.patch("services.gemini_client")
     mock_file = mocker.MagicMock()
     mock_file.name = "name"
@@ -165,7 +165,7 @@ def test_upload_and_wait_for_audio_file_failed(mocker):
     mock_client.files.upload.return_value = mock_file
 
     with pytest.raises(ValueError, match="FAILED"):
-        upload_and_wait_for_audio_file("path", "audio/ogg", 1)
+        upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
 def test_resolve_mime_type_fallback_when_mimetypes_returns_none(mocker):
@@ -180,19 +180,19 @@ def test_resolve_mime_type_fallback_when_mimetypes_returns_none(mocker):
     assert resolve_mime_type("unknown.bin") == "application/octet-stream"
 
 
-def test_upload_and_wait_for_audio_file_name_none(mocker):
-    """upload_and_wait_for_audio_file raises AttributeError when upload returns no name."""
+def test_upload_and_wait_for_file_name_none(mocker):
+    """upload_and_wait_for_file raises AttributeError when upload returns no name."""
     mock_client = mocker.patch("services.gemini_client")
     mock_file = mocker.MagicMock()
     mock_file.name = None
     mock_client.files.upload.return_value = mock_file
 
     with pytest.raises(AttributeError):
-        upload_and_wait_for_audio_file("path", "audio/ogg", 1)
+        upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
-def test_upload_and_wait_for_audio_file_missing_uri(mocker):
-    """upload_and_wait_for_audio_file raises AttributeError when uri or mime_type is None."""
+def test_upload_and_wait_for_file_missing_uri(mocker):
+    """upload_and_wait_for_file raises AttributeError when uri or mime_type is None."""
     mock_client = mocker.patch("services.gemini_client")
     mock_file = mocker.MagicMock()
     mock_file.name = "name"
@@ -201,7 +201,7 @@ def test_upload_and_wait_for_audio_file_missing_uri(mocker):
     mock_client.files.upload.return_value = mock_file
 
     with pytest.raises(AttributeError):
-        upload_and_wait_for_audio_file("path", "audio/ogg", 1)
+        upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
 def test_get_remaining_quota(mocker):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -260,6 +260,31 @@ def test_summarize_with_document_cleans_up_on_failed_processing(mocker):
     mock_clean_up.assert_called_once_with(file="temp_doc.pdf")
 
 
+def test_summarize_youtube_skips_transcript_when_disabled(mocker):
+    """Test summarize() downloads YouTube directly when use_yt_transcription=False."""
+    url = "https://youtube.com/watch?v=123"
+    mocker.patch("summary.check_quota", return_value=True)
+    mock_get_transcript = mocker.patch("summary.get_yt_transcript")
+    mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
+    mocker.patch("summary.summarize_with_file", return_value="File summary")
+    mocker.patch("summary.clean_up")
+
+    result = summarize(
+        data=url,
+        use_transcription=False,
+        model="test-model",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        user_id=123,
+        daily_limit=10,
+        use_yt_transcription=False,
+    )
+
+    assert result == "File summary"
+    mock_get_transcript.assert_not_called()
+    mock_download.assert_called_once_with(url)
+
+
 def test_summarize_youtube_direct_transcript(mocker):
     """Test summarize() using direct YouTube transcript (📹 prefix)."""
     url = "https://youtube.com/watch?v=123"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -398,6 +398,36 @@ def test_summarize_youtube_transcript_retry_error_falls_back_to_download(mocker)
     )
 
 
+def test_summarize_youtube_transcript_value_error_falls_back_to_download(mocker):
+    """Test summarize() falls back to downloading YouTube audio when get_yt_transcript raises ValueError."""
+    url = "https://youtube.com/watch?v=123"
+    mocker.patch("summary.check_quota", return_value=True)
+    mocker.patch("summary.get_yt_transcript", side_effect=ValueError("no transcript"))
+    mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
+    mocker.patch("summary.summarize_with_file", return_value="File summary")
+    mock_clean_up = mocker.patch("summary.clean_up")
+    mock_logger = mocker.patch("summary.logger")
+
+    result = summarize(
+        data=url,
+        use_transcription=True,
+        model="test-model",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        user_id=123,
+        daily_limit=10,
+        use_yt_transcription=True,
+    )
+
+    assert result == "File summary"
+    mock_download.assert_called_once_with(url)
+    mock_clean_up.assert_called_once_with(file="downloaded.ogg")
+    mock_logger.warning.assert_called_once_with(
+        "get_yt_transcript failed, falling back to download: %s",
+        mocker.ANY,
+    )
+
+
 def test_summarize_fallback_to_transcription(mocker):
     """Test summarize() fallback to transcription (📝 prefix) when file summary fails."""
     mocker.patch("summary.check_quota", return_value=True)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -68,7 +68,7 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
         uri="https://mock.uri",
         mime_type="audio/ogg",
     )
-    mocker.patch("summary.upload_and_wait_for_audio_file", return_value=mock_audio_file)
+    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mock_client = mocker.patch("summary.gemini_client")
     mocker.patch("services.gemini_client", mock_client)
     mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
@@ -89,7 +89,7 @@ def test_summarize_with_file_retries_on_missing_upload_metadata(mocker):
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("tenacity.nap.time.sleep")
     mock_audio_file = SimpleNamespace(name=None, uri=None, mime_type="audio/ogg")
-    mocker.patch("summary.upload_and_wait_for_audio_file", return_value=mock_audio_file)
+    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
 
     with pytest.raises(RetryError):
         summarize_with_file(
@@ -203,8 +203,9 @@ def test_summarize_with_document_polling(mocker):
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
     mocker.patch("summary.clean_up")
-    mocker.patch("summary.time.sleep")
+    mocker.patch("services.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
+    mocker.patch("services.gemini_client", mock_client)
     mock_file_proc = SimpleNamespace(state="PROCESSING", name="files/doc123")
     mock_file_active = SimpleNamespace(
         state="ACTIVE",
@@ -237,9 +238,11 @@ def test_summarize_with_document_cleans_up_on_failed_processing(mocker):
     """Test summarize_with_document cleans up the downloaded file on failure."""
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("tenacity.nap.time.sleep")
+    mocker.patch("services.time.sleep")
     mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
     mock_clean_up = mocker.patch("summary.clean_up")
     mock_client = mocker.patch("summary.gemini_client")
+    mocker.patch("services.gemini_client", mock_client)
     mock_failed_file = SimpleNamespace(state="FAILED", name="files/doc123")
     mock_client.files.upload.return_value = mock_failed_file
 
@@ -507,7 +510,7 @@ def test_summarize_with_file_deletes_gemini_file_when_quota_check_fails(mocker):
         uri="https://mock.uri",
         mime_type="audio/ogg",
     )
-    mocker.patch("summary.upload_and_wait_for_audio_file", return_value=mock_audio_file)
+    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
     mock_check = mocker.patch("summary.check_quota", side_effect=[True, LimitExceededError])
@@ -558,7 +561,7 @@ def test_summarize_with_file_logs_warning_on_delete_failure(mocker):
         uri="https://mock.uri",
         mime_type="audio/ogg",
     )
-    mocker.patch("summary.upload_and_wait_for_audio_file", return_value=mock_audio_file)
+    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mock_client = mocker.patch("summary.gemini_client")
     mock_client.models.generate_content.return_value = mocker.MagicMock(text="summary text")
     mock_client.files.delete.side_effect = Exception("delete failed")
@@ -620,7 +623,9 @@ def test_summarize_with_document_raises_when_upload_name_none(mocker):
     mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
     mocker.patch("summary.clean_up")
     mocker.patch("tenacity.nap.time.sleep")
+    mocker.patch("services.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
+    mocker.patch("services.gemini_client", mock_client)
     mock_file = mocker.MagicMock()
     mock_file.name = None
     mock_client.files.upload.return_value = mock_file
@@ -640,12 +645,14 @@ def test_summarize_with_document_raises_when_upload_name_none(mocker):
 
 
 def test_summarize_with_document_raises_when_uri_none(mocker):
-    """Test summarize_with_document raises RetryError and deletes Gemini file when uri is None."""
+    """Test summarize_with_document raises RetryError when uri is None."""
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
     mocker.patch("summary.clean_up")
     mocker.patch("tenacity.nap.time.sleep")
+    mocker.patch("services.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
+    mocker.patch("services.gemini_client", mock_client)
     mock_file = SimpleNamespace(
         state="ACTIVE", name="files/doc123", uri=None, mime_type="application/pdf"
     )
@@ -662,16 +669,16 @@ def test_summarize_with_document_raises_when_uri_none(mocker):
             daily_limit=10,
         )
 
-    mock_client.files.delete.assert_called_with(name="files/doc123")
-
 
 def test_summarize_with_document_raises_when_mime_type_none(mocker):
-    """Test summarize_with_document raises RetryError and deletes Gemini file when mime_type is None."""
+    """Test summarize_with_document raises RetryError when mime_type is None."""
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
     mocker.patch("summary.clean_up")
     mocker.patch("tenacity.nap.time.sleep")
+    mocker.patch("services.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
+    mocker.patch("services.gemini_client", mock_client)
     mock_file = SimpleNamespace(
         state="ACTIVE", name="files/doc123", uri="https://mock.uri", mime_type=None
     )
@@ -688,8 +695,6 @@ def test_summarize_with_document_raises_when_mime_type_none(mocker):
             daily_limit=10,
         )
 
-    mock_client.files.delete.assert_called_with(name="files/doc123")
-
 
 def test_summarize_with_document_raises_on_empty_response(mocker):
     """Test summarize_with_document raises RetryError when Gemini returns empty response."""
@@ -697,7 +702,9 @@ def test_summarize_with_document_raises_on_empty_response(mocker):
     mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
     mocker.patch("summary.clean_up")
     mocker.patch("tenacity.nap.time.sleep")
+    mocker.patch("services.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
+    mocker.patch("services.gemini_client", mock_client)
     mock_file = SimpleNamespace(
         state="ACTIVE",
         name="files/doc123",
@@ -724,7 +731,9 @@ def test_summarize_with_document_logs_warning_on_delete_failure(mocker):
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
     mocker.patch("summary.clean_up")
+    mocker.patch("services.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
+    mocker.patch("services.gemini_client", mock_client)
     mock_file = SimpleNamespace(
         state="ACTIVE",
         name="files/doc123",

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -73,14 +73,14 @@ def test_get_yt_transcript_fallback_languages(mocker):
 
     mock_formatter.return_value.format_transcript.return_value = "Hola"
 
-    url = "https://youtu.be/vid"
+    url = "https://youtu.be/dQw4w9WgXcQ"
     result = get_yt_transcript(url)
 
     assert result == "Hola"
     # Verify it was called twice, once without languages, once with languages
     calls = mock_ytt.return_value.fetch.call_args_list
-    assert calls[0].args == ("vid",)
-    assert calls[1].args == ("vid",)
+    assert calls[0].args == ("dQw4w9WgXcQ",)
+    assert calls[1].args == ("dQw4w9WgXcQ",)
     assert calls[1].kwargs == {"languages": ["es"]}
 
 def test_get_yt_transcript_falls_back_to_ytdlp_on_api_failure(mocker, tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
+import pytest
+
 from config import PROTECTED_FILES
-from utils import clean_up, compress_audio, generate_temporary_name
+from utils import clean_up, compress_audio, extract_youtube_video_id, generate_temporary_name
 
 
 def test_generate_temporary_name_no_ext():
@@ -118,3 +120,21 @@ def test_clean_up_all_downloads(mocker):
 
     # Only file1 should have been unlinked
     mock_unlink.assert_called_once_with(file1)
+
+
+def test_extract_youtube_video_id_uppercase_host():
+    """extract_youtube_video_id handles uppercase and mixed-case hostnames."""
+    assert extract_youtube_video_id("https://YOUTU.BE/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+    assert extract_youtube_video_id("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+
+def test_extract_youtube_video_id_malformed_url():
+    """extract_youtube_video_id returns None for malformed URLs with no hostname."""
+    assert extract_youtube_video_id("not-a-url") is None
+    assert extract_youtube_video_id("https://") is None
+
+
+def test_extract_youtube_video_id_invalid_id():
+    """extract_youtube_video_id returns None when video ID fails 11-char validation."""
+    assert extract_youtube_video_id("https://youtu.be/short") is None
+    assert extract_youtube_video_id("https://www.youtube.com/watch?v=tooshort") is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import pytest
-
 from config import PROTECTED_FILES
 from utils import clean_up, compress_audio, extract_youtube_video_id, generate_temporary_name
 
@@ -134,7 +132,13 @@ def test_extract_youtube_video_id_malformed_url():
     assert extract_youtube_video_id("https://") is None
 
 
-def test_extract_youtube_video_id_invalid_id():
-    """extract_youtube_video_id returns None when video ID fails 11-char validation."""
-    assert extract_youtube_video_id("https://youtu.be/short") is None
-    assert extract_youtube_video_id("https://www.youtube.com/watch?v=tooshort") is None
+def test_extract_youtube_video_id_empty_path():
+    """extract_youtube_video_id returns None for youtu.be with no video ID and watch with no v param."""
+    assert extract_youtube_video_id("https://youtu.be/") is None
+    assert extract_youtube_video_id("https://www.youtube.com/watch") is None
+
+
+def test_extract_youtube_video_id_unrecognized_path():
+    """extract_youtube_video_id returns None for youtube.com URLs with unrecognized paths."""
+    assert extract_youtube_video_id("https://youtube.com/playlist?list=PLxxx") is None
+    assert extract_youtube_video_id("https://youtube.com/") is None


### PR DESCRIPTION
## **User description**
## What changed

Full-codebase simplification pass — no behavior changes, all 153 tests green.

### Centralized constants (`config.py`)
- `TG_MAX_FILE_SIZE`, `SUPPORTED_DOCUMENT_MIME_TYPES`, `YT_HOSTS`, `CASTRO_HOST`
- `MODEL_LABELS_REVERSE`, `PROMPT_STRATEGY_LABELS_REVERSE` (precomputed once; previously recomputed on every command invocation)

### `handlers.py`
- Extracted `_fetch_media()` — single helper replacing 5 near-identical None/size/file_id check blocks
- Extracted `_summary_kwargs()` (TypedDict) — collapses the 5-field user kwarg spread into one call
- Extracted `_handle_video_like()` — shared pipeline for video and video_note
- Replaced regex URL routing with `_classify_url()` using `urlsplit` (consistent with project review policy)

### `main.py`
- Extracted `_prompt_choice()` — shared keyboard-prompt helper used by all three `/set_*` commands
- Removed inline reverse-map dict-comprehensions at call sites; use precomputed maps from config

### `services.py`
- Renamed `upload_and_wait_for_audio_file` → `upload_and_wait_for_file` (it was already generic)
- Simplified `resolve_mime_type` with a small extension→MIME lookup dict
- Privatized `reply_with_retry` → `_reply_with_retry` (only called internally by `send_answer`)

### `summary.py`
- Extracted `_generate_text()` — unifies `summarize_with_transcript` and `summarize_webpage` Gemini call scaffolding
- `summarize_with_document` now uses `upload_and_wait_for_file` instead of reimplementing the upload+poll loop

### `download.py`
- Extracted `_stream_to_file()` — shared streaming download used by both `download_castro` and `download_tg`

### `utils.py`
- Added `extract_youtube_video_id()` using `urlsplit` (replaces stringly-typed `startswith`/`replace` chains in `transcription.py`)

### `transcription.py`
- Dropped redundant `model.versions.get(model.versions.list()[0].id)` round-trip; use `list()[0]` directly (removes one network call per transcription)
- Uses `extract_youtube_video_id()` from utils

### Cleanup
- README and `renovate.json`: removed stale `rush` references left over from the rush→limits migration

## Reviewer notes
- All changes are behavior-preserving; retry policies and tenacity decorators untouched
- Tests updated where symbols were renamed (`upload_and_wait_for_file`, `_reply_with_retry`)
- Net: 12 files, −25 LOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved URL recognition for media (YouTube/Castro) and unified one-time reply keyboards for model/prompt/language selection.

* **Bug Fixes**
  * Enforced download size limits, stronger Telegram file validation, safer temporary file cleanup, and more robust document MIME handling.

* **Documentation**
  * Docs list updated: removed active rush link and added a limits entry.

* **Chores**
  * Automated update rules adjusted to apply CalVer pinning/review only to yt-dlp.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Handle media links and downloads more reliably**

### What Changed
- Files exactly 20 MB are now accepted, and oversized Telegram uploads are rejected before processing starts
- Document uploads now accept RTF files in the supported format list
- YouTube links are recognized more reliably, including uppercase hosts and `www.` variants, and invalid or incomplete links are rejected cleanly
- When a YouTube transcript cannot be read, the app now falls back to downloading and summarizing the audio instead of stopping on a lookup error
- Telegram downloads now stop if a file is too large, and partial downloads are removed when a size limit is hit
- Video and video note handling now always removes temporary downloaded files after processing

### Impact
`✅ Fewer failed media uploads`
`✅ Clearer handling of large files`
`✅ More reliable YouTube summaries`
`✅ Fewer broken downloads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
