### PR TITLE
chore(transcription): log exception class in yt-dlp warnings

### DIFF
--- a/src/transcription.py
+++ b/src/transcription.py
@@ -173,10 +173,14 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
 
         return vtt_to_text(vtt_files[0])
     except DownloadError as e:
-        logger.warning("yt-dlp subtitle fetch failed: %s", e)
+        logger.warning("yt-dlp subtitle fetch failed: %s: %s", type(e).__name__, e)
         raise
     except Exception as e:
-        logger.warning("yt-dlp subtitle fetch failed unexpectedly: %s", e)
+        logger.warning(
+            "yt-dlp subtitle fetch failed unexpectedly: %s: %s",
+            type(e).__name__,
+            e,
+        )
         msg = "yt-dlp subtitle fetch failed"
         raise DownloadError(msg) from e
     finally:

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -250,6 +250,25 @@ def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     mock_proxy_cfg.assert_called_once_with(https_url="http://proxy:8080")
     mock_ytt.assert_called_once_with(proxy_config=mock_proxy_cfg.return_value)
 
+def test_fetch_transcript_via_ytdlp_download_error_logged_and_reraised(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp logs and re-raises DownloadError from yt-dlp."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    original_exc = DownloadError("Sign in to confirm")
+    mock_ydl_cls.return_value.__enter__.return_value.download.side_effect = original_exc
+    mock_logger = mocker.patch("transcription.logger")
+
+    with pytest.raises(DownloadError) as exc_info:
+        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert exc_info.value is original_exc
+    mock_logger.warning.assert_called_once_with(
+        "yt-dlp subtitle fetch failed: %s: %s",
+        "DownloadError",
+        mocker.ANY,
+    )
+
 def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_as_download_error(mocker, tmp_path):
     """Test fetch_transcript_via_ytdlp wraps non-DownloadError exceptions as DownloadError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -262,7 +262,8 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_as_download_error(m
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
     mock_logger.warning.assert_called_once_with(
-        "yt-dlp subtitle fetch failed unexpectedly: %s",
+        "yt-dlp subtitle fetch failed unexpectedly: %s: %s",
+        "ConnectionError",
         mocker.ANY,
     )
 


### PR DESCRIPTION
## **User description**
## Summary
- Include `type(e).__name__` in both `logger.warning` calls inside `fetch_transcript_via_ytdlp` so warning lines now show the concrete exception class alongside the message.
- Update the matching unit test to assert the new format.

## Why
`fetch_transcript_via_ytdlp` is the only YouTube transcript backend without a `@retry` decorator. Before adding one we need to know which exception types actually surface from yt-dlp (the current logs only show the message, e.g. the "Sign in to confirm you're not a bot" line, which doesn't tell us what class to put in `retry_if_exception_type(...)`). This is a diagnostic-only change — no control flow or behavior is altered, no decorator is added yet.

## Test plan
- [x] `ruff format .`, `ruff check .`, `ty check .`
- [x] `uv run pytest`
- [x] Trigger a failing yt-dlp fetch in production and confirm the warning line now includes the exception class name (e.g. `DownloadError: ...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics for subtitle download failures during transcription: logs now include exception type and detailed message for clearer troubleshooting.

* **Tests**
  * Added a test ensuring download errors are logged and re-raised unchanged.
  * Updated existing tests to match the new multi-part logging format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Show the exception type in yt-dlp failure logs**

### What Changed
- yt-dlp subtitle fetch failures now log the concrete exception name along with the error message
- Unexpected failures still raise the same download error, but the logs now clearly show what kind of exception occurred
- The transcript test now checks for the updated warning format

### Impact
`✅ Clearer yt-dlp failure logs`
`✅ Faster diagnosis of transcript fetch issues`
`✅ Easier retry handling for failed subtitle fetches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
