### PR TITLE
refactor: remove redundant oversize guard from _stream_to_file

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -18,7 +18,7 @@ from tenacity import (
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
-from config import PROXY, TG_API_TOKEN, TG_MAX_FILE_SIZE, headers
+from config import PROXY, TG_API_TOKEN, headers
 from services import choose_yt_audio_format
 from utils import generate_temporary_name
 
@@ -90,7 +90,6 @@ def _stream_to_file(
     url: str,
     dest: str,
     timeout: int = 120,
-    max_size: int | None = None,
 ) -> None:
     """GET `url` and stream the body to `dest` in 8KB chunks."""
     with requests.get(
@@ -99,41 +98,16 @@ def _stream_to_file(
         headers=headers,
         verify=True,
         timeout=timeout,
-    ) as response:
+    ) as r:
         try:
-            response.raise_for_status()
+            r.raise_for_status()
         except requests.exceptions.HTTPError:
-            logger.exception("%s: status code", response.status_code)
+            logger.exception("%s: status code", r.status_code)
             raise
-        if max_size is not None:
-            content_length = response.headers.get("Content-Length")
-            if content_length is not None and int(content_length) > max_size:
-                logger.warning(
-                    "Content-Length %s exceeds limit %s, aborting",
-                    content_length,
-                    max_size,
-                )
-                msg = f"Remote file too large: Content-Length {content_length} > {max_size}"  # noqa: E501
-                raise ValueError(msg)
-        dest_path = Path(dest)
-        total = 0
-        try:
-            with dest_path.open("wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    if chunk:
-                        total += len(chunk)
-                        if max_size is not None and total > max_size:
-                            logger.warning(
-                                "Download exceeded limit %s after %s bytes, aborting",
-                                max_size,
-                                total,
-                            )
-                            msg = f"Remote file too large: exceeded {max_size} bytes"
-                            raise ValueError(msg)  # noqa: TRY301
-                        f.write(chunk)
-        except ValueError:
-            dest_path.unlink(missing_ok=True)
-            raise
+        with Path(dest).open("wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
 
 
 @retry(
@@ -211,5 +185,5 @@ def download_tg(file_id: File, ext: str = "") -> str:
         msg = "Telegram file path is missing."
         raise ValueError(msg)
     file_url = f"https://api.telegram.org/file/bot{TG_API_TOKEN}/{file_id.file_path}"
-    _stream_to_file(file_url, temporary_file_name, max_size=TG_MAX_FILE_SIZE)
+    _stream_to_file(file_url, temporary_file_name)
     return temporary_file_name

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -276,41 +276,6 @@ def test_download_tg_http_error(mocker):
     mock_logger.exception.assert_called_once_with("%s: status code", 403)
 
 
-def test_stream_to_file_content_length_exceeded(mocker, tmp_path):
-    """_stream_to_file raises ValueError and no file is created when Content-Length exceeds max_size."""
-    from download import _stream_to_file
-
-    dest = str(tmp_path / "out.bin")
-    mock_resp = mocker.MagicMock()
-    mock_resp.headers = {"Content-Length": "100"}
-    mock_resp.raise_for_status.return_value = None
-    mock_resp.__enter__.return_value = mock_resp
-    mocker.patch("download.requests.get", return_value=mock_resp)
-
-    with pytest.raises(ValueError, match="Content-Length"):
-        _stream_to_file("https://example.com/file", dest, max_size=50)
-
-    assert not Path(dest).exists()
-
-
-def test_stream_to_file_mid_stream_exceeded_cleans_up(mocker, tmp_path):
-    """_stream_to_file raises ValueError and removes the partial file when streaming exceeds max_size."""
-    from download import _stream_to_file
-
-    dest = str(tmp_path / "out.bin")
-    mock_resp = mocker.MagicMock()
-    mock_resp.headers = {}
-    mock_resp.raise_for_status.return_value = None
-    mock_resp.iter_content.return_value = [b"A" * 30, b"B" * 30]
-    mock_resp.__enter__.return_value = mock_resp
-    mocker.patch("download.requests.get", return_value=mock_resp)
-
-    with pytest.raises(ValueError, match="exceeded"):
-        _stream_to_file("https://example.com/file", dest, max_size=50)
-
-    assert not Path(dest).exists()
-
-
 def test_classify_url_uppercase_youtube_host(mocker):
     """_classify_url normalises uppercase YouTube hostnames to 'media'."""
     from handlers import _classify_url


### PR DESCRIPTION
## **User description**
## Summary

- Removed the `max_size` parameter from `_stream_to_file` in `src/download.py`
- Deleted the `Content-Length` check, per-chunk running-total check, and the `try/except ValueError` cleanup block that existed solely to serve them
- Dropped the now-unused `TG_MAX_FILE_SIZE` import from `download.py` (still used by `_fetch_media` in `handlers.py`)
- Removed 2 tests that exercised the now-deleted abort paths

## Why

The size guard was unreachable in practice:
1. Telegram's Bot API raises an error for `getFile` on any file >20 MB — `get_file_with_retry` never returns a handle for an oversize file
2. The handler layer (`_fetch_media`) also rejects oversize media before `download_tg` is ever called

The code was defensive against a condition that two upstream layers already guarantee cannot occur.

## Test plan

- [x] `uv run ruff check . && uv run ty check .` — passes
- [x] `uv run pytest --tb=short -q` — 164 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop rejecting Telegram downloads with a removed size check**

### What Changed
- Telegram files now download straight to disk without the extra file-size check that was removed
- If the download request fails, the error is still logged and passed back as before
- Tests that covered the removed size-limit failure cases were deleted

### Impact
`✅ Fewer blocked Telegram downloads`
`✅ Cleaner handling of download failures`
`✅ Less test coverage for unreachable error paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
