### PR TITLE
refactor(transcription): simplify English subtitle language detection

### DIFF
--- a/src/transcription.py
+++ b/src/transcription.py
@@ -176,8 +176,8 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
         msg = "No subtitles available via yt-dlp"
         raise DownloadError(msg)
 
-    has_english = any(lang == "en" or lang.startswith("en") for lang in available)
-    chosen_langs = ["en.*", "en"] if has_english else [available[0]]
+    has_english = any(lang.startswith("en") for lang in available)
+    chosen_langs = ["en.*"] if has_english else [available[0]]
 
     ydl_opts: dict[str, Any] = {
         "proxy": proxy,

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -498,7 +498,7 @@ def test_fetch_transcript_via_ytdlp_prefers_english_when_available(mocker, tmp_p
     result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
     assert result == "Hello"
-    assert download_calls == [["en.*", "en"]]
+    assert download_calls == [["en.*"]]
 
 
 def test_fetch_transcript_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path):


### PR DESCRIPTION
## **User description**
## What changed

Remove two redundancies in the language-selection logic inside `fetch_transcript_via_ytdlp`:

1. **`has_english` condition** — `lang == "en" or lang.startswith("en")` → `lang.startswith("en")`
   The equality branch was dead: `"en".startswith("en")` is always `True`, so the `==` check never fired independently.

2. **`chosen_langs` list** — `["en.*", "en"]` → `["en.*"]`
   yt-dlp matches `subtitleslangs` via `re.compile(val, re.I).fullmatch()` (see `yt_dlp/utils/_utils.py`). Because `.*` matches zero or more characters, `"en.*"` already matches the bare string `"en"` — the literal entry was unreachable.

## Why

Dead code removal. No behaviour change for any real input.

## Verification

- `uv run pytest tests/test_transcription.py` — 32 passed
- `ruff format . && ruff check . && ty check .` — clean
- yt-dlp source confirmed: `re.fullmatch("en.*", "en")` returns a match (span 0–2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined English subtitle language selection for transcripts. The system now more efficiently identifies and prioritizes English subtitles when available, with improved fallback behavior for alternative languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Keep English subtitle selection the same while simplifying how transcript languages are picked

### What Changed
- Transcript fetching still prefers English subtitles when they are available
- The language check now treats any English-prefixed subtitle as English
- The fallback still uses the first available subtitle language when no English subtitles exist
- The test now matches the simplified subtitle language choice

### Impact
`✅ Same transcript results`
`✅ Preserved English subtitle preference`
`✅ Cleaner subtitle selection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
