### PR TITLE
chore(models): drop gemini-2.5-flash and gemini-3-flash-preview

### DIFF
--- a/migrations/versions/6bb4ed473ffd_drop_legacy_gemini_models.py
+++ b/migrations/versions/6bb4ed473ffd_drop_legacy_gemini_models.py
@@ -1,0 +1,29 @@
+"""drop legacy gemini models
+
+Revision ID: 6bb4ed473ffd
+Revises: 10c9ae0e381a
+Create Date: 2026-05-25 19:32:52.521315
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "6bb4ed473ffd"
+down_revision: Union[str, None] = "10c9ae0e381a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE users SET summarizing_model = 'gemini-3.5-flash' "
+        "WHERE summarizing_model IN ('gemini-2.5-flash', 'gemini-3-flash-preview')",
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/src/config.py
+++ b/src/config.py
@@ -66,15 +66,9 @@ GEMINI_API_KEY = os.environ["GEMINI_API_KEY"]
 gemini_client = genai.Client(api_key=GEMINI_API_KEY)
 MODEL_LABELS: dict[str, str] = {
     "gemini-3.5-flash": "Gemini 3.5 Flash",
-    "gemini-3-flash-preview": "Gemini 3 Flash",
-    "gemini-2.5-flash": "Gemini 2.5 Flash",
 }
 MODEL_LABELS_REVERSE: dict[str, str] = {v: k for k, v in MODEL_LABELS.items()}
 ALLOWED_MODELS_FOR_SUMMARY = list(MODEL_LABELS.keys())
-MODELS_WITH_THINKING_SUPPORT = [
-    "gemini-3.5-flash",
-    "gemini-3-flash-preview",
-]
 # If you change DEFAULT_MODEL_ID_FOR_SUMMARY, also change it in models.py.
 DEFAULT_MODEL_ID_FOR_SUMMARY = "gemini-3.5-flash"
 SAFETY_SETTINGS = [

--- a/src/services.py
+++ b/src/services.py
@@ -25,7 +25,6 @@ from config import (
     DAILY_LIMIT_KEY,
     GEMINI_CONFIG,
     MINUTE_LIMIT_KEY,
-    MODELS_WITH_THINKING_SUPPORT,
     bot,
     gemini_client,
     per_minute_rate,
@@ -216,23 +215,16 @@ def get_remaining_quota(user_id: int, daily_limit: int) -> int:
 
 def get_gemini_config(
     target_language: str,
-    model: str = "",
 ) -> types.GenerateContentConfig:
-    """Get Gemini config with system instruction.
-
-    Selects a config with or without thinking support based on the model.
-
-    """
+    """Get Gemini config with system instruction and thinking enabled."""
     system_instruction = dedent(
         SYSTEM_INSTRUCTION.format(language=target_language),
     ).strip()
     return GEMINI_CONFIG.model_copy(
         update={
             "system_instruction": system_instruction,
-            "thinking_config": (
-                types.ThinkingConfig(thinking_level=types.ThinkingLevel.HIGH)
-                if model in MODELS_WITH_THINKING_SUPPORT
-                else None
+            "thinking_config": types.ThinkingConfig(
+                thinking_level=types.ThinkingLevel.HIGH,
             ),
         },
     )

--- a/src/summary.py
+++ b/src/summary.py
@@ -114,7 +114,7 @@ def summarize_with_file(
                     ],
                 ),
             ],
-            config=get_gemini_config(target_language, model=model),
+            config=get_gemini_config(target_language),
         )
         if response.text is None:
             raise AttributeError
@@ -133,7 +133,7 @@ def summarize_with_file(
 
 def _generate_text(prompt: str, model: str, target_language: str) -> str:
     """Run a single Gemini text-prompt generation with the standard config."""
-    config = get_gemini_config(target_language, model=model)
+    config = get_gemini_config(target_language)
     response = gemini_client.models.generate_content(
         model=model,
         contents=prompt,
@@ -308,7 +308,7 @@ def summarize_with_document(
                     ],
                 ),
             ],
-            config=get_gemini_config(target_language, model=model),
+            config=get_gemini_config(target_language),
         )
         if response.text is None:
             raise AttributeError

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -82,7 +82,7 @@ def test_handle_myinfo(message_factory, mocker):
         user_id=123,
         approved=True,
         target_language="English",
-        summarizing_model="gemini-2.5-flash",
+        summarizing_model="gemini-3.5-flash",
         prompt_key_for_summary="basic_prompt_for_transcript",
         use_yt_transcription=False,
         use_transcription=False,
@@ -100,7 +100,7 @@ def test_handle_myinfo(message_factory, mocker):
     assert "Target language: English" in content
     assert "Daily limit: 10" in content
     assert "Remaining quota: 7" in content
-    assert "Summarizing model: Gemini 2.5 Flash" in content
+    assert "Summarizing model: Gemini 3.5 Flash" in content
     assert "YT transcript source: yt-dlp" in content
     assert "Prompt strategy: Detailed Summary" in content
 
@@ -255,19 +255,19 @@ def test_handle_set_summarizing_model(message_factory, mocker):
 
 def test_proceed_set_summarizing_model_success(message_factory, mocker):
     """Test successful model selection."""
-    msg = message_factory(content_type="text", text="Gemini 2.5 Flash")
+    msg = message_factory(content_type="text", text="Gemini 3.5 Flash")
     mock_set_model = mocker.patch("main.set_summarizing_model", return_value=True)
     mock_send = mocker.patch("main.bot.send_message")
 
     proceed_set_summarizing_model(msg)
 
-    mock_set_model.assert_called_once_with(msg.from_user.id, "gemini-2.5-flash")
-    assert "The summarizing model is set to Gemini 2.5 Flash" in mock_send.call_args[0][1]
+    mock_set_model.assert_called_once_with(msg.from_user.id, "gemini-3.5-flash")
+    assert "The summarizing model is set to Gemini 3.5 Flash" in mock_send.call_args[0][1]
 
 
 def test_proceed_set_summarizing_model_missing_input(message_factory, mocker):
     """Test model selection fails fast when user or text is missing."""
-    msg = message_factory(content_type="text", text="gemini-2.5-flash")
+    msg = message_factory(content_type="text", text="gemini-3.5-flash")
     msg.from_user = None
     mock_reply = mocker.patch("main.bot.reply_to")
     mock_set_model = mocker.patch("main.set_summarizing_model")
@@ -280,7 +280,7 @@ def test_proceed_set_summarizing_model_missing_input(message_factory, mocker):
 
 def test_proceed_set_summarizing_model_db_failure(message_factory, mocker):
     """Test DB failure returns a clear user-facing message."""
-    msg = message_factory(content_type="text", text="Gemini 2.5 Flash")
+    msg = message_factory(content_type="text", text="Gemini 3.5 Flash")
     mocker.patch("main.set_summarizing_model", return_value=False)
     mock_send = mocker.patch("main.bot.send_message")
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,7 +1,6 @@
 import pytest
 from limits.util import WindowStats
 
-from config import MODELS_WITH_THINKING_SUPPORT
 from exceptions import LimitExceededError
 from services import (
     check_quota,
@@ -86,23 +85,10 @@ def test_get_gemini_config_content():
     assert "French" in config.system_instruction
 
 
-def test_get_gemini_config_thinking_enabled_for_supported_model():
-    """Test that thinking config is set for models that support it."""
-    model = MODELS_WITH_THINKING_SUPPORT[0]
-    config = get_gemini_config("English", model=model)
-    assert config.thinking_config is not None
-
-
-def test_get_gemini_config_thinking_disabled_for_unsupported_model():
-    """Test that thinking config is None for models that do not support it."""
-    config = get_gemini_config("English", model="gemini-2.5-flash")
-    assert config.thinking_config is None
-
-
-def test_get_gemini_config_thinking_disabled_when_no_model_given():
-    """Test that thinking config is None when model is omitted."""
+def test_get_gemini_config_thinking_enabled():
+    """Test that thinking config is always set."""
     config = get_gemini_config("English")
-    assert config.thinking_config is None
+    assert config.thinking_config is not None
 
 
 def test_upload_and_wait_for_file_happy(mocker):


### PR DESCRIPTION
## **User description**
## Summary

- Drop `gemini-2.5-flash` (nearing EOL, last non-thinking model) and `gemini-3-flash-preview` (superseded by released `gemini-3.5-flash`) from `MODEL_LABELS`. Only `gemini-3.5-flash` remains.
- Remove `MODELS_WITH_THINKING_SUPPORT` — every remaining model has thinking, so `get_gemini_config()` unconditionally enables `ThinkingLevel.HIGH`. The now-unused `model` parameter is dropped (and removed from its three `summary.py` call sites).
- Add Alembic data migration `6bb4ed473ffd` that coerces `users.summarizing_model` from the two dropped IDs to `gemini-3.5-flash`. Migration runs at `docker build` time before the new image serves traffic, so there is no window where the new code reads pre-migration rows.
- `/set_summarizing_model` keyboard kept in place (single option for now) so new models can be added later without re-introducing the UI.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .` clean
- [x] `uv run ty check .` clean
- [x] `uv run pytest` — 193 passed
- [ ] Post-deploy smoke: `/myinfo` shows `Summarizing model: Gemini 3.5 Flash`; `/set_summarizing_model` round-trips; a summary request uses thinking

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use the current Gemini summarizing model everywhere**

### What Changed
- Removed the old Gemini model options and kept only Gemini 3.5 Flash for summaries
- Summaries now always use thinking, including file-based and text-based requests
- Existing users on the retired models are moved to Gemini 3.5 Flash automatically
- `/myinfo` and the model selection flow now show Gemini 3.5 Flash as the summarizing model

### Impact
`✅ Fewer summary failures from retired models`
`✅ Consistent thinking-enabled summaries`
`✅ Clearer model selection for users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for legacy Gemini model versions and updated to Gemini 3.5 Flash
  * Migrated existing user model selections automatically
  * Enabled advanced thinking capabilities by default for all Gemini interactions
  * Updated application validation logic to support the new model configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->