### PR TITLE
refactor(transcription): probe yt-dlp subtitles before download, handle non-vtt formats

### DIFF
--- a/src/transcription.py
+++ b/src/transcription.py
@@ -150,37 +150,55 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
         "quiet": True,
         "nocheckcertificate": False,
     }
+
+    # Phase 1: probe available subtitle tracks (no download, no temp files written).
     try:
         with YoutubeDL(probe_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
             info = ydl.extract_info(url, download=False)
+    except DownloadError as e:
+        logger.warning("yt-dlp probe failed: %s: %s", type(e).__name__, e)
+        raise
+    except Exception as e:
+        logger.warning("yt-dlp probe failed unexpectedly: %s: %s", type(e).__name__, e)
+        msg = "yt-dlp probe failed"
+        raise DownloadError(msg) from e
 
-        if info is None:
-            msg = "No subtitles available via yt-dlp"
-            raise DownloadError(msg)  # noqa: TRY301
+    if info is None:
+        msg = "No subtitles available via yt-dlp"
+        raise DownloadError(msg)
 
-        manual = info.get("subtitles") or {}
-        auto = info.get("automatic_captions") or {}
-        available = list(dict.fromkeys([*manual.keys(), *auto.keys()]))
+    manual = info.get("subtitles") or {}
+    auto = info.get("automatic_captions") or {}
+    available = list(dict.fromkeys([*manual.keys(), *auto.keys()]))
 
-        if not available:
-            msg = "No subtitles available via yt-dlp"
-            raise DownloadError(msg)  # noqa: TRY301
+    if not available:
+        msg = "No subtitles available via yt-dlp"
+        raise DownloadError(msg)
 
-        has_english = any(lang == "en" or lang.startswith("en") for lang in available)
-        chosen_langs = ["en.*", "en"] if has_english else [available[0]]
+    has_english = any(lang == "en" or lang.startswith("en") for lang in available)
+    chosen_langs = ["en.*", "en"] if has_english else [available[0]]
 
-        ydl_opts: dict[str, Any] = {
-            "proxy": proxy,
-            "skip_download": True,
-            "writesubtitles": True,
-            "writeautomaticsub": True,
-            "subtitleslangs": chosen_langs,
-            "subtitlesformat": "vtt/best",
-            "convertsubtitles": "vtt",
-            "outtmpl": temp_basename,
-            "quiet": True,
-            "nocheckcertificate": False,
-        }
+    ydl_opts: dict[str, Any] = {
+        "proxy": proxy,
+        "skip_download": True,
+        "writesubtitles": True,
+        "writeautomaticsub": True,
+        "subtitleslangs": chosen_langs,
+        "subtitlesformat": "vtt/best",
+        "postprocessors": [
+            {
+                "key": "FFmpegSubtitlesConvertor",
+                "format": "vtt",
+                "when": "before_dl",
+            },
+        ],
+        "outtmpl": temp_basename,
+        "quiet": True,
+        "nocheckcertificate": False,
+    }
+
+    # Phase 2: download and convert subtitles.
+    try:
         with YoutubeDL(ydl_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
             ydl.download([url])
 
@@ -203,7 +221,7 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
         msg = "yt-dlp subtitle fetch failed"
         raise DownloadError(msg) from e
     finally:
-        for f in Path.cwd().glob(f"{temp_basename}.*.vtt"):
+        for f in Path.cwd().glob(f"{temp_basename}.*"):
             clean_up(file=str(f))
 
 

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -146,6 +146,7 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
     proxy = get_proxy()
     probe_opts: dict[str, Any] = {
         "proxy": proxy,
+        "noplaylist": True,
         "skip_download": True,
         "quiet": True,
         "nocheckcertificate": False,
@@ -180,6 +181,7 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
 
     ydl_opts: dict[str, Any] = {
         "proxy": proxy,
+        "noplaylist": True,
         "skip_download": True,
         "writesubtitles": True,
         "writeautomaticsub": True,
@@ -208,7 +210,7 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
             msg = "No subtitles available via yt-dlp"
             raise DownloadError(msg)  # noqa: TRY301
 
-        return vtt_to_text(vtt_files[0])
+        return vtt_to_text(sorted(vtt_files)[0])
     except DownloadError as e:
         logger.warning("yt-dlp subtitle fetch failed: %s: %s", type(e).__name__, e)
         raise

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -130,8 +130,7 @@ def fetch_transcript_via_api(video_id: str) -> str:
 def fetch_transcript_via_ytdlp(url: str) -> str:
     """Retrieve a YouTube transcript by downloading subtitles via yt-dlp.
 
-    Tries English subtitles first (manual then auto-generated), then falls
-    back to any available language. Always uses PROXY when configured.
+    Probes available tracks first, prefers English, converts to vtt via ffmpeg.
 
     Args:
         url (str): The YouTube video URL.
@@ -144,28 +143,48 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
 
     """
     temp_basename = generate_temporary_name()
-    ydl_opts: dict[str, Any] = {
-        "proxy": get_proxy(),
+    proxy = get_proxy()
+    probe_opts: dict[str, Any] = {
+        "proxy": proxy,
         "skip_download": True,
-        "writesubtitles": True,
-        "writeautomaticsub": True,
-        "subtitleslangs": ["en.*", "en"],
-        "subtitlesformat": "vtt",
-        "outtmpl": temp_basename,
         "quiet": True,
         "nocheckcertificate": False,
     }
     try:
+        with YoutubeDL(probe_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
+            info = ydl.extract_info(url, download=False)
+
+        if info is None:
+            msg = "No subtitles available via yt-dlp"
+            raise DownloadError(msg)  # noqa: TRY301
+
+        manual = info.get("subtitles") or {}
+        auto = info.get("automatic_captions") or {}
+        available = list(dict.fromkeys([*manual.keys(), *auto.keys()]))
+
+        if not available:
+            msg = "No subtitles available via yt-dlp"
+            raise DownloadError(msg)  # noqa: TRY301
+
+        has_english = any(lang == "en" or lang.startswith("en") for lang in available)
+        chosen_langs = ["en.*", "en"] if has_english else [available[0]]
+
+        ydl_opts: dict[str, Any] = {
+            "proxy": proxy,
+            "skip_download": True,
+            "writesubtitles": True,
+            "writeautomaticsub": True,
+            "subtitleslangs": chosen_langs,
+            "subtitlesformat": "vtt/best",
+            "convertsubtitles": "vtt",
+            "outtmpl": temp_basename,
+            "quiet": True,
+            "nocheckcertificate": False,
+        }
         with YoutubeDL(ydl_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
             ydl.download([url])
 
         vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
-
-        if not vtt_files:
-            ydl_opts_all = {**ydl_opts, "subtitleslangs": ["all"]}
-            with YoutubeDL(ydl_opts_all) as ydl:  # pyrefly: ignore[bad-argument-type]
-                ydl.download([url])
-            vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
 
         if not vtt_files:
             msg = "No subtitles available via yt-dlp"

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -4,10 +4,20 @@ import pytest
 from replicate.exceptions import ModelError
 from tenacity import RetryError
 from defusedxml.ElementTree import ParseError
-from youtube_transcript_api._errors import IpBlocked, NoTranscriptFound, RequestBlocked, TranscriptsDisabled
+from youtube_transcript_api._errors import (
+    IpBlocked,
+    NoTranscriptFound,
+    RequestBlocked,
+    TranscriptsDisabled,
+)
 from yt_dlp.utils import DownloadError
 
-from transcription import fetch_transcript_via_api, fetch_transcript_via_ytdlp, get_yt_transcript, transcribe
+from transcription import (
+    fetch_transcript_via_api,
+    fetch_transcript_via_ytdlp,
+    get_yt_transcript,
+    transcribe,
+)
 from utils import vtt_to_text
 
 
@@ -17,7 +27,9 @@ def test_get_yt_transcript_youtube_watch_url(mocker):
     mock_formatter = mocker.patch("transcription.TextFormatter")
 
     # Mocking the fetch results
-    mock_ytt.return_value.fetch.return_value = [{"text": "Hello", "start": 0, "duration": 1}]
+    mock_ytt.return_value.fetch.return_value = [
+        {"text": "Hello", "start": 0, "duration": 1}
+    ]
     mock_formatter.return_value.format_transcript.return_value = "Hello"
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
@@ -25,6 +37,7 @@ def test_get_yt_transcript_youtube_watch_url(mocker):
 
     assert result == "Hello"
     mock_ytt.return_value.fetch.assert_called_once_with("dQw4w9WgXcQ")
+
 
 def test_get_yt_transcript_youtu_be_url(mocker):
     """Test get_yt_transcript with short youtu.be URL."""
@@ -40,6 +53,7 @@ def test_get_yt_transcript_youtu_be_url(mocker):
     assert result == "Hello short"
     mock_ytt.return_value.fetch.assert_called_once_with("dQw4w9WgXcQ")
 
+
 def test_get_yt_transcript_youtube_live_url(mocker):
     """Test get_yt_transcript with YouTube live URL."""
     mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
@@ -54,10 +68,12 @@ def test_get_yt_transcript_youtube_live_url(mocker):
     assert result == "Hello live"
     mock_ytt.return_value.fetch.assert_called_once_with("dQw4w9WgXcQ")
 
+
 def test_get_yt_transcript_unknown_url():
     """Test get_yt_transcript raises ValueError for unknown URL formats."""
     with pytest.raises(ValueError, match="Unknown URL"):
         get_yt_transcript("https://example.com/not-youtube", source="api")
+
 
 def test_get_yt_transcript_fallback_languages(mocker):
     """Test get_yt_transcript falls back to other languages if NoTranscriptFound."""
@@ -65,7 +81,10 @@ def test_get_yt_transcript_fallback_languages(mocker):
     mock_formatter = mocker.patch("transcription.TextFormatter")
 
     # First call to fetch raises NoTranscriptFound
-    mock_ytt.return_value.fetch.side_effect = [NoTranscriptFound("vid", "en", []), [{"text": "Hola"}]]
+    mock_ytt.return_value.fetch.side_effect = [
+        NoTranscriptFound("vid", "en", []),
+        [{"text": "Hola"}],
+    ]
     # Mock list to return language codes
     mock_transcript = mocker.MagicMock()
     mock_transcript.language_code = "es"
@@ -82,6 +101,7 @@ def test_get_yt_transcript_fallback_languages(mocker):
     assert calls[0].args == ("dQw4w9WgXcQ",)
     assert calls[1].args == ("dQw4w9WgXcQ",)
     assert calls[1].kwargs == {"languages": ["es"]}
+
 
 def test_get_yt_transcript_source_ytdlp(mocker, tmp_path):
     """Test get_yt_transcript with source='ytdlp' uses yt-dlp and does not touch the API."""
@@ -100,6 +120,10 @@ def test_get_yt_transcript_source_ytdlp(mocker, tmp_path):
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     mock_ydl_inst = mock_ydl_cls.return_value.__enter__.return_value
+    mock_ydl_inst.extract_info.return_value = {
+        "subtitles": {"en": [{}]},
+        "automatic_captions": {},
+    }
     mock_api = mocker.patch("transcription.fetch_transcript_via_api")
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
@@ -108,6 +132,7 @@ def test_get_yt_transcript_source_ytdlp(mocker, tmp_path):
     assert "Hello world" in result
     mock_ydl_inst.download.assert_called_once_with([url])
     mock_api.assert_not_called()
+
 
 def test_get_yt_transcript_source_api_does_not_fall_back(mocker):
     """Test get_yt_transcript with source='api' propagates errors without falling back to yt-dlp."""
@@ -124,6 +149,7 @@ def test_get_yt_transcript_source_api_does_not_fall_back(mocker):
 
     mock_ytdlp.assert_not_called()
 
+
 def test_get_yt_transcript_source_ytdlp_does_not_fall_back(mocker):
     """Test get_yt_transcript with source='ytdlp' propagates errors without falling back to the API."""
     mocker.patch(
@@ -138,11 +164,13 @@ def test_get_yt_transcript_source_ytdlp_does_not_fall_back(mocker):
 
     mock_api.assert_not_called()
 
+
 def test_get_yt_transcript_unknown_source_raises_value_error():
     """Test get_yt_transcript raises ValueError for an unknown source."""
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with pytest.raises(ValueError, match="Unknown transcript source"):
         get_yt_transcript(url, source="bogus")
+
 
 def test_vtt_to_text_dedupes_and_strips_tags(tmp_path):
     """Test vtt_to_text removes headers, timestamps, HTML tags, entities, and duplicates."""
@@ -169,6 +197,7 @@ def test_vtt_to_text_dedupes_and_strips_tags(tmp_path):
 
     assert result == "Hello & world\nSecond line"
 
+
 def test_vtt_to_text_skips_cue_identifiers(tmp_path):
     """Test vtt_to_text skips cue identifier lines (numeric or text) before timestamps."""
     vtt_content = textwrap.dedent("""\
@@ -188,6 +217,7 @@ def test_vtt_to_text_skips_cue_identifiers(tmp_path):
     result = vtt_to_text(vtt_path)
 
     assert result == "Hello\nWorld"
+
 
 def test_vtt_to_text_skips_multiline_note_block(tmp_path):
     """Test vtt_to_text skips all lines inside a multiline NOTE block."""
@@ -215,6 +245,7 @@ def test_vtt_to_text_skips_multiline_note_block(tmp_path):
     assert "comment" not in result
     assert "inline" not in result
 
+
 def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
     """Test vtt_to_text only skips consecutive duplicate lines, not non-consecutive ones."""
     vtt_content = textwrap.dedent("""\
@@ -236,12 +267,15 @@ def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
 
     assert result == "Hello\nWorld\nHello"
 
+
 def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     """Test fetch_transcript_via_api passes GenericProxyConfig when PROXY is set."""
     mocker.patch("transcription.get_proxy", return_value="http://proxy:8080")
     mock_proxy_cfg = mocker.patch("transcription.GenericProxyConfig")
     mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
-    mocker.patch("transcription.TextFormatter").return_value.format_transcript.return_value = "Hello"
+    mocker.patch(
+        "transcription.TextFormatter"
+    ).return_value.format_transcript.return_value = "Hello"
     mock_ytt.return_value.fetch.return_value = []
 
     result = fetch_transcript_via_api("vid")
@@ -250,13 +284,21 @@ def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     mock_proxy_cfg.assert_called_once_with(https_url="http://proxy:8080")
     mock_ytt.assert_called_once_with(proxy_config=mock_proxy_cfg.return_value)
 
-def test_fetch_transcript_via_ytdlp_download_error_logged_and_reraised(mocker, tmp_path):
+
+def test_fetch_transcript_via_ytdlp_download_error_logged_and_reraised(
+    mocker, tmp_path
+):
     """Test fetch_transcript_via_ytdlp logs and re-raises DownloadError from yt-dlp."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    ctx = mock_ydl_cls.return_value.__enter__.return_value
+    ctx.extract_info.return_value = {
+        "subtitles": {"en": [{}]},
+        "automatic_captions": {},
+    }
     original_exc = DownloadError("Sign in to confirm")
-    mock_ydl_cls.return_value.__enter__.return_value.download.side_effect = original_exc
+    ctx.download.side_effect = original_exc
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(DownloadError) as exc_info:
@@ -269,12 +311,20 @@ def test_fetch_transcript_via_ytdlp_download_error_logged_and_reraised(mocker, t
         mocker.ANY,
     )
 
-def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_as_download_error(mocker, tmp_path):
+
+def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_as_download_error(
+    mocker, tmp_path
+):
     """Test fetch_transcript_via_ytdlp wraps non-DownloadError exceptions as DownloadError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
-    mock_ydl_cls.return_value.__enter__.return_value.download.side_effect = ConnectionError("network failure")
+    ctx = mock_ydl_cls.return_value.__enter__.return_value
+    ctx.extract_info.return_value = {
+        "subtitles": {"en": [{}]},
+        "automatic_captions": {},
+    }
+    ctx.download.side_effect = ConnectionError("network failure")
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(DownloadError, match="yt-dlp subtitle fetch failed"):
@@ -286,18 +336,25 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_as_download_error(m
         mocker.ANY,
     )
 
+
 def test_fetch_transcript_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp_path):
     """Test fetch_transcript_via_ytdlp sets original exception as __cause__ of raised DownloadError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    ctx = mock_ydl_cls.return_value.__enter__.return_value
+    ctx.extract_info.return_value = {
+        "subtitles": {"en": [{}]},
+        "automatic_captions": {},
+    }
     original_exc = ConnectionError("network failure")
-    mock_ydl_cls.return_value.__enter__.return_value.download.side_effect = original_exc
+    ctx.download.side_effect = original_exc
 
     with pytest.raises(DownloadError) as exc_info:
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
     assert exc_info.value.__cause__ is original_exc
+
 
 def test_fetch_transcript_via_api_propagates_non_retryable_error(mocker):
     """Test fetch_transcript_via_api propagates CouldNotRetrieveTranscript subclasses."""
@@ -321,14 +378,15 @@ def test_fetch_transcript_via_api_retries_on_retryable_exception(mocker, exc):
 
     assert mock_ytt.return_value.fetch.call_count == 2
 
-def test_fetch_transcript_via_ytdlp_all_language_fallback(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp retries with all languages when English is unavailable."""
+
+def test_fetch_transcript_via_ytdlp_non_english_fallback(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp requests the available language when no English is offered."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.clean_up")
 
     vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
     vtt_path = tmp_path / "fake-uuid.fr.vtt"
-    extract_calls: list[list[str]] = []
+    download_calls: list[list[str]] = []
 
     class MockYDL:
         def __init__(self, opts: object) -> None:
@@ -340,11 +398,13 @@ def test_fetch_transcript_via_ytdlp_all_language_fallback(mocker, tmp_path):
         def __exit__(self, *args: object) -> None:
             pass
 
+        def extract_info(self, url: str, download: bool = True) -> dict:
+            return {"subtitles": {"fr": [{}]}, "automatic_captions": {}}
+
         def download(self, url_list: list[str]) -> int:
             langs = self.opts.get("subtitleslangs", [])
-            extract_calls.append(langs)
-            if "all" in langs:
-                vtt_path.write_text(vtt_content, encoding="utf-8")
+            download_calls.append(langs)
+            vtt_path.write_text(vtt_content, encoding="utf-8")
             return 0
 
     mocker.patch("transcription.YoutubeDL", MockYDL)
@@ -353,29 +413,118 @@ def test_fetch_transcript_via_ytdlp_all_language_fallback(mocker, tmp_path):
     result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
     assert result == "Bonjour"
-    assert extract_calls == [["en.*", "en"], ["all"]]
+    assert download_calls == [["fr"]]
+
+
+def test_fetch_transcript_via_ytdlp_prefers_english_when_available(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp picks English even when other languages are present."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.clean_up")
+
+    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHello\n"
+    vtt_path = tmp_path / "fake-uuid.en.vtt"
+    download_calls: list[list[str]] = []
+
+    class MockYDL:
+        def __init__(self, opts: object) -> None:
+            self.opts = opts
+
+        def __enter__(self) -> "MockYDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool = True) -> dict:
+            return {"subtitles": {"fr": [{}], "en": [{}]}, "automatic_captions": {}}
+
+        def download(self, url_list: list[str]) -> int:
+            langs = self.opts.get("subtitleslangs", [])
+            download_calls.append(langs)
+            vtt_path.write_text(vtt_content, encoding="utf-8")
+            return 0
+
+    mocker.patch("transcription.YoutubeDL", MockYDL)
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+
+    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert result == "Hello"
+    assert download_calls == [["en.*", "en"]]
+
+
+def test_fetch_transcript_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp raises without calling download when no subtitles exist."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    ctx = mock_ydl_cls.return_value.__enter__.return_value
+    ctx.extract_info.return_value = {"subtitles": {}, "automatic_captions": {}}
+
+    with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
+        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    ctx.download.assert_not_called()
+
+
+def test_fetch_transcript_via_ytdlp_pins_proxy_across_probe_and_download(
+    mocker, tmp_path
+):
+    """Test fetch_transcript_via_ytdlp resolves the proxy once and reuses it for both YoutubeDL instances."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.clean_up")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("transcription.get_proxy", return_value="http://proxy.example:8080")
+
+    vtt_path = tmp_path / "fake-uuid.en.vtt"
+    vtt_path.write_text(
+        "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHello\n",
+        encoding="utf-8",
+    )
+
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    ctx = mock_ydl_cls.return_value.__enter__.return_value
+    ctx.extract_info.return_value = {
+        "subtitles": {"en": [{}]},
+        "automatic_captions": {},
+    }
+
+    fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert mock_ydl_cls.call_count == 2
+    probe_opts, download_opts = (call.args[0] for call in mock_ydl_cls.call_args_list)
+    assert probe_opts["proxy"] == "http://proxy.example:8080"
+    assert download_opts["proxy"] == "http://proxy.example:8080"
+    assert download_opts["subtitlesformat"] == "vtt/best"
+    assert download_opts["convertsubtitles"] == "vtt"
+
 
 def test_transcribe_happy_path(mocker):
     """Test transcribing an audio file successfully via Replicate."""
     mock_replicate = mocker.patch("transcription.replicate_client")
     mocker.patch("transcription.Path.open", mocker.mock_open())
-    mocker.patch("transcription.time.sleep") # Don't actually wait
+    mocker.patch("transcription.time.sleep")  # Don't actually wait
 
     # Mock the prediction object and its lifecycle
     mock_prediction = mocker.MagicMock()
     mock_prediction.status = "processing"
     # sequence of statuses: processing -> succeeded
     # status is checked twice per loop (while condition and inside if)
-    type(mock_prediction).status = mocker.PropertyMock(side_effect=["processing", "processing", "succeeded", "succeeded"])
+    type(mock_prediction).status = mocker.PropertyMock(
+        side_effect=["processing", "processing", "succeeded", "succeeded"]
+    )
     mock_prediction.output = {"segments": [{"text": "Hello "}, {"text": "world!"}]}
 
-    mock_replicate.models.get.return_value.versions.list.return_value = [mocker.MagicMock(id="v1")]
+    mock_replicate.models.get.return_value.versions.list.return_value = [
+        mocker.MagicMock(id="v1")
+    ]
     mock_replicate.predictions.create.return_value = mock_prediction
 
     result = transcribe("test.ogg")
 
     assert result == "Hello world!"
     mock_prediction.reload.assert_called_once()
+
 
 def test_transcribe_failed_prediction(mocker):
     """Test transcribe raises ModelError when prediction fails."""
@@ -385,10 +534,13 @@ def test_transcribe_failed_prediction(mocker):
     mock_prediction = mocker.MagicMock()
     mock_prediction.status = "failed"
     mock_replicate.predictions.create.return_value = mock_prediction
-    mock_replicate.models.get.return_value.versions.list.return_value = [mocker.MagicMock(id="v1")]
+    mock_replicate.models.get.return_value.versions.list.return_value = [
+        mocker.MagicMock(id="v1")
+    ]
 
     with pytest.raises(ModelError):
         transcribe("test.ogg")
+
 
 def test_transcribe_null_output(mocker):
     """Test transcribe raises ModelError when prediction output is None."""
@@ -399,7 +551,9 @@ def test_transcribe_null_output(mocker):
     mock_prediction.status = "succeeded"
     mock_prediction.output = None
     mock_replicate.predictions.create.return_value = mock_prediction
-    mock_replicate.models.get.return_value.versions.list.return_value = [mocker.MagicMock(id="v1")]
+    mock_replicate.models.get.return_value.versions.list.return_value = [
+        mocker.MagicMock(id="v1")
+    ]
 
     with pytest.raises(ModelError):
         transcribe("test.ogg")

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -515,6 +515,36 @@ def test_fetch_transcript_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path
     ctx.download.assert_not_called()
 
 
+def test_fetch_transcript_via_ytdlp_extract_info_none_raises(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp raises when extract_info returns None."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    ctx = mock_ydl_cls.return_value.__enter__.return_value
+    ctx.extract_info.return_value = None
+
+    with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
+        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    ctx.download.assert_not_called()
+
+
+def test_fetch_transcript_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp raises when download writes no vtt file."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("transcription.clean_up")
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    ctx = mock_ydl_cls.return_value.__enter__.return_value
+    ctx.extract_info.return_value = {"subtitles": {"en": [{}]}, "automatic_captions": {}}
+    # download() succeeds but writes nothing to tmp_path
+
+    with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
+        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    ctx.download.assert_called_once()
+
+
 def test_fetch_transcript_via_ytdlp_pins_proxy_across_probe_and_download(
     mocker, tmp_path
 ):
@@ -542,7 +572,9 @@ def test_fetch_transcript_via_ytdlp_pins_proxy_across_probe_and_download(
     assert mock_ydl_cls.call_count == 2
     probe_opts, download_opts = (call.args[0] for call in mock_ydl_cls.call_args_list)
     assert probe_opts["proxy"] == "http://proxy.example:8080"
+    assert probe_opts["noplaylist"] is True
     assert download_opts["proxy"] == "http://proxy.example:8080"
+    assert download_opts["noplaylist"] is True
     assert download_opts["subtitlesformat"] == "vtt/best"
     assert any(
         pp.get("key") == "FFmpegSubtitlesConvertor" and pp.get("format") == "vtt"

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -356,6 +356,54 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp
     assert exc_info.value.__cause__ is original_exc
 
 
+def test_fetch_transcript_via_ytdlp_probe_download_error_logged_with_probe_message(
+    mocker, tmp_path
+):
+    """Test fetch_transcript_via_ytdlp logs 'probe failed' (not 'subtitle fetch failed') when extract_info raises."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    ctx = mock_ydl_cls.return_value.__enter__.return_value
+    original_exc = DownloadError("Private video")
+    ctx.extract_info.side_effect = original_exc
+    mock_logger = mocker.patch("transcription.logger")
+
+    with pytest.raises(DownloadError) as exc_info:
+        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert exc_info.value is original_exc
+    mock_logger.warning.assert_called_once_with(
+        "yt-dlp probe failed: %s: %s",
+        "DownloadError",
+        mocker.ANY,
+    )
+    ctx.download.assert_not_called()
+
+
+def test_fetch_transcript_via_ytdlp_probe_unexpected_error_wrapped_and_logged(
+    mocker, tmp_path
+):
+    """Test fetch_transcript_via_ytdlp wraps and logs unexpected errors from extract_info as probe failures."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
+    ctx = mock_ydl_cls.return_value.__enter__.return_value
+    original_exc = ValueError("unexpected extractor failure")
+    ctx.extract_info.side_effect = original_exc
+    mock_logger = mocker.patch("transcription.logger")
+
+    with pytest.raises(DownloadError, match="yt-dlp probe failed") as exc_info:
+        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert exc_info.value.__cause__ is original_exc
+    mock_logger.warning.assert_called_once_with(
+        "yt-dlp probe failed unexpectedly: %s: %s",
+        "ValueError",
+        mocker.ANY,
+    )
+    ctx.download.assert_not_called()
+
+
 def test_fetch_transcript_via_api_propagates_non_retryable_error(mocker):
     """Test fetch_transcript_via_api propagates CouldNotRetrieveTranscript subclasses."""
     mocker.patch("transcription.get_proxy", return_value="")
@@ -496,7 +544,10 @@ def test_fetch_transcript_via_ytdlp_pins_proxy_across_probe_and_download(
     assert probe_opts["proxy"] == "http://proxy.example:8080"
     assert download_opts["proxy"] == "http://proxy.example:8080"
     assert download_opts["subtitlesformat"] == "vtt/best"
-    assert download_opts["convertsubtitles"] == "vtt"
+    assert any(
+        pp.get("key") == "FFmpegSubtitlesConvertor" and pp.get("format") == "vtt"
+        for pp in download_opts.get("postprocessors", [])
+    )
 
 
 def test_transcribe_happy_path(mocker):


### PR DESCRIPTION
## **User description**
## What

Rewrites `fetch_transcript_via_ytdlp` in `src/transcription.py` with four improvements:

1. **Probe before downloading** — calls `extract_info(url, download=False)` first to discover available subtitle tracks. Raises `DownloadError` immediately if none are found, without attempting a download. Follows the same pattern already used in `download_yt` ([src/download.py:67](src/download.py)).

2. **Single `get_proxy()` call** — proxy was previously called twice (once per download pass), which could return different random proxies from the pool. Now called once and reused across both YoutubeDL instances.

3. **Non-vtt format support** — adds `subtitlesformat="vtt/best"` (accept vtt or fall back to any format) and an explicit `FFmpegSubtitlesConvertor` postprocessor to convert to vtt. Replaces the previous `subtitlesformat="vtt"` strict request and the no-op `convertsubtitles` top-level key (which is CLI-only and silently ignored by the Python API).

4. **Two-phase error logging** — probe errors log `"yt-dlp probe failed"`; download errors log `"yt-dlp subtitle fetch failed"`. Previously all failures used the same message, making it impossible to tell from logs whether the probe or the actual download had failed.

The old two-pass language fallback (`["en.*", "en"]` → retry with `["all"]`) is removed. Language selection now happens from `extract_info` metadata: English-family codes are preferred; if none are present, the first available language is used.

## Why

- YouTube occasionally serves subtitles in formats other than vtt (ttml, srv3, srt, ass, json3). The old code only requested vtt and the glob only matched `*.vtt`, so those tracks were silently missed.
- Calling `get_proxy()` twice risked routing probe and download through different proxies, risking inconsistent identity and mid-session IP blocks.
- The second download pass was wasted when `extract_info` can tell us upfront whether any subtitles exist.

## Tests

- 4 existing `fetch_transcript_via_ytdlp` tests updated for the new probe-first flow.
- 1 test replaced: `test_fetch_transcript_via_ytdlp_all_language_fallback` → `test_fetch_transcript_via_ytdlp_non_english_fallback` (single-pass).
- 5 new tests added: English preference, no-subtitles early exit, proxy pinned across both instances, probe `DownloadError` logging, probe unexpected error wrapping.
- Full suite: **191 passed**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fetch YouTube subtitles more reliably and handle more subtitle formats**

### What Changed
- Checks for available subtitle tracks before trying to download, so videos with no subtitles now fail immediately instead of going through a wasted download attempt
- Picks English subtitles when they exist; otherwise it uses the first available language instead of retrying with a broad fallback
- Accepts subtitle files in more formats and converts them into text-ready VTT files, so transcripts are found more often
- Keeps the same proxy for the whole subtitle fetch and gives clearer logs when the probe step fails versus the download step

### Impact
`✅ Fewer failed transcript attempts`
`✅ More transcripts from videos that do not offer VTT subtitles`
`✅ Clearer subtitle fetch errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved YouTube subtitle fetching: two-phase probe-and-download flow with preference for English and automatic selection of fallbacks
  * Subtitle outputs now consistently produced in VTT format for broader compatibility

* **Bug Fixes**
  * Clearer error handling and logging when probing or downloading subtitles; original errors are preserved for diagnostics
  * Broader cleanup of temporary artifacts when downloads complete or fail

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->