### PR TITLE
refactor(summary): move parse_url out of summarize_webpage retry scope (STG-119)

### DIFF
--- a/src/handlers.py
+++ b/src/handlers.py
@@ -5,7 +5,8 @@ from urllib.parse import urlsplit
 
 from config import CASTRO_HOST, TG_MAX_FILE_SIZE, YT_HOSTS, bot
 from download import download_tg
-from services import get_file_with_retry, send_answer
+from parsing import parse_url
+from services import check_quota, get_file_with_retry, send_answer
 from summary import summarize, summarize_webpage, summarize_with_document
 from utils import clean_up, compress_audio, generate_temporary_name
 
@@ -162,7 +163,9 @@ def handle_url(message: Message, user: UsersOrm, url: str) -> None:
         )
         send_answer(message, answer)
     elif kind == "web":
-        answer = summarize_webpage(content=url, **_summary_kwargs(user))
+        check_quota(user_id=user.user_id, daily_limit=user.daily_limit, quantity=0)
+        parsed = parse_url(url)
+        answer = summarize_webpage(content=parsed, **_summary_kwargs(user))
         send_answer(message, answer)
     else:
         bot.send_message(message.chat.id, "No data to proceed.")

--- a/src/summary.py
+++ b/src/summary.py
@@ -22,7 +22,6 @@ from yt_dlp.utils import DownloadError
 
 from config import DEFAULT_YT_TRANSCRIPT_SOURCE, gemini_client
 from download import download_castro, download_tg, download_yt
-from parsing import parse_url
 from prompts import PROMPTS
 from services import (
     check_quota,
@@ -209,14 +208,10 @@ def summarize_webpage(
     user_id: int,
     daily_limit: int,
 ) -> str:
-    """Generate a summary from webpage content using Gemini API.
-
-    The URL is parsed into clean text via Tavily before being passed to Gemini,
-    which removes the variability introduced by Gemini's server-side UrlContext
-    tool across model versions.
+    """Generate a summary from pre-parsed webpage content using Gemini API.
 
     Args:
-        content (str): The webpage URL to be summarized
+        content (str): Pre-parsed webpage content (markdown text from Tavily).
         model (str): The Gemini model identifier to use for generation
         prompt_key (str): Key to retrieve the prompt template from PROMPTS
         target_language (str): The language to translate the text into.
@@ -227,15 +222,12 @@ def summarize_webpage(
         str: Generated summary text from the webpage content
 
     Raises:
-        WebParseError: If the URL cannot be parsed into usable content.
         AttributeError: If Gemini returns an empty response.
         RetryError: If transient Gemini or network errors persist after retries.
 
     """
-    check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
-    parsed = parse_url(content)
+    prompt = (f"{dedent(PROMPTS[prompt_key])} {content}").strip()
     check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-    prompt = (f"{dedent(PROMPTS[prompt_key])} {parsed}").strip()
     return _generate_text(prompt, model, target_language)
 
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -176,16 +176,59 @@ def test_handle_url_castro_pattern(message_factory, mocker):
 
 
 def test_handle_url_other_http_pattern(message_factory, mocker):
-    """Test that other URLs trigger summarize_webpage."""
+    """Test that other URLs preflight quota, parse, then summarize with parsed text."""
     url = "https://example.com/article"
     msg = message_factory(content_type="text", text=url)
     mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
+    mocker.patch("handlers.check_quota", return_value=True)
+    mock_parse_url = mocker.patch(
+        "handlers.parse_url",
+        return_value="Parsed page content.",
+    )
     mock_summarize_webpage = mocker.patch("handlers.summarize_webpage")
     mocker.patch("handlers.send_answer")
 
     handle_message(msg)
 
-    assert mock_summarize_webpage.call_args.kwargs["content"] == url
+    mock_parse_url.assert_called_once_with(url)
+    assert mock_summarize_webpage.call_args.kwargs["content"] == "Parsed page content."
+
+
+def test_handle_url_web_preflight_blocks_before_parse_url(message_factory, mocker):
+    """Test that quota preflight blocks Tavily IO for over-quota users."""
+    url = "https://example.com/article"
+    msg = message_factory(content_type="text", text=url)
+    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
+    mocker.patch("handlers.check_quota", side_effect=LimitExceededError)
+    mock_parse_url = mocker.patch("handlers.parse_url")
+    mock_summarize_webpage = mocker.patch("handlers.summarize_webpage")
+    mocker.patch("handlers.send_answer")
+    mocker.patch("main.bot.reply_to")
+    mocker.patch("main.capture_exception")
+
+    handle_message(msg)
+
+    mock_parse_url.assert_not_called()
+    mock_summarize_webpage.assert_not_called()
+
+
+def test_handle_url_web_parse_error_skips_summarize(message_factory, mocker):
+    """Test that WebParseError from parse_url short-circuits before summarize_webpage."""
+    from exceptions import WebParseError
+
+    url = "https://example.com/article"
+    msg = message_factory(content_type="text", text=url)
+    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
+    mocker.patch("handlers.check_quota", return_value=True)
+    mocker.patch("handlers.parse_url", side_effect=WebParseError("boom"))
+    mock_summarize_webpage = mocker.patch("handlers.summarize_webpage")
+    mocker.patch("handlers.send_answer")
+    mocker.patch("main.bot.reply_to")
+    mocker.patch("main.capture_exception")
+
+    handle_message(msg)
+
+    mock_summarize_webpage.assert_not_called()
 
 
 def test_handle_voice_happy_path(message_factory, mocker):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -128,16 +128,15 @@ def test_format_prefixed_summary_preserves_blank_line():
 
 
 def test_summarize_webpage(mocker):
-    """Test summarize_webpage parses the URL via Tavily and feeds text to Gemini."""
+    """Test summarize_webpage feeds pre-parsed content to Gemini."""
     mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.parse_url", return_value="Parsed page content.")
     mock_client = mocker.patch("summary.gemini_client")
     mock_client.models.generate_content.return_value = mocker.MagicMock(
         text="Webpage summary.",
     )
 
     result = summarize_webpage(
-        content="https://example.com",
+        content="Parsed page content.",
         model="test-model",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
@@ -708,38 +707,16 @@ def test_summarize_with_transcript_raises_on_empty_response(mocker):
         )
 
 
-def test_summarize_webpage_preflight_blocks_before_parse_url(mocker):
-    """Test summarize_webpage blocks over-quota users before any Tavily IO."""
-    from exceptions import LimitExceededError
-
-    mock_check = mocker.patch("summary.check_quota", side_effect=LimitExceededError)
-    mock_parse = mocker.patch("summary.parse_url")
-
-    with pytest.raises(LimitExceededError):
-        summarize_webpage(
-            content="https://example.com",
-            model="test-model",
-            prompt_key="basic_prompt_for_transcript",
-            target_language="English",
-            user_id=1,
-            daily_limit=0,
-        )
-
-    mock_check.assert_called_once_with(user_id=1, daily_limit=0, quantity=0)
-    mock_parse.assert_not_called()
-
-
 def test_summarize_webpage_raises_on_empty_response(mocker):
     """Test summarize_webpage raises RetryError on repeated empty Gemini responses."""
     mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.parse_url", return_value="Parsed page content.")
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
     mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
 
     with pytest.raises(RetryError):
         summarize_webpage(
-            content="https://example.com",
+            content="Parsed page content.",
             model="test-model",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",


### PR DESCRIPTION
## **User description**
## Summary
- `parse_url` (Tavily extraction) ran inside `summarize_webpage`'s `@retry` scope, so any Gemini-driven retry re-paid for Tavily extraction of the same URL.
- Moved `parse_url` and the `check_quota(quantity=0)` preflight to `handle_url`'s web branch in `src/handlers.py`. `summarize_webpage` now takes pre-parsed text and only retries the Gemini generation step — its body mirrors `summarize_with_transcript`.
- Quota preflight stays at the caller (`handle_url`), keeping `parse_url` in `src/parsing.py` single-purpose (no `user_id` / `daily_limit` coupling).

## Why
Fixes [STG-119](https://linear.app/vasiliadi/issue/STG-119). On a Gemini transient error the old code burned a duplicate Tavily call plus ~Tavily latency on every retry. Tavily is now invoked exactly once per request regardless of retries.

Note: `check_quota(quantity=1)` is intentionally kept inside `@retry` — Gemini bills every call (including failures), so the quota model deliberately counts attempts, not successes.

## Test plan
- [x] `ruff format .`, `ruff check .`, `ty check .`
- [x] `uv run pytest` — **195 passed** (was 194; added `test_handle_url_web_preflight_blocks_before_parse_url`, removed `test_summarize_webpage_preflight_blocks_before_parse_url`, simplified two `test_summary` tests to pass pre-parsed content, updated `test_handle_url_other_http_pattern` to assert parse_url runs first)
- [x] Manual: send a web URL through the bot, confirm summary returns and logs show `parse_url` runs once even on a forced Gemini retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Quota limits are now validated before URL processing, providing faster rejection of over-limit requests
  - Enhanced error handling for URL parsing with earlier detection of parsing failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Avoid re-parsing webpages during summary retries**

### What Changed
- Webpage links are now parsed once before summarization starts, instead of being parsed again on each retry
- Over-quota users are blocked before any webpage parsing happens
- If webpage parsing fails, summarization stops immediately instead of continuing with bad input
- The summary step now receives clean webpage text directly

### Impact
`✅ Fewer repeated webpage fetches`
`✅ Faster recovery from summary retries`
`✅ Faster rejection of over-limit requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
