### PR TITLE
refactor(gemini): migrate to Interactions API (STG-115)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,6 @@ import replicate
 import sentry_sdk
 import telebot
 from google import genai
-from google.genai import types
 from limits import parse as parse_rate_limit
 from limits.storage import RedisStorage
 from limits.strategies import FixedWindowRateLimiter
@@ -77,29 +76,6 @@ MODELS_WITH_THINKING_SUPPORT = [
 ]
 # If you change DEFAULT_MODEL_ID_FOR_SUMMARY, also change it in models.py.
 DEFAULT_MODEL_ID_FOR_SUMMARY = "gemini-3.5-flash"
-SAFETY_SETTINGS = [
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-]
-GEMINI_CONFIG = types.GenerateContentConfig(
-    system_instruction=None,
-    safety_settings=SAFETY_SETTINGS,
-    response_mime_type="text/plain",
-)
 
 
 # Prompts

--- a/src/services.py
+++ b/src/services.py
@@ -6,7 +6,7 @@ import mimetypes
 import time
 from functools import lru_cache
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from limits import parse as _parse_rate_limit
 from requests.exceptions import ReadTimeout
@@ -34,6 +34,7 @@ from prompts import SYSTEM_INSTRUCTION
 
 if TYPE_CHECKING:
     from google.genai import types
+    from google.genai._interactions.types import GenerationConfigParam
     from telebot.types import File, Message
     from tenacity import (
         _utils as tenacity_utils,
@@ -213,10 +214,17 @@ def get_remaining_quota(user_id: int, daily_limit: int) -> int:
     return max(0, stats.remaining)
 
 
+class GeminiKwargs(TypedDict):
+    """Keyword arguments accepted by `client.interactions.create`."""
+
+    system_instruction: str
+    generation_config: GenerationConfigParam
+
+
 def get_gemini_kwargs(
     target_language: str,
     model: str = "",
-) -> dict[str, Any]:
+) -> GeminiKwargs:
     """Build kwargs for `client.interactions.create` with a thinking toggle."""
     system_instruction = dedent(
         SYSTEM_INSTRUCTION.format(language=target_language),

--- a/src/services.py
+++ b/src/services.py
@@ -8,7 +8,6 @@ from functools import lru_cache
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, cast
 
-from google.genai import types
 from limits import parse as _parse_rate_limit
 from requests.exceptions import ReadTimeout
 from telebot.apihelper import ApiTelegramException
@@ -23,7 +22,6 @@ from tenacity import (
 
 from config import (
     DAILY_LIMIT_KEY,
-    GEMINI_CONFIG,
     MINUTE_LIMIT_KEY,
     MODELS_WITH_THINKING_SUPPORT,
     bot,
@@ -35,6 +33,7 @@ from exceptions import LimitExceededError
 from prompts import SYSTEM_INSTRUCTION
 
 if TYPE_CHECKING:
+    from google.genai import types
     from telebot.types import File, Message
     from tenacity import (
         _utils as tenacity_utils,
@@ -214,28 +213,26 @@ def get_remaining_quota(user_id: int, daily_limit: int) -> int:
     return max(0, stats.remaining)
 
 
-def get_gemini_config(
+def get_gemini_kwargs(
     target_language: str,
     model: str = "",
-) -> types.GenerateContentConfig:
-    """Get Gemini config with system instruction.
+) -> dict[str, Any]:
+    """Build the keyword arguments for `client.interactions.create`.
 
-    Selects a config with or without thinking support based on the model.
-
+    Returns a dict suitable for `**`-unpacking into the call: system
+    instruction, response MIME type, and a thinking-level generation config
+    that toggles based on whether the model supports high-quality thinking.
     """
     system_instruction = dedent(
         SYSTEM_INSTRUCTION.format(language=target_language),
     ).strip()
-    return GEMINI_CONFIG.model_copy(
-        update={
-            "system_instruction": system_instruction,
-            "thinking_config": (
-                types.ThinkingConfig(thinking_level=types.ThinkingLevel.HIGH)
-                if model in MODELS_WITH_THINKING_SUPPORT
-                else None
-            ),
-        },
-    )
+    return {
+        "system_instruction": system_instruction,
+        "response_mime_type": "text/plain",
+        "generation_config": (
+            {"thinking_level": "high"} if model in MODELS_WITH_THINKING_SUPPORT else {}
+        ),
+    }
 
 
 _EXT_MIME_FALLBACK = {

--- a/src/services.py
+++ b/src/services.py
@@ -217,18 +217,12 @@ def get_gemini_kwargs(
     target_language: str,
     model: str = "",
 ) -> dict[str, Any]:
-    """Build the keyword arguments for `client.interactions.create`.
-
-    Returns a dict suitable for `**`-unpacking into the call: system
-    instruction, response MIME type, and a thinking-level generation config
-    that toggles based on whether the model supports high-quality thinking.
-    """
+    """Build kwargs for `client.interactions.create` with a thinking toggle."""
     system_instruction = dedent(
         SYSTEM_INSTRUCTION.format(language=target_language),
     ).strip()
     return {
         "system_instruction": system_instruction,
-        "response_mime_type": "text/plain",
         "generation_config": (
             {"thinking_level": "high"} if model in MODELS_WITH_THINKING_SUPPORT else {}
         ),

--- a/src/summary.py
+++ b/src/summary.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import logging
 from textwrap import dedent
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
-from google.genai import types
 from google.genai.errors import ClientError, ServerError
 from requests.exceptions import SSLError
 from sentry_sdk import capture_exception
@@ -27,7 +26,7 @@ from prompts import PROMPTS
 from services import (
     check_quota,
     format_prefixed_summary,
-    get_gemini_config,
+    get_gemini_kwargs,
     resolve_mime_type,
     upload_and_wait_for_file,
 )
@@ -101,25 +100,22 @@ def summarize_with_file(
         if audio_file.uri is None or audio_file.mime_type is None:
             raise AttributeError
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-        response = gemini_client.models.generate_content(
+        audio_input: list[Any] = [
+            {"type": "text", "text": prompt},
+            {
+                "type": "audio",
+                "uri": audio_file.uri,
+                "mime_type": audio_file.mime_type,
+            },
+        ]
+        interaction = gemini_client.interactions.create(
             model=model,
-            contents=[
-                types.Content(
-                    role="user",
-                    parts=[
-                        types.Part.from_text(text=prompt),
-                        types.Part.from_uri(
-                            file_uri=audio_file.uri,
-                            mime_type=audio_file.mime_type,
-                        ),
-                    ],
-                ),
-            ],
-            config=get_gemini_config(target_language, model=model),
+            input=audio_input,
+            **get_gemini_kwargs(target_language, model=model),
         )
-        if response.text is None:
+        if interaction.output_text is None:
             raise AttributeError
-        return response.text
+        return interaction.output_text
     finally:
         if audio_file_name is not None:
             try:
@@ -134,15 +130,14 @@ def summarize_with_file(
 
 def _generate_text(prompt: str, model: str, target_language: str) -> str:
     """Run a single Gemini text-prompt generation with the standard config."""
-    config = get_gemini_config(target_language, model=model)
-    response = gemini_client.models.generate_content(
+    interaction = gemini_client.interactions.create(
         model=model,
-        contents=prompt,
-        config=config,
+        input=prompt,
+        **get_gemini_kwargs(target_language, model=model),
     )
-    if response.text is None:
+    if interaction.output_text is None:
         raise AttributeError
-    return response.text
+    return interaction.output_text
 
 
 @retry(
@@ -184,7 +179,7 @@ def summarize_with_transcript(
 
     Note:
         The function checks quota usage before making the API call and uses
-        get_gemini_config for model configuration.
+        get_gemini_kwargs for model configuration.
 
     """
     prompt = (f"{dedent(PROMPTS[prompt_key])} {transcript}").strip()
@@ -302,23 +297,20 @@ def summarize_with_document(
         )
         document_file_name = document_file.name
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-        response = gemini_client.models.generate_content(
+        document_input: list[Any] = [
+            {"type": "text", "text": prompt},
+            {
+                "type": "document",
+                "uri": cast("str", document_file.uri),
+                "mime_type": cast("str", document_file.mime_type),
+            },
+        ]
+        interaction = gemini_client.interactions.create(
             model=model,
-            contents=[
-                types.Content(
-                    role="user",
-                    parts=[
-                        types.Part.from_text(text=prompt),
-                        types.Part.from_uri(
-                            file_uri=cast("str", document_file.uri),
-                            mime_type=cast("str", document_file.mime_type),
-                        ),
-                    ],
-                ),
-            ],
-            config=get_gemini_config(target_language, model=model),
+            input=document_input,
+            **get_gemini_kwargs(target_language, model=model),
         )
-        if response.text is None:
+        if interaction.output_text is None:
             raise AttributeError
     finally:
         if document_file_name is not None:
@@ -332,7 +324,7 @@ def summarize_with_document(
                 )
         if data is not None:
             clean_up(file=data)
-    return response.text
+    return interaction.output_text
 
 
 def summarize(

--- a/src/summary.py
+++ b/src/summary.py
@@ -113,7 +113,7 @@ def summarize_with_file(
             input=audio_input,
             **get_gemini_kwargs(target_language, model=model),
         )
-        if interaction.output_text is None:
+        if not interaction.output_text:
             raise AttributeError
         return interaction.output_text
     finally:
@@ -135,7 +135,7 @@ def _generate_text(prompt: str, model: str, target_language: str) -> str:
         input=prompt,
         **get_gemini_kwargs(target_language, model=model),
     )
-    if interaction.output_text is None:
+    if not interaction.output_text:
         raise AttributeError
     return interaction.output_text
 
@@ -310,7 +310,7 @@ def summarize_with_document(
             input=document_input,
             **get_gemini_kwargs(target_language, model=model),
         )
-        if interaction.output_text is None:
+        if not interaction.output_text:
             raise AttributeError
     finally:
         if document_file_name is not None:

--- a/src/summary.py
+++ b/src/summary.py
@@ -296,13 +296,15 @@ def summarize_with_document(
             sleep_time=sleep_time,
         )
         document_file_name = document_file.name
+        if document_file.uri is None or document_file.mime_type is None:
+            raise AttributeError
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
         document_input: list[Any] = [
             {"type": "text", "text": prompt},
             {
                 "type": "document",
-                "uri": cast("str", document_file.uri),
-                "mime_type": cast("str", document_file.mime_type),
+                "uri": document_file.uri,
+                "mime_type": document_file.mime_type,
             },
         ]
         interaction = gemini_client.interactions.create(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -84,7 +84,10 @@ def test_get_gemini_kwargs_content():
     """get_gemini_kwargs embeds the requested language in the system instruction."""
     kwargs = get_gemini_kwargs("French")
     assert "French" in kwargs["system_instruction"]
-    assert kwargs["response_mime_type"] == "text/plain"
+    # response_mime_type is intentionally absent — plain text is the default
+    # modality, and setting the MIME type requires a paired response_format
+    # (only used for structured output).
+    assert "response_mime_type" not in kwargs
 
 
 def test_get_gemini_kwargs_thinking_enabled_for_supported_model():

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,7 +6,7 @@ from exceptions import LimitExceededError
 from services import (
     check_quota,
     get_file_with_retry,
-    get_gemini_config,
+    get_gemini_kwargs,
     get_remaining_quota,
     _reply_with_retry,
     resolve_mime_type,
@@ -80,29 +80,30 @@ def test_send_answer_multi_chunk(mocker):
     assert mock_reply.call_count == 2
 
 
-def test_get_gemini_config_content():
-    """Test get_gemini_config includes the correct language in instruction."""
-    config = get_gemini_config("French")
-    assert "French" in config.system_instruction
+def test_get_gemini_kwargs_content():
+    """get_gemini_kwargs embeds the requested language in the system instruction."""
+    kwargs = get_gemini_kwargs("French")
+    assert "French" in kwargs["system_instruction"]
+    assert kwargs["response_mime_type"] == "text/plain"
 
 
-def test_get_gemini_config_thinking_enabled_for_supported_model():
-    """Test that thinking config is set for models that support it."""
+def test_get_gemini_kwargs_thinking_enabled_for_supported_model():
+    """generation_config requests high thinking for models that support it."""
     model = MODELS_WITH_THINKING_SUPPORT[0]
-    config = get_gemini_config("English", model=model)
-    assert config.thinking_config is not None
+    kwargs = get_gemini_kwargs("English", model=model)
+    assert kwargs["generation_config"] == {"thinking_level": "high"}
 
 
-def test_get_gemini_config_thinking_disabled_for_unsupported_model():
-    """Test that thinking config is None for models that do not support it."""
-    config = get_gemini_config("English", model="gemini-2.5-flash")
-    assert config.thinking_config is None
+def test_get_gemini_kwargs_thinking_disabled_for_unsupported_model():
+    """generation_config is empty for models without thinking support."""
+    kwargs = get_gemini_kwargs("English", model="gemini-2.5-flash")
+    assert kwargs["generation_config"] == {}
 
 
-def test_get_gemini_config_thinking_disabled_when_no_model_given():
-    """Test that thinking config is None when model is omitted."""
-    config = get_gemini_config("English")
-    assert config.thinking_config is None
+def test_get_gemini_kwargs_thinking_disabled_when_no_model_given():
+    """generation_config is empty when no model is provided."""
+    kwargs = get_gemini_kwargs("English")
+    assert kwargs["generation_config"] == {}
 
 
 def test_upload_and_wait_for_file_happy(mocker):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -71,7 +71,7 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
     mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mock_client = mocker.patch("summary.gemini_client")
     mocker.patch("services.gemini_client", mock_client)
-    mock_client.interactions.create.return_value = mocker.MagicMock(output_text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text="")
 
     with pytest.raises(RetryError):
         summarize_with_file(
@@ -148,7 +148,7 @@ def test_summarize_webpage(mocker):
     assert result == "Webpage summary."
     call_kwargs = mock_client.interactions.create.call_args.kwargs
     assert "Parsed page content." in call_kwargs["input"]
-    assert "UrlContext" not in (call_kwargs.get("system_instruction") or "")
+    assert "tools" not in call_kwargs
 
 
 def test_summarize_with_file_upload_failure(mocker):
@@ -638,7 +638,7 @@ def test_summarize_with_transcript_raises_on_empty_response(mocker):
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.interactions.create.return_value = mocker.MagicMock(output_text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text="")
 
     with pytest.raises(RetryError):
         summarize_with_transcript(
@@ -678,7 +678,7 @@ def test_summarize_webpage_raises_on_empty_response(mocker):
     mocker.patch("summary.parse_url", return_value="Parsed page content.")
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.interactions.create.return_value = mocker.MagicMock(output_text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text="")
 
     with pytest.raises(RetryError):
         summarize_webpage(
@@ -786,7 +786,7 @@ def test_summarize_with_document_raises_on_empty_response(mocker):
         mime_type="application/pdf",
     )
     mock_client.files.upload.return_value = mock_file
-    mock_client.interactions.create.return_value = mocker.MagicMock(output_text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text="")
 
     with pytest.raises(RetryError):
         summarize_with_document(

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -856,3 +856,29 @@ def test_summarize_with_telegram_file(mocker):
 
     assert result == "Telegram file summary"
     mock_download_tg.assert_called_once_with(mock_tg_file, ext=".ogg")
+
+
+def test_summarize_with_document_raises_when_upload_returns_none_uri(mocker):
+    """Test summarize_with_document raises RetryError when upload_and_wait_for_file
+    returns a file with uri=None, triggering the guard in summarize_with_document
+    before interactions.create is called."""
+    mocker.patch("summary.check_quota", return_value=True)
+    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
+    mocker.patch("summary.clean_up")
+    mocker.patch("tenacity.nap.time.sleep")
+    mock_client = mocker.patch("summary.gemini_client")
+    mock_file = SimpleNamespace(name="files/doc123", uri=None, mime_type="application/pdf")
+    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_file)
+
+    with pytest.raises(RetryError):
+        summarize_with_document(
+            file=mocker.MagicMock(),
+            model="test-model",
+            prompt_key="basic_prompt_for_transcript",
+            target_language="English",
+            mime_type="application/pdf",
+            user_id=123,
+            daily_limit=10,
+        )
+
+    mock_client.interactions.create.assert_not_called()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -39,8 +39,8 @@ def test_summarize_with_file_upload_and_genai_call(mocker):
         state="ACTIVE",
     )
     mock_client.files.upload.return_value = mock_uploaded_file
-    mock_response = mocker.MagicMock(text="This is a mocked summary of the file.")
-    mock_client.models.generate_content.return_value = mock_response
+    mock_response = mocker.MagicMock(output_text="This is a mocked summary of the file.")
+    mock_client.interactions.create.return_value = mock_response
 
     result = summarize_with_file(
         file="test_audio.ogg",
@@ -71,7 +71,7 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
     mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mock_client = mocker.patch("summary.gemini_client")
     mocker.patch("services.gemini_client", mock_client)
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text=None)
 
     with pytest.raises(RetryError):
         summarize_with_file(
@@ -106,8 +106,8 @@ def test_summarize_with_transcript(mocker):
     """Test summarize_with_transcript functionality."""
     mocker.patch("summary.check_quota", return_value=True)
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(
-        text="Transcript summary.",
+    mock_client.interactions.create.return_value = mocker.MagicMock(
+        output_text="Transcript summary.",
     )
 
     result = summarize_with_transcript(
@@ -132,8 +132,8 @@ def test_summarize_webpage(mocker):
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("summary.parse_url", return_value="Parsed page content.")
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(
-        text="Webpage summary.",
+    mock_client.interactions.create.return_value = mocker.MagicMock(
+        output_text="Webpage summary.",
     )
 
     result = summarize_webpage(
@@ -146,11 +146,9 @@ def test_summarize_webpage(mocker):
     )
 
     assert result == "Webpage summary."
-    call_kwargs = mock_client.models.generate_content.call_args.kwargs
-    assert "Parsed page content." in call_kwargs["contents"]
-    config = call_kwargs["config"]
-    assert config.tools is None
-    assert "UrlContext" not in (config.system_instruction or "")
+    call_kwargs = mock_client.interactions.create.call_args.kwargs
+    assert "Parsed page content." in call_kwargs["input"]
+    assert "UrlContext" not in (call_kwargs.get("system_instruction") or "")
 
 
 def test_summarize_with_file_upload_failure(mocker):
@@ -175,7 +173,7 @@ def test_summarize_genai_exception(mocker):
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.side_effect = ClientError(
+    mock_client.interactions.create.side_effect = ClientError(
         400,
         {
             "error": {
@@ -214,8 +212,8 @@ def test_summarize_with_document_polling(mocker):
     )
     mock_client.files.upload.return_value = mock_file_proc
     mock_client.files.get.return_value = mock_file_active
-    mock_client.models.generate_content.return_value = mocker.MagicMock(
-        text="Document summary",
+    mock_client.interactions.create.return_value = mocker.MagicMock(
+        output_text="Document summary",
     )
     mock_tg_file = mocker.MagicMock()
 
@@ -617,7 +615,7 @@ def test_summarize_with_file_logs_warning_on_delete_failure(mocker):
     )
     mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text="summary text")
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text="summary text")
     mock_client.files.delete.side_effect = Exception("delete failed")
     mock_logger = mocker.patch("summary.logger")
 
@@ -640,7 +638,7 @@ def test_summarize_with_transcript_raises_on_empty_response(mocker):
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text=None)
 
     with pytest.raises(RetryError):
         summarize_with_transcript(
@@ -680,7 +678,7 @@ def test_summarize_webpage_raises_on_empty_response(mocker):
     mocker.patch("summary.parse_url", return_value="Parsed page content.")
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text=None)
 
     with pytest.raises(RetryError):
         summarize_webpage(
@@ -788,7 +786,7 @@ def test_summarize_with_document_raises_on_empty_response(mocker):
         mime_type="application/pdf",
     )
     mock_client.files.upload.return_value = mock_file
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text=None)
 
     with pytest.raises(RetryError):
         summarize_with_document(
@@ -817,7 +815,7 @@ def test_summarize_with_document_logs_warning_on_delete_failure(mocker):
         mime_type="application/pdf",
     )
     mock_client.files.upload.return_value = mock_file
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text="document summary")
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text="document summary")
     mock_client.files.delete.side_effect = Exception("delete failed")
     mock_logger = mocker.patch("summary.logger")
 


### PR DESCRIPTION
## **User description**
## What

Migrates all Gemini calls from the legacy `client.models.generate_content` surface to `client.interactions.create` (Google's recommended path going forward).

## Why

The Interactions API is the supported surface in `google-genai==2.3.0` and unlocks future capabilities (streaming events, background execution, thought summaries). Migrating now avoids a forced upgrade under pressure when the legacy surface is removed.

## Changes

### `src/config.py`
- Removed `GEMINI_CONFIG = types.GenerateContentConfig(...)` — no longer needed.
- Removed `SAFETY_SETTINGS` — the Interactions API rejects `safety_settings` with a 400 even via `extra_body` (confirmed via Sentry). Bot now relies on Gemini's default safety filtering.
- Removed unused `from google.genai import types` import.

### `src/services.py`
- Renamed `get_gemini_config` → `get_gemini_kwargs`: returns a plain `dict` for `**`-unpacking into `interactions.create`.
- Returns `system_instruction` and `generation_config` (`{"thinking_level": "high"}` for thinking-capable models, `{}` otherwise).
- `response_mime_type` was also dropped — the API requires `responseFormat` when `responseMimeType` is set, and plain text is the default modality anyway (confirmed via Sentry).
- `types` moved to `TYPE_CHECKING` block (still used for `types.File` annotation).

### `src/summary.py`
- Three `generate_content` call sites → `interactions.create`:
  - `summarize_with_file` — multimodal `input` as typed-dict list `[{"type": "text", ...}, {"type": "audio", ...}]`
  - `_generate_text` — plain string `input`
  - `summarize_with_document` — typed-dict list with `"document"` discriminator
- `response.text` → `interaction.output_text`
- Empty-output guards changed from `is None` to `not` — the SDK returns `""` (not `None`) on empty output; the falsy check handles both.

### `tests/`
- All mock patterns updated: `models.generate_content` → `interactions.create`; `text=` → `output_text=`
- Empty-response tests updated to mock `output_text=""` (matches real SDK behaviour).
- Webpage test: dropped stale `UrlContext` assertion (only in a docstring), added `assert "tools" not in call_kwargs`.

## Reviewer notes

- **Safety settings**: dropping these is intentional. The live Interactions API returned `400 - Unknown parameter 'safety_settings'` for both top-level and `extra_body` injection. See memory file `project_gemini_interactions_no_safety_settings.md`.
- **Smoke test still needed** before merge: YouTube transcript path, YouTube audio path, webpage (Tavily), and PDF document — on both a thinking-capable model (`gemini-3.5-flash`) and a non-thinking model (`gemini-2.5-flash`).
- 173 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Switch Gemini summaries to the new Interactions API and handle empty replies correctly**

### What Changed
- Gemini summary requests now use the Interactions API for file, transcript, webpage, and document summaries
- Empty Gemini replies are now treated as failures whether the API returns no text or an empty string
- The bot no longer sends the old safety and plain-text response settings that the new Gemini surface rejects
- Tests were updated to match the new response shape and empty-output behavior

### Impact
`✅ Fewer Gemini request failures`
`✅ Clearer handling of empty summaries`
`✅ More reliable file, transcript, and document summaries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended reasoning enabled for models that support it, improving responses on complex tasks.

* **Refactor**
  * Summary generation updated to use the latest model API and configuration approach for more consistent behavior.

* **Bug Fixes**
  * Improved handling of empty/failed responses and clearer errors for missing document metadata, reducing silent failures and unnecessary retries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->