### PR TITLE
refactor(transcription): retry fetch_transcript_via_ytdlp on transient yt-dlp errors

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -4,3 +4,7 @@ class LimitExceededError(Exception):
 
 class WebParseError(Exception):
     """Exception raised when webpage parsing returns no usable content."""
+
+
+class TranscriptDownloadError(Exception):
+    """Exception raised when yt-dlp transiently fails to fetch subtitles."""

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -128,15 +128,6 @@ def fetch_transcript_via_api(video_id: str) -> str:
     return TextFormatter().format_transcript(transcript)
 
 
-def _cleanup_temp_files(temp_basename: str) -> None:
-    """Remove all temp files matching temp_basename, ignoring OS errors."""
-    try:
-        for f in Path.cwd().glob(f"{temp_basename}.*"):
-            clean_up(file=str(f))
-    except Exception as e:
-        logger.warning("yt-dlp cleanup glob failed: %s: %s", type(e).__name__, e)
-
-
 @retry(
     stop=stop_after_attempt(2),
     wait=wait_fixed(10),
@@ -144,7 +135,7 @@ def _cleanup_temp_files(temp_basename: str) -> None:
     before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
     reraise=False,
 )
-def fetch_transcript_via_ytdlp(url: str) -> str:
+def fetch_transcript_via_ytdlp(url: str) -> str:  # noqa: C901, PLR0915
     """Retrieve a YouTube transcript by downloading subtitles via yt-dlp.
 
     Probes available tracks first, prefers English, converts to vtt via ffmpeg.
@@ -258,7 +249,11 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
 
         return vtt_to_text(sorted(vtt_files)[0])
     finally:
-        _cleanup_temp_files(temp_basename)
+        try:
+            for f in Path.cwd().glob(f"{temp_basename}.*"):
+                clean_up(file=str(f))
+        except Exception as e:
+            logger.warning("yt-dlp cleanup glob failed: %s: %s", type(e).__name__, e)
 
 
 @retry(

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -135,7 +135,7 @@ def fetch_transcript_via_api(video_id: str) -> str:
     before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
     reraise=False,
 )
-def fetch_transcript_via_ytdlp(url: str) -> str:  # noqa: C901, PLR0915
+def fetch_transcript_via_ytdlp(url: str) -> str:
     """Retrieve a YouTube transcript by downloading subtitles via yt-dlp.
 
     Probes available tracks first, prefers English, converts to vtt via ffmpeg.
@@ -236,12 +236,7 @@ def fetch_transcript_via_ytdlp(url: str) -> str:  # noqa: C901, PLR0915
             msg = "yt-dlp subtitle fetch failed"
             raise TranscriptDownloadError(msg) from e
 
-        try:
-            vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
-        except Exception as e:
-            logger.warning("yt-dlp glob failed: %s: %s", type(e).__name__, e)
-            msg = "No subtitles available via yt-dlp"
-            raise DownloadError(msg) from e
+        vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
 
         if not vtt_files:
             msg = "No subtitles available via yt-dlp"
@@ -249,11 +244,8 @@ def fetch_transcript_via_ytdlp(url: str) -> str:  # noqa: C901, PLR0915
 
         return vtt_to_text(sorted(vtt_files)[0])
     finally:
-        try:
-            for f in Path.cwd().glob(f"{temp_basename}.*"):
-                clean_up(file=str(f))
-        except Exception as e:
-            logger.warning("yt-dlp cleanup glob failed: %s: %s", type(e).__name__, e)
+        for f in Path.cwd().glob(f"{temp_basename}.*"):
+            clean_up(file=str(f))
 
 
 @retry(

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -284,8 +284,9 @@ def get_yt_transcript(url: str, source: str) -> str:
             (TranscriptsDisabled, VideoUnavailable, AgeRestricted, etc.).
         DownloadError: If the yt-dlp backend cannot fetch subtitles.
         RetryError: If proxy/SSL/network errors persist after all retry attempts,
-            or if API-internal retries (IpBlocked/RequestBlocked/ParseError) are
-            exhausted.
+            if API-internal retries (IpBlocked/RequestBlocked/ParseError) are
+            exhausted, or if the yt-dlp backend's TranscriptDownloadError
+            retries are exhausted.
 
     """
     video_id = extract_youtube_video_id(url)

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -27,6 +27,7 @@ from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
 from config import replicate_client
+from exceptions import TranscriptDownloadError
 from utils import (
     clean_up,
     extract_youtube_video_id,
@@ -127,6 +128,13 @@ def fetch_transcript_via_api(video_id: str) -> str:
     return TextFormatter().format_transcript(transcript)
 
 
+@retry(
+    stop=stop_after_attempt(2),
+    wait=wait_fixed(10),
+    retry=retry_if_exception_type(TranscriptDownloadError),
+    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+    reraise=False,
+)
 def fetch_transcript_via_ytdlp(url: str) -> str:
     """Retrieve a YouTube transcript by downloading subtitles via yt-dlp.
 
@@ -139,7 +147,14 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
         str: The transcript as plain text.
 
     Raises:
-        DownloadError: If no subtitles are available or yt-dlp cannot fetch them.
+        DownloadError: If no subtitles are available for the video (sentinel
+            paths: extract_info returned no data, no subtitle languages
+            offered, or no vtt file appeared after download), or if vtt
+            conversion/reading fails unexpectedly after a successful download.
+        TranscriptDownloadError: Wraps transient yt-dlp failures from
+            extract_info / download. Up to 2 total attempts (1 retry); on
+            exhaustion tenacity raises RetryError to the caller.
+        RetryError: If TranscriptDownloadError persists after all retries.
 
     """
     temp_basename = generate_temporary_name()
@@ -158,11 +173,11 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
             info = ydl.extract_info(url, download=False)
     except DownloadError as e:
         logger.warning("yt-dlp probe failed: %s: %s", type(e).__name__, e)
-        raise
+        raise TranscriptDownloadError(str(e)) from e
     except Exception as e:
         logger.warning("yt-dlp probe failed unexpectedly: %s: %s", type(e).__name__, e)
         msg = "yt-dlp probe failed"
-        raise DownloadError(msg) from e
+        raise TranscriptDownloadError(msg) from e
 
     if info is None:
         msg = "No subtitles available via yt-dlp"
@@ -201,27 +216,32 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
 
     # Phase 2: download and convert subtitles.
     try:
-        with YoutubeDL(ydl_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
-            ydl.download([url])
+        try:
+            with YoutubeDL(ydl_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
+                ydl.download([url])
+        except DownloadError as e:
+            logger.warning(
+                "yt-dlp subtitle fetch failed: %s: %s",
+                type(e).__name__,
+                e,
+            )
+            raise TranscriptDownloadError(str(e)) from e
+        except Exception as e:
+            logger.warning(
+                "yt-dlp subtitle fetch failed unexpectedly: %s: %s",
+                type(e).__name__,
+                e,
+            )
+            msg = "yt-dlp subtitle fetch failed"
+            raise TranscriptDownloadError(msg) from e
 
         vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
 
         if not vtt_files:
             msg = "No subtitles available via yt-dlp"
-            raise DownloadError(msg)  # noqa: TRY301
+            raise DownloadError(msg)
 
         return vtt_to_text(sorted(vtt_files)[0])
-    except DownloadError as e:
-        logger.warning("yt-dlp subtitle fetch failed: %s: %s", type(e).__name__, e)
-        raise
-    except Exception as e:
-        logger.warning(
-            "yt-dlp subtitle fetch failed unexpectedly: %s: %s",
-            type(e).__name__,
-            e,
-        )
-        msg = "yt-dlp subtitle fetch failed"
-        raise DownloadError(msg) from e
     finally:
         for f in Path.cwd().glob(f"{temp_basename}.*"):
             clean_up(file=str(f))

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -128,6 +128,15 @@ def fetch_transcript_via_api(video_id: str) -> str:
     return TextFormatter().format_transcript(transcript)
 
 
+def _cleanup_temp_files(temp_basename: str) -> None:
+    """Remove all temp files matching temp_basename, ignoring OS errors."""
+    try:
+        for f in Path.cwd().glob(f"{temp_basename}.*"):
+            clean_up(file=str(f))
+    except Exception as e:
+        logger.warning("yt-dlp cleanup glob failed: %s: %s", type(e).__name__, e)
+
+
 @retry(
     stop=stop_after_attempt(2),
     wait=wait_fixed(10),
@@ -191,8 +200,9 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
         msg = "No subtitles available via yt-dlp"
         raise DownloadError(msg)
 
-    has_english = any(lang.startswith("en") for lang in available)
-    chosen_langs = ["en.*"] if has_english else [available[0]]
+    chosen_langs = (
+        ["en.*"] if any(lang.startswith("en") for lang in available) else [available[0]]
+    )
 
     ydl_opts: dict[str, Any] = {
         "proxy": proxy,
@@ -235,7 +245,12 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
             msg = "yt-dlp subtitle fetch failed"
             raise TranscriptDownloadError(msg) from e
 
-        vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
+        try:
+            vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
+        except Exception as e:
+            logger.warning("yt-dlp glob failed: %s: %s", type(e).__name__, e)
+            msg = "No subtitles available via yt-dlp"
+            raise DownloadError(msg) from e
 
         if not vtt_files:
             msg = "No subtitles available via yt-dlp"
@@ -243,8 +258,7 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
 
         return vtt_to_text(sorted(vtt_files)[0])
     finally:
-        for f in Path.cwd().glob(f"{temp_basename}.*"):
-            clean_up(file=str(f))
+        _cleanup_temp_files(temp_basename)
 
 
 @retry(

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import re
 import subprocess
@@ -5,7 +6,11 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 from uuid import uuid4
 
+from yt_dlp.utils import DownloadError
+
 from config import PROTECTED_FILES, PROXIES, YT_HOSTS
+
+logger = logging.getLogger(__name__)
 
 
 def get_proxy() -> str:
@@ -109,8 +114,16 @@ def vtt_to_text(vtt_path: Path) -> str:
     Returns:
         str: Clean transcript text with duplicate lines removed.
 
+    Raises:
+        DownloadError: If the file cannot be read or decoded.
+
     """
-    lines = vtt_path.read_text(encoding="utf-8").splitlines()
+    try:
+        lines = vtt_path.read_text(encoding="utf-8").splitlines()
+    except Exception as e:
+        logger.warning("yt-dlp vtt conversion failed: %s: %s", type(e).__name__, e)
+        msg = "yt-dlp vtt conversion failed"
+        raise DownloadError(msg) from e
     out: list[str] = []
     prev = ""
     in_note = False

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,3 @@
-import logging
 import random
 import re
 import subprocess
@@ -6,11 +5,7 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 from uuid import uuid4
 
-from yt_dlp.utils import DownloadError
-
 from config import PROTECTED_FILES, PROXIES, YT_HOSTS
-
-logger = logging.getLogger(__name__)
 
 
 def get_proxy() -> str:
@@ -114,16 +109,8 @@ def vtt_to_text(vtt_path: Path) -> str:
     Returns:
         str: Clean transcript text with duplicate lines removed.
 
-    Raises:
-        DownloadError: If the file cannot be read or decoded.
-
     """
-    try:
-        lines = vtt_path.read_text(encoding="utf-8").splitlines()
-    except Exception as e:
-        logger.warning("yt-dlp vtt conversion failed: %s: %s", type(e).__name__, e)
-        msg = "yt-dlp vtt conversion failed"
-        raise DownloadError(msg) from e
+    lines = vtt_path.read_text(encoding="utf-8").splitlines()
     out: list[str] = []
     prev = ""
     in_note = False

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -269,25 +269,6 @@ def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
     assert result == "Hello\nWorld\nHello"
 
 
-def test_vtt_to_text_raises_download_error_on_read_failure(tmp_path, mocker):
-    """Test vtt_to_text wraps read errors as DownloadError."""
-    vtt_path = tmp_path / "test.vtt"
-    vtt_path.write_text("irrelevant", encoding="utf-8")
-    original_exc = UnicodeDecodeError("utf-8", b"", 0, 1, "invalid start byte")
-    mocker.patch("utils.Path.read_text", side_effect=original_exc)
-    mock_logger = mocker.patch("utils.logger")
-
-    with pytest.raises(DownloadError, match="yt-dlp vtt conversion failed") as exc_info:
-        vtt_to_text(vtt_path)
-
-    assert exc_info.value.__cause__ is original_exc
-    mock_logger.warning.assert_called_once_with(
-        "yt-dlp vtt conversion failed: %s: %s",
-        "UnicodeDecodeError",
-        mocker.ANY,
-    )
-
-
 def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     """Test fetch_transcript_via_api passes GenericProxyConfig when PROXY is set."""
     mocker.patch("transcription.get_proxy", return_value="http://proxy:8080")

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -12,6 +12,7 @@ from youtube_transcript_api._errors import (
 )
 from yt_dlp.utils import DownloadError
 
+from exceptions import TranscriptDownloadError
 from transcription import (
     fetch_transcript_via_api,
     fetch_transcript_via_ytdlp,
@@ -268,6 +269,25 @@ def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
     assert result == "Hello\nWorld\nHello"
 
 
+def test_vtt_to_text_raises_download_error_on_read_failure(tmp_path, mocker):
+    """Test vtt_to_text wraps read errors as DownloadError."""
+    vtt_path = tmp_path / "test.vtt"
+    vtt_path.write_text("irrelevant", encoding="utf-8")
+    original_exc = UnicodeDecodeError("utf-8", b"", 0, 1, "invalid start byte")
+    mocker.patch("utils.Path.read_text", side_effect=original_exc)
+    mock_logger = mocker.patch("utils.logger")
+
+    with pytest.raises(DownloadError, match="yt-dlp vtt conversion failed") as exc_info:
+        vtt_to_text(vtt_path)
+
+    assert exc_info.value.__cause__ is original_exc
+    mock_logger.warning.assert_called_once_with(
+        "yt-dlp vtt conversion failed: %s: %s",
+        "UnicodeDecodeError",
+        mocker.ANY,
+    )
+
+
 def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     """Test fetch_transcript_via_api passes GenericProxyConfig when PROXY is set."""
     mocker.patch("transcription.get_proxy", return_value="http://proxy:8080")
@@ -285,39 +305,40 @@ def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     mock_ytt.assert_called_once_with(proxy_config=mock_proxy_cfg.return_value)
 
 
-def test_fetch_transcript_via_ytdlp_download_error_logged_and_reraised(
+def test_fetch_transcript_via_ytdlp_download_error_logged_and_retried(
     mocker, tmp_path
 ):
-    """Test fetch_transcript_via_ytdlp logs and re-raises DownloadError from yt-dlp."""
+    """Test fetch_transcript_via_ytdlp retries DownloadError from yt-dlp twice then raises RetryError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
     ctx.extract_info.return_value = {
         "subtitles": {"en": [{}]},
         "automatic_captions": {},
     }
-    original_exc = DownloadError("Sign in to confirm")
-    ctx.download.side_effect = original_exc
+    ctx.download.side_effect = DownloadError("Sign in to confirm")
     mock_logger = mocker.patch("transcription.logger")
 
-    with pytest.raises(DownloadError) as exc_info:
+    with pytest.raises(RetryError):
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
-    assert exc_info.value is original_exc
-    mock_logger.warning.assert_called_once_with(
+    assert ctx.download.call_count == 2
+    mock_logger.warning.assert_any_call(
         "yt-dlp subtitle fetch failed: %s: %s",
         "DownloadError",
         mocker.ANY,
     )
 
 
-def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_as_download_error(
+def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_and_retried(
     mocker, tmp_path
 ):
-    """Test fetch_transcript_via_ytdlp wraps non-DownloadError exceptions as DownloadError."""
+    """Test fetch_transcript_via_ytdlp wraps non-DownloadError exceptions and retries."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
     ctx.extract_info.return_value = {
@@ -327,10 +348,11 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_as_download_error(
     ctx.download.side_effect = ConnectionError("network failure")
     mock_logger = mocker.patch("transcription.logger")
 
-    with pytest.raises(DownloadError, match="yt-dlp subtitle fetch failed"):
+    with pytest.raises(RetryError):
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
-    mock_logger.warning.assert_called_once_with(
+    assert ctx.download.call_count == 2
+    mock_logger.warning.assert_any_call(
         "yt-dlp subtitle fetch failed unexpectedly: %s: %s",
         "ConnectionError",
         mocker.ANY,
@@ -338,9 +360,10 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_as_download_error(
 
 
 def test_fetch_transcript_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp sets original exception as __cause__ of raised DownloadError."""
+    """Test fetch_transcript_via_ytdlp preserves original cause through RetryError on exhaustion."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
     ctx.extract_info.return_value = {
@@ -350,29 +373,31 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp
     original_exc = ConnectionError("network failure")
     ctx.download.side_effect = original_exc
 
-    with pytest.raises(DownloadError) as exc_info:
+    with pytest.raises(RetryError) as exc_info:
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
-    assert exc_info.value.__cause__ is original_exc
+    last_exc = exc_info.value.last_attempt.exception()
+    assert isinstance(last_exc, TranscriptDownloadError)
+    assert last_exc.__cause__ is original_exc
 
 
-def test_fetch_transcript_via_ytdlp_probe_download_error_logged_with_probe_message(
+def test_fetch_transcript_via_ytdlp_probe_download_error_logged_and_retried(
     mocker, tmp_path
 ):
-    """Test fetch_transcript_via_ytdlp logs 'probe failed' (not 'subtitle fetch failed') when extract_info raises."""
+    """Test fetch_transcript_via_ytdlp retries probe DownloadError twice then raises RetryError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
-    original_exc = DownloadError("Private video")
-    ctx.extract_info.side_effect = original_exc
+    ctx.extract_info.side_effect = DownloadError("Private video")
     mock_logger = mocker.patch("transcription.logger")
 
-    with pytest.raises(DownloadError) as exc_info:
+    with pytest.raises(RetryError):
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
-    assert exc_info.value is original_exc
-    mock_logger.warning.assert_called_once_with(
+    assert ctx.extract_info.call_count == 2
+    mock_logger.warning.assert_any_call(
         "yt-dlp probe failed: %s: %s",
         "DownloadError",
         mocker.ANY,
@@ -380,28 +405,72 @@ def test_fetch_transcript_via_ytdlp_probe_download_error_logged_with_probe_messa
     ctx.download.assert_not_called()
 
 
-def test_fetch_transcript_via_ytdlp_probe_unexpected_error_wrapped_and_logged(
+def test_fetch_transcript_via_ytdlp_probe_unexpected_error_wrapped_and_retried(
     mocker, tmp_path
 ):
-    """Test fetch_transcript_via_ytdlp wraps and logs unexpected errors from extract_info as probe failures."""
+    """Test fetch_transcript_via_ytdlp wraps and retries unexpected errors from extract_info."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
     original_exc = ValueError("unexpected extractor failure")
     ctx.extract_info.side_effect = original_exc
     mock_logger = mocker.patch("transcription.logger")
 
-    with pytest.raises(DownloadError, match="yt-dlp probe failed") as exc_info:
+    with pytest.raises(RetryError) as exc_info:
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
-    assert exc_info.value.__cause__ is original_exc
-    mock_logger.warning.assert_called_once_with(
+    last_exc = exc_info.value.last_attempt.exception()
+    assert isinstance(last_exc, TranscriptDownloadError)
+    assert isinstance(last_exc.__cause__, ValueError)
+    assert ctx.extract_info.call_count == 2
+    mock_logger.warning.assert_any_call(
         "yt-dlp probe failed unexpectedly: %s: %s",
         "ValueError",
         mocker.ANY,
     )
     ctx.download.assert_not_called()
+
+
+def test_fetch_transcript_via_ytdlp_succeeds_on_second_attempt(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp returns transcript when first probe fails but second succeeds."""
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.clean_up")
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    mocker.patch("time.sleep")
+
+    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHello\n"
+    vtt_path = tmp_path / "fake-uuid.en.vtt"
+
+    class MockYDL:
+        attempt = 0
+
+        def __init__(self, opts: object) -> None:
+            self.opts = opts
+
+        def __enter__(self) -> "MockYDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool = True) -> dict:
+            MockYDL.attempt += 1
+            if MockYDL.attempt == 1:
+                raise DownloadError("transient network blip")
+            return {"subtitles": {"en": [{}]}, "automatic_captions": {}}
+
+        def download(self, url_list: list[str]) -> int:
+            vtt_path.write_text(vtt_content, encoding="utf-8")
+            return 0
+
+    mocker.patch("transcription.YoutubeDL", MockYDL)
+
+    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert result == "Hello"
+    assert MockYDL.attempt == 2
 
 
 def test_fetch_transcript_via_api_propagates_non_retryable_error(mocker):


### PR DESCRIPTION
## **User description**
## Summary

- Adds a narrow `TranscriptDownloadError` (in `src/exceptions.py`) and decorates `fetch_transcript_via_ytdlp` with `@retry(stop_after_attempt(2), wait_fixed(10), retry_if_exception_type(TranscriptDownloadError), reraise=False)`. yt-dlp's probe/download calls are flaky — the first call often fails while a second succeeds. Wrapping only the transient paths in `TranscriptDownloadError` lets tenacity retry them while sentinel "no subtitles" paths keep raising plain `DownloadError` and short-circuit immediately.
- Restructures Phase 2 so only `ydl.download([url])` sits inside the inner try/except; the `vtt_files` glob and `if not vtt_files` sentinel live outside, preserving the "sentinel is never retried" guarantee.
- Updates `get_yt_transcript`'s docstring so its `Raises: RetryError` clause reflects the new exhaustion source.

## Why

Caller chain in `src/summary.py` already catches `(CouldNotRetrieveTranscript, RetryError, DownloadError, ValueError)` — so retry exhaustion (raises `RetryError` under `reraise=False`) and sentinel "no subtitles" (`DownloadError`) both keep falling through to the `download_yt` fallback. No caller change needed; transient-error robustness is the only behavioral change.

## Test plan

- [x] `ruff format . && ruff check . && ty check .` — clean
- [x] `uv run pytest` — 194/194 passing
- [x] 5 existing yt-dlp tests updated: expect `RetryError`, assert `extract_info`/`download` ran twice, patch `time.sleep`
- [x] New test `test_fetch_transcript_via_ytdlp_succeeds_on_second_attempt` covers transient-fail-then-succeed
- [x] Sentinel paths (`info is None`, no available langs, no vtt after download) still raise `DownloadError` once — verified by existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Retry transient yt-dlp subtitle fetch failures**

### What Changed
- yt-dlp subtitle fetching now retries once when a temporary fetch error occurs, instead of failing immediately
- If yt-dlp still fails after both attempts, the transcript request returns a retry error to the caller
- Missing subtitles still stop right away with the same “no subtitles available” result
- Transcript lookup now handles subtitle-read failures as transcript download errors, so they do not escape as unexpected crashes

### Impact
`✅ Fewer transcript fetch failures from temporary yt-dlp errors`
`✅ More successful transcript downloads after a brief retry`
`✅ Fewer crashy subtitle-read errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transcript download reliability with improved error handling and automatic retry logic for transient download failures.

* **Tests**
  * Added comprehensive test coverage for transcript download error scenarios and retry behavior to ensure robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->