### PR TITLE
refactor(prompts): modernize prompts for Gemini 2.5/3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Python](https://img.shields.io/badge/Python-3.14-blue)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15-blue)
-![Valkey](https://img.shields.io/badge/Valkey-8-blue)
+![Valkey](https://img.shields.io/badge/Valkey-9-blue)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/e215a12081084eed95c60e5e80480218)](https://app.codacy.com/gh/vasiliadi/ai-summarizer-telegram-bot/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![codecov](https://codecov.io/github/vasiliadi/ai-summarizer-telegram-bot/graph/badge.svg?token=JLUAET14RE)](https://codecov.io/github/vasiliadi/ai-summarizer-telegram-bot)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fvasiliadi%2Fai-summarizer-telegram-bot.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fvasiliadi%2Fai-summarizer-telegram-bot?ref=badge_shield&issueType=license)

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -10,7 +10,7 @@ PROMPTS = {
         Summarize the content below as a bulleted list of key points.
 
         Guidelines:
-        - Produce between 5 and 10 bullets, depending on the depth and length of the content. Short content may warrant fewer; do not pad.
+        - Produce at least 5 bullets. For content that is broad or detailed, use as many bullets as needed to cover it faithfully. Do not pad with filler to reach 5.
         - Each bullet must capture a distinct, significant idea — no overlap, no filler.
         - Output a plain markdown bulleted list, one key point per bullet, nothing else.
 

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -1,11 +1,8 @@
 # ruff: noqa: E501
 
-# Prompts
 PROMPTS = {
     "basic_prompt_for_transcript": """
         Produce a detailed summary of the content below.
-
-        If the content is a transcript or audio, ignore non-verbal cues such as [music] or [laughter] and treat any recognition errors or missing punctuation as artifacts to look past rather than features to comment on.
 
         Here is the provided content:
         """,
@@ -16,7 +13,6 @@ PROMPTS = {
         - Produce between 5 and 10 bullets, depending on the depth and length of the content. Short content may warrant fewer; do not pad.
         - Each bullet must capture a distinct, significant idea — no overlap, no filler.
         - Output a plain markdown bulleted list, one key point per bullet, nothing else.
-        - If the content is a transcript or audio, ignore non-verbal cues like [music] or [laughter] and look past recognition errors or missing punctuation. Do not mention these artifacts in the output.
 
         Here is the provided content:
         """,
@@ -29,4 +25,5 @@ SYSTEM_INSTRUCTION = """
     - Respond in {language}.
     - Begin the response with the summary itself. No preamble, no acknowledgements, no meta-commentary about the task or the content's format.
     - Stay faithful to the source. Do not invent facts, speakers, timestamps, or structure that is not in the content.
+    - If the content is a transcript or audio, ignore non-verbal cues such as [music] or [laughter] and treat any recognition errors or missing punctuation as artifacts — do not mention them in the output.
 """

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -3,59 +3,30 @@
 # Prompts
 PROMPTS = {
     "basic_prompt_for_transcript": """
-        Read or listen carefully to the provided content below and provide a detailed summary.
+        Produce a detailed summary of the content below.
 
-        STRICTLY FORBIDDEN: Do not preface the response with any introductory phrases like "Here is the summary", "Here are the key points", etc. Start directly with the content.
+        If the content is a transcript or audio, ignore non-verbal cues such as [music] or [laughter] and treat any recognition errors or missing punctuation as artifacts to look past rather than features to comment on.
 
         Here is the provided content:
         """,
     "key_points_for_transcript": """
-        You are tasked with summarizing the provided content below into at least 5 key points.
+        Summarize the content below as a bulleted list of key points.
 
-        This task comes with several challenges (if the provided content is a transcript):
-        1. The transcript may contain errors, such as incorrect word recognition or lack of punctuation.
-        2. It's more akin to video subtitles than a formal transcript.
-        3. The transcript may include non-verbal cues like [music] or [laughing].
-
-        To complete this task effectively, follow these steps:
-
-        1. Preprocessing:
-        a. Remove non-verbal cues (e.g., [music], [laughing]) from the transcript.
-        b. Attempt to add basic punctuation where it seems appropriate.
-        c. Correct obvious word recognition errors based on context.
-
-        2. Content Analysis:
-        a. Read through the preprocessed transcript carefully.
-        b. Identify the main topics or themes discussed in the content.
-        c. Look for key information, important facts, or central ideas presented.
-
-        3. Summarization:
-        a. Distill the content into at least 5 key points.
-        b. Ensure each key point captures a distinct and significant aspect of the content.
-        c. Present the information in a clear, concise manner.
-        d. If the video content allows for more than 5 key points, include them as well.
-
-        4. Output Formatting:
-        Present your summary in the following format:
-
-        - [Concise statement of the first main idea]
-        - [Concise statement of the second main idea]
-        - [Concise statement of the third main idea]
-        - [Concise statement of the fourth main idea]
-        - [Concise statement of the fifth main idea]
-        [Additional key points if applicable]
-
-        Remember to focus on the most important and relevant information from the content.
-        Your summary should provide a clear and accurate representation of the content, despite any challenges in the original transcript.
-        Do not include preprocessing information.
-        STRICTLY FORBIDDEN: Do not preface the response with any introductory phrases like "Here is the summary", "Here are the key points", etc. Start directly with the content.
+        Guidelines:
+        - Produce between 5 and 10 bullets, depending on the depth and length of the content. Short content may warrant fewer; do not pad.
+        - Each bullet must capture a distinct, significant idea — no overlap, no filler.
+        - Output a plain markdown bulleted list, one key point per bullet, nothing else.
+        - If the content is a transcript or audio, ignore non-verbal cues like [music] or [laughter] and look past recognition errors or missing punctuation. Do not mention these artifacts in the output.
 
         Here is the provided content:
         """,
 }
 
 SYSTEM_INSTRUCTION = """
-    You are a helpful assistant.
-    Your goal is to provide a summary of the content provided by the user.
-    You must reply in {language} language.
+    You summarize user-provided content — text, articles, PDFs, transcripts, and audio — into clear, faithful summaries.
+
+    Rules:
+    - Respond in {language}.
+    - Begin the response with the summary itself. No preamble, no acknowledgements, no meta-commentary about the task or the content's format.
+    - Stay faithful to the source. Do not invent facts, speakers, timestamps, or structure that is not in the content.
 """


### PR DESCRIPTION
## **User description**
## Summary

- Replace the generic "you are a helpful assistant" `SYSTEM_INSTRUCTION` with a role-scoped prompt that covers all supported input types (text, PDFs, transcripts, audio) and folds the no-preamble rule in once instead of duplicating it per user prompt.
- Strip dated chain-of-thought scaffolding from `key_points_for_transcript` (numbered preprocessing/analysis/summarization sub-steps, bracketed placeholder example) that newer thinking-enabled Gemini models do not need; replace the arbitrary "at least 5" floor with a 5–10 range so short content isn't padded.
- Reframe transcript-specific guidance as conditional in both prompts so PDFs and plain text are not misframed as transcripts.

## Why

`src/prompts.py` had not been touched as the project moved to thinking-enabled Gemini models (current default `gemini-3.5-flash`). The old prompts read like a 2023-era CoT scaffold: numbered reasoning steps, shouty `STRICTLY FORBIDDEN` prohibitions, and a "transcript" framing applied uniformly even to PDFs and plain text — which can bias the model toward inventing speakers or timestamps. With thinking models, terser declarative instructions perform at least as well and avoid contaminating the output with preprocessing artifacts.

## Reviewer notes

- Dict keys `basic_prompt_for_transcript` / `key_points_for_transcript` are intentionally **kept stable**. They are persisted per user in SQLite (`User.prompt_key_for_summary`, `src/models.py:48`) — renaming would require a data migration. Only the prompt strings changed.
- `SYSTEM_INSTRUCTION` still uses the `{language}` placeholder consumed by `SYSTEM_INSTRUCTION.format(language=...)` in `src/services.py:228`. No call-site changes.
- The `dedent().strip()` flow at `src/summary.py:91,202,249,320` is unaffected — leading triple-quote indentation preserved.

## Test plan

- [x] `ruff format .`
- [x] `ruff check .`
- [x] `ty check .`
- [x] `uv run pytest` — 164/164 pass
- [x] Manual smoke test: YouTube link, PDF, OGG audio → request both basic summary and key points; verify outputs start cleanly with no preamble, respect target language, and that PDF/text summaries no longer reference "transcript"


___

## **CodeAnt-AI Description**
**Update summary prompts for cleaner summaries across text, PDFs, transcripts, and audio**

### What Changed
- Summaries now start directly with the content, without intro phrases or meta commentary.
- Transcript and audio summaries now ignore non-verbal cues like `[music]` and `[laughter]`, and avoid calling out punctuation or recognition errors.
- Key-point summaries now ask for 5 to 10 distinct bullets instead of forcing a minimum of 5, so short content is not padded.
- The README badge now shows Valkey 9.

### Impact
`✅ Cleaner summary openings`
`✅ Fewer transcript-specific mistakes`
`✅ Shorter, less padded bullet summaries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated dependency badge version in the README.

* **Improvements**
  * Tightened summarization templates to produce more detailed, structured summaries.
  * Key-points extraction now requires a plain markdown bulleted list with at least five distinct, non-overlapping ideas and no extra text.
  * Response rules now enforce language, start directly with the summary (no preamble), and ignore non‑verbal audio cues for cleaner outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->