### PR TITLE
refactor(gemini): ♻️ refactor get_gemini_config to receive thinking_l… / STG-122

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,6 @@ REDIS_URL="rediss://default:password@host:port"
 SENTRY_DSN="your_sentry_dsn"
 PROXY=""
 LOG_LEVEL="ERROR"
+DEFAULT_THINKING_LEVEL="MEDIUM"  # Supported values: LOW, MEDIUM, HIGH, MINIMAL
 MODAL_TOKEN_ID="your_token"
 MODAL_TOKEN_SECRET="your_token_secret"

--- a/src/config.py
+++ b/src/config.py
@@ -89,6 +89,9 @@ SAFETY_SETTINGS = [
         threshold=types.HarmBlockThreshold.BLOCK_NONE,
     ),
 ]
+DEFAULT_THINKING_LEVEL = types.ThinkingLevel(
+    os.environ.get("DEFAULT_THINKING_LEVEL", "MEDIUM").upper(),
+)
 GEMINI_CONFIG = types.GenerateContentConfig(
     system_instruction=None,
     safety_settings=SAFETY_SETTINGS,

--- a/src/config.py
+++ b/src/config.py
@@ -89,8 +89,12 @@ SAFETY_SETTINGS = [
         threshold=types.HarmBlockThreshold.BLOCK_NONE,
     ),
 ]
+THINKING_LEVEL_ENV = os.environ.get("DEFAULT_THINKING_LEVEL", "MEDIUM").upper()
+VALID_THINKING_LEVELS = {
+    m.value for m in types.ThinkingLevel if m.value != "THINKING_LEVEL_UNSPECIFIED"
+}
 DEFAULT_THINKING_LEVEL = types.ThinkingLevel(
-    os.environ.get("DEFAULT_THINKING_LEVEL", "MEDIUM").upper(),
+    THINKING_LEVEL_ENV if THINKING_LEVEL_ENV in VALID_THINKING_LEVELS else "MEDIUM",
 )
 GEMINI_CONFIG = types.GenerateContentConfig(
     system_instruction=None,

--- a/src/services.py
+++ b/src/services.py
@@ -23,6 +23,7 @@ from tenacity import (
 
 from config import (
     DAILY_LIMIT_KEY,
+    DEFAULT_THINKING_LEVEL,
     GEMINI_CONFIG,
     MINUTE_LIMIT_KEY,
     bot,
@@ -215,7 +216,7 @@ def get_remaining_quota(user_id: int, daily_limit: int) -> int:
 
 def get_gemini_config(
     target_language: str,
-    thinking_level: types.ThinkingLevel,
+    thinking_level: types.ThinkingLevel = DEFAULT_THINKING_LEVEL,
 ) -> types.GenerateContentConfig:
     """Get Gemini config with system instruction and thinking enabled."""
     system_instruction = dedent(

--- a/src/services.py
+++ b/src/services.py
@@ -215,6 +215,7 @@ def get_remaining_quota(user_id: int, daily_limit: int) -> int:
 
 def get_gemini_config(
     target_language: str,
+    thinking_level: types.ThinkingLevel,
 ) -> types.GenerateContentConfig:
     """Get Gemini config with system instruction and thinking enabled."""
     system_instruction = dedent(
@@ -224,7 +225,7 @@ def get_gemini_config(
         update={
             "system_instruction": system_instruction,
             "thinking_config": types.ThinkingConfig(
-                thinking_level=types.ThinkingLevel.HIGH,
+                thinking_level=thinking_level,
             ),
         },
     )

--- a/src/summary.py
+++ b/src/summary.py
@@ -20,7 +20,7 @@ from tenacity import (
 from youtube_transcript_api._errors import CouldNotRetrieveTranscript
 from yt_dlp.utils import DownloadError
 
-from config import DEFAULT_YT_TRANSCRIPT_SOURCE, gemini_client
+from config import DEFAULT_THINKING_LEVEL, DEFAULT_YT_TRANSCRIPT_SOURCE, gemini_client
 from download import download_castro, download_tg, download_yt
 from prompts import PROMPTS
 from services import (
@@ -114,7 +114,10 @@ def summarize_with_file(
                     ],
                 ),
             ],
-            config=get_gemini_config(target_language),
+            config=get_gemini_config(
+                target_language,
+                thinking_level=DEFAULT_THINKING_LEVEL,
+            ),
         )
         if response.text is None:
             raise AttributeError
@@ -133,7 +136,7 @@ def summarize_with_file(
 
 def _generate_text(prompt: str, model: str, target_language: str) -> str:
     """Run a single Gemini text-prompt generation with the standard config."""
-    config = get_gemini_config(target_language)
+    config = get_gemini_config(target_language, thinking_level=DEFAULT_THINKING_LEVEL)
     response = gemini_client.models.generate_content(
         model=model,
         contents=prompt,
@@ -308,7 +311,10 @@ def summarize_with_document(
                     ],
                 ),
             ],
-            config=get_gemini_config(target_language),
+            config=get_gemini_config(
+                target_language,
+                thinking_level=DEFAULT_THINKING_LEVEL,
+            ),
         )
         if response.text is None:
             raise AttributeError

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -81,14 +81,19 @@ def test_send_answer_multi_chunk(mocker):
 
 def test_get_gemini_config_content():
     """Test get_gemini_config includes the correct language in instruction."""
-    config = get_gemini_config("French")
+    from google.genai import types
+
+    config = get_gemini_config("French", thinking_level=types.ThinkingLevel.HIGH)
     assert "French" in config.system_instruction
 
 
 def test_get_gemini_config_thinking_enabled():
-    """Test that thinking config is always set."""
-    config = get_gemini_config("English")
+    """Test that thinking config is set based on the passed thinking level."""
+    from google.genai import types
+
+    config = get_gemini_config("English", thinking_level=types.ThinkingLevel.MEDIUM)
     assert config.thinking_config is not None
+    assert config.thinking_config.thinking_level == types.ThinkingLevel.MEDIUM
 
 
 def test_upload_and_wait_for_file_happy(mocker):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,4 +1,5 @@
 import pytest
+from google.genai import types
 from limits.util import WindowStats
 
 from exceptions import LimitExceededError
@@ -81,16 +82,12 @@ def test_send_answer_multi_chunk(mocker):
 
 def test_get_gemini_config_content():
     """Test get_gemini_config includes the correct language in instruction."""
-    from google.genai import types
-
     config = get_gemini_config("French", thinking_level=types.ThinkingLevel.HIGH)
     assert "French" in config.system_instruction
 
 
 def test_get_gemini_config_thinking_enabled():
     """Test that thinking config is set based on the passed thinking level."""
-    from google.genai import types
-
     config = get_gemini_config("English", thinking_level=types.ThinkingLevel.MEDIUM)
     assert config.thinking_config is not None
     assert config.thinking_config.thinking_level == types.ThinkingLevel.MEDIUM


### PR DESCRIPTION
## **User description**
…evel as argument


___

## **CodeAnt-AI Description**
**Use a configurable Gemini thinking level for summaries**

### What Changed
- Summary generation now uses the thinking level set in the app configuration instead of always using the same default
- Text, file, and document summaries all pass that configured thinking level through to Gemini
- Tests now check that the chosen thinking level is included in the Gemini settings

### Impact
`✅ Easier tuning of summary quality`
`✅ More consistent Gemini behavior across summary types`
`✅ Clearer control over output depth`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the AI thinking level configurable via environment variables (defaults to Medium), allowing users to customize the reasoning depth used by the AI model across all generation tasks.

* **Tests**
  * Improved test coverage to ensure the thinking level configuration is properly validated and applied throughout the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->