### PR TITLE
♻️ refactor(download): switch from requests to curl_cffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ While text transcripts can provide a solid foundation for understanding the cont
 [SQLAlchemy 2.0](https://docs.sqlalchemy.org/en/20/contents.html) \
 [Alembic](https://alembic.sqlalchemy.org/en/latest/tutorial.html) \
 [Google Gen AI SDK](https://github.com/googleapis/python-genai) \
-[Requests](https://requests.readthedocs.io/en/latest/) \
+~~[Requests](https://requests.readthedocs.io/en/latest/)~~ \
 [yt-dlp](https://github.com/yt-dlp/yt-dlp) \
 [beautifulsoup4](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) \
 [Replicate](https://github.com/replicate/replicate-python) \
@@ -208,7 +208,9 @@ While text transcripts can provide a solid foundation for understanding the cont
 [Sentry](https://docs.sentry.io/platforms/python/) \
 ~~[rush](https://rush.readthedocs.io/en/latest/)~~ \
 [limits](https://github.com/alisaifee/limits) \
-[tavily-python](https://docs.tavily.com/welcome)
+[tavily-python](https://docs.tavily.com/welcome) \
+[curl_cffi](https://github.com/lexiforest/curl_cffi) \
+[PySocks](https://github.com/Anorov/PySocks)
 
 [Telegram Bot API](https://core.telegram.org/bots/api) \
 [Docker | Set build-time variables (--build-arg)](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg) \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,13 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "beautifulsoup4==4.14.3",
+    "curl-cffi==0.14.0",
     "google-genai==2.5.0",
     "limits[redis]==5.8.0",
     "psycopg2-binary==2.9.12",
+    "pysocks==1.7.1",
     "pytelegrambotapi==4.33.0",
     "replicate==1.0.7",
-    "requests[socks]==2.34.2",
     "sentry-sdk==2.60.0",
     "sqlalchemy==2.0.49",
     "tavily-python==0.7.24",

--- a/src/config.py
+++ b/src/config.py
@@ -142,12 +142,6 @@ TAVILY_API_KEY = os.environ["TAVILY_API_KEY"]
 tavily_client = TavilyClient(api_key=TAVILY_API_KEY)
 
 
-# Headers for requests https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome
-headers: dict[str, str | bytes] = {
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",  # noqa: E501
-}
-
-
 # Rate limits
 MINUTE_LIMIT_KEY = "RPM"
 DAILY_LIMIT_KEY = "RPD"

--- a/src/download.py
+++ b/src/download.py
@@ -4,10 +4,11 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-import requests
 from bs4 import BeautifulSoup
-from requests.exceptions import ConnectionError as RequestsConnectionError
-from requests.exceptions import SSLError
+from curl_cffi import requests
+from curl_cffi.requests.exceptions import ConnectionError as RequestsConnectionError
+from curl_cffi.requests.exceptions import HTTPError, SSLError
+from curl_cffi.requests.utils import requote_uri
 from tenacity import (
     before_sleep_log,
     retry,
@@ -18,7 +19,7 @@ from tenacity import (
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
-from config import TG_API_TOKEN, headers
+from config import TG_API_TOKEN
 from services import choose_yt_audio_format
 from utils import generate_temporary_name, get_proxy
 
@@ -93,22 +94,25 @@ def _stream_to_file(
     timeout: int = 120,
 ) -> None:
     """GET `url` and stream the body to `dest` in 8KB chunks."""
-    with requests.get(
+    r = requests.get(
         url,
         stream=True,
-        headers=headers,
+        impersonate="chrome",
         verify=True,
         timeout=timeout,
-    ) as r:
+    )
+    try:
         try:
             r.raise_for_status()
-        except requests.exceptions.HTTPError:
+        except HTTPError:
             logger.exception("%s: status code", r.status_code)
             raise
         with Path(dest).open("wb") as f:
             for chunk in r.iter_content(chunk_size=8192):
                 if chunk:
                     f.write(chunk)
+    finally:
+        r.close()
 
 
 @retry(
@@ -144,7 +148,12 @@ def download_castro(url: str) -> str:
     temporary_file_name = generate_temporary_name(ext=".mp3")
     logger.debug("Parsing URL...")
     soup = BeautifulSoup(
-        requests.get(requests.utils.requote_uri(url), verify=True, timeout=30).content,
+        requests.get(
+            requote_uri(url),
+            impersonate="chrome",
+            verify=True,
+            timeout=30,
+        ).content,
         "html.parser",
     )
     source_tag = soup.source
@@ -159,7 +168,7 @@ def download_castro(url: str) -> str:
         msg = "Audio URL is not a string."
         raise TypeError(msg)
     logger.debug("URL parsed! Starting download...")
-    _stream_to_file(requests.utils.requote_uri(audio_url), temporary_file_name)
+    _stream_to_file(requote_uri(audio_url), temporary_file_name)
     logger.debug("File downloaded...")
     return temporary_file_name
 

--- a/src/download.py
+++ b/src/download.py
@@ -147,15 +147,17 @@ def download_castro(url: str) -> str:
     """
     temporary_file_name = generate_temporary_name(ext=".mp3")
     logger.debug("Parsing URL...")
-    soup = BeautifulSoup(
-        requests.get(
-            requote_uri(url),
-            impersonate="chrome",
-            verify=True,
-            timeout=30,
-        ).content,
-        "html.parser",
+    response = requests.get(
+        requote_uri(url),
+        impersonate="chrome",
+        verify=True,
+        timeout=30,
     )
+    try:
+        response.raise_for_status()
+        soup = BeautifulSoup(response.content, "html.parser")
+    finally:
+        response.close()
     source_tag = soup.source
     if source_tag is None:
         msg = "Audio source tag not found in Castro page."

--- a/src/summary.py
+++ b/src/summary.py
@@ -4,6 +4,7 @@ import logging
 from textwrap import dedent
 from typing import TYPE_CHECKING, cast
 
+from curl_cffi.requests.exceptions import ConnectionError as CurlConnectionError
 from curl_cffi.requests.exceptions import SSLError as CurlSSLError
 from google.genai import types
 from google.genai.errors import ClientError, ServerError
@@ -250,7 +251,14 @@ def summarize_webpage(
     stop=stop_after_attempt(2),
     wait=wait_fixed(30),
     retry=retry_if_exception_type(
-        (ServerError, AttributeError, ClientError, SSLError, CurlSSLError),
+        (
+            ServerError,
+            AttributeError,
+            ClientError,
+            SSLError,
+            CurlSSLError,
+            CurlConnectionError,
+        ),
     ),
     before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
     reraise=False,

--- a/src/summary.py
+++ b/src/summary.py
@@ -4,6 +4,7 @@ import logging
 from textwrap import dedent
 from typing import TYPE_CHECKING, cast
 
+from curl_cffi.requests.exceptions import SSLError as CurlSSLError
 from google.genai import types
 from google.genai.errors import ClientError, ServerError
 from requests.exceptions import SSLError
@@ -249,7 +250,7 @@ def summarize_webpage(
     stop=stop_after_attempt(2),
     wait=wait_fixed(30),
     retry=retry_if_exception_type(
-        (ServerError, AttributeError, ClientError, SSLError),
+        (ServerError, AttributeError, ClientError, SSLError, CurlSSLError),
     ),
     before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
     reraise=False,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -252,6 +252,22 @@ def test_download_castro_http_error(mocker):
     mock_logger.exception.assert_called_once_with("%s: status code", 500)
 
 
+def test_download_castro_page_http_error(mocker):
+    """Test download_castro surfaces an HTTP error from the page fetch."""
+    mock_page_resp = mocker.MagicMock()
+    mock_page_resp.raise_for_status.side_effect = HTTPError("404 Not Found")
+
+    mock_get = mocker.patch("download.requests.get", return_value=mock_page_resp)
+    mocker.patch("download.requote_uri", side_effect=lambda x: x)
+
+    with pytest.raises(HTTPError):
+        download_castro("https://castro.fm/episode/123")
+
+    # Only the page fetch happens; the audio download is never reached.
+    mock_get.assert_called_once()
+    mock_page_resp.close.assert_called_once()
+
+
 def test_download_tg_http_error(mocker):
     """Test download_tg logs status code and re-raises HTTPError."""
     mocker.patch("download.TG_API_TOKEN", "TEST_TOKEN")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-import requests
+from curl_cffi.requests.exceptions import HTTPError
 
 from download import download_castro, download_tg, download_yt
 from services import choose_yt_audio_format
@@ -13,7 +13,6 @@ def test_download_tg_happy_path(mocker):
     mock_resp = mocker.MagicMock()
     mock_resp.iter_content.return_value = [b"test ", b"content"]
     mock_resp.status_code = 200
-    mock_resp.__enter__.return_value = mock_resp
     mock_get = mocker.patch("download.requests.get", return_value=mock_resp)
 
     # Mock generate_temporary_name to return a fixed name
@@ -31,12 +30,13 @@ def test_download_tg_happy_path(mocker):
     mock_get.assert_called_once_with(
         "https://api.telegram.org/file/botTEST_TOKEN/path/to/file",
         stream=True,
-        headers=mocker.ANY,
+        impersonate="chrome",
         verify=True,
         timeout=120,
     )
     mock_resp.iter_content.assert_called_once_with(chunk_size=8192)
     mock_resp.raise_for_status.assert_called_once()
+    mock_resp.close.assert_called_once()
     mock_path_open.assert_called_once_with("wb")
     mock_path_open().write.assert_has_calls(
         [
@@ -53,7 +53,6 @@ def test_download_tg_skips_empty_chunks(mocker):
     mock_resp = mocker.MagicMock()
     mock_resp.iter_content.return_value = [b"", b"data", b""]
     mock_resp.status_code = 200
-    mock_resp.__enter__.return_value = mock_resp
     mocker.patch("download.requests.get", return_value=mock_resp)
     mocker.patch("download.generate_temporary_name", return_value="temp_file.ext")
 
@@ -174,9 +173,8 @@ def test_download_castro_happy_path(mocker):
     mock_audio_resp.status_code = 200
 
     # Side effect for the two requests.get calls
-    mock_audio_resp.__enter__.return_value = mock_audio_resp
     mocker.patch("download.requests.get", side_effect=[mock_page_resp, mock_audio_resp])
-    mocker.patch("download.requests.utils.requote_uri", side_effect=lambda x: x)
+    mocker.patch("download.requote_uri", side_effect=lambda x: x)
 
     # Mock Path.open
     mock_path_open = mocker.patch("pathlib.Path.open", mocker.mock_open())
@@ -200,7 +198,7 @@ def test_download_castro_missing_source_tag(mocker):
     mock_page_resp = mocker.MagicMock()
     mock_page_resp.content = b"<html><body>No source here</body></html>"
     mocker.patch("download.requests.get", return_value=mock_page_resp)
-    mocker.patch("download.requests.utils.requote_uri", side_effect=lambda x: x)
+    mocker.patch("download.requote_uri", side_effect=lambda x: x)
 
     with pytest.raises(ValueError, match="Audio source tag not found in Castro page."):
         download_castro("https://castro.fm/episode/123")
@@ -210,7 +208,7 @@ def test_download_castro_missing_audio_url(mocker):
     mock_page_resp = mocker.MagicMock()
     mock_page_resp.content = b"<html><source></html>"
     mocker.patch("download.requests.get", return_value=mock_page_resp)
-    mocker.patch("download.requests.utils.requote_uri", side_effect=lambda x: x)
+    mocker.patch("download.requote_uri", side_effect=lambda x: x)
 
     with pytest.raises(ValueError, match="Audio URL not found in Castro page."):
         download_castro("https://castro.fm/episode/123")
@@ -221,7 +219,7 @@ def test_download_castro_non_string_audio_url(mocker):
     mock_page_resp = mocker.MagicMock()
     mock_page_resp.content = b'<html><source src="a.mp3 b.mp3"></html>'
     mocker.patch("download.requests.get", return_value=mock_page_resp)
-    mocker.patch("download.requests.utils.requote_uri", side_effect=lambda x: x)
+    mocker.patch("download.requote_uri", side_effect=lambda x: x)
 
     mock_source = mocker.MagicMock()
     mock_source.get.return_value = ["a.mp3", "b.mp3"]
@@ -242,14 +240,13 @@ def test_download_castro_http_error(mocker):
 
     mock_audio_resp = mocker.MagicMock()
     mock_audio_resp.status_code = 500
-    mock_audio_resp.__enter__.return_value = mock_audio_resp
-    mock_audio_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("500 Server Error")
+    mock_audio_resp.raise_for_status.side_effect = HTTPError("500 Server Error")
 
     mocker.patch("download.requests.get", side_effect=[mock_page_resp, mock_audio_resp])
-    mocker.patch("download.requests.utils.requote_uri", side_effect=lambda x: x)
+    mocker.patch("download.requote_uri", side_effect=lambda x: x)
     mock_logger = mocker.patch("download.logger")
 
-    with pytest.raises(requests.exceptions.HTTPError):
+    with pytest.raises(HTTPError):
         download_castro("https://castro.fm/episode/123")
 
     mock_logger.exception.assert_called_once_with("%s: status code", 500)
@@ -265,12 +262,11 @@ def test_download_tg_http_error(mocker):
 
     mock_resp = mocker.MagicMock()
     mock_resp.status_code = 403
-    mock_resp.__enter__.return_value = mock_resp
-    mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("403 Forbidden")
+    mock_resp.raise_for_status.side_effect = HTTPError("403 Forbidden")
     mocker.patch("download.requests.get", return_value=mock_resp)
     mock_logger = mocker.patch("download.logger")
 
-    with pytest.raises(requests.exceptions.HTTPError):
+    with pytest.raises(HTTPError):
         download_tg(mock_file, ext=".ext")
 
     mock_logger.exception.assert_called_once_with("%s: status code", 403)

--- a/uv.lock
+++ b/uv.lock
@@ -12,12 +12,13 @@ version = "0.12.0"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "curl-cffi" },
     { name = "google-genai" },
     { name = "limits", extra = ["redis"] },
     { name = "psycopg2-binary" },
+    { name = "pysocks" },
     { name = "pytelegrambotapi" },
     { name = "replicate" },
-    { name = "requests", extra = ["socks"] },
     { name = "sentry-sdk" },
     { name = "sqlalchemy" },
     { name = "tavily-python" },
@@ -55,12 +56,13 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.14.3" },
+    { name = "curl-cffi", specifier = "==0.14.0" },
     { name = "google-genai", specifier = "==2.5.0" },
     { name = "limits", extras = ["redis"], specifier = "==5.8.0" },
     { name = "psycopg2-binary", specifier = "==2.9.12" },
+    { name = "pysocks", specifier = "==1.7.1" },
     { name = "pytelegrambotapi", specifier = "==4.33.0" },
     { name = "replicate", specifier = "==1.0.7" },
-    { name = "requests", extras = ["socks"], specifier = "==2.34.2" },
     { name = "sentry-sdk", specifier = "==2.60.0" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
     { name = "tavily-python", specifier = "==0.7.24" },
@@ -1425,11 +1427,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[package.optional-dependencies]
-socks = [
-    { name = "pysocks" },
 ]
 
 [[package]]


### PR DESCRIPTION
## **User description**
## Summary
- Switch `src/download.py` HTTP paths (`download_castro`, `download_tg` via `_stream_to_file`) from `requests` to **curl_cffi** with browser TLS-fingerprint impersonation (`impersonate="chrome"`) instead of a hand-set `User-Agent`, improving resilience against bot blocking. `download_yt` (yt-dlp) is unaffected.
- Drop the direct `requests[socks]` dependency and add **`pysocks`** directly. `requests` remains installed transitively (google-genai, pytelegrambotapi, tavily-python, tiktoken, youtube-transcript-api), and PySocks keeps socks-proxy support for `youtube_transcript_api`, which routes proxies through `requests`. curl_cffi handles socks natively for downloads.
- Use `curl_cffi.requests.utils.requote_uri` and curl_cffi exception types in `download.py`.
- Remove the now-unused `headers` User-Agent dict from `config.py`.
- `summarize_with_document` retry now catches **both** `requests.SSLError` (Gemini upload) and curl_cffi `SSLError` (it wraps `download_tg`).

## Why
Browser impersonation provides a realistic TLS/HTTP fingerprint (not just a UA string), which is harder for hosts to block than the previous static header.

## Reviewer notes
- `requests.exceptions` imports in `services.py` (`ReadTimeout` ← telebot) and `transcription.py` (`ProxyError/SSLError/ChunkedEncodingError` ← youtube_transcript_api) are intentionally left as-is — those libraries raise them and still use `requests`.
- curl_cffi's `Response` is **not** a context manager, so `_stream_to_file` now streams via explicit `try/finally` + `r.close()` (the `r =` assignment is outside the `try`, so a failure in `requests.get` can't trigger an unbound-`r` close).
- Verified against curl_cffi 0.14.0: `Response.close()` exists, module-level `get(stream=True)` streams correctly, and `impersonate="chrome"` is a valid alias that applies a real Chrome UA.

## Test plan
- [x] `ruff format .`
- [x] `ruff check .`
- [x] `ty check .`
- [x] `uv run pytest` (202 passed)
- [x] (optional, needs network) exercise a real Castro episode URL end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use browser-style downloading to reduce blocks and keep retries working**

### What Changed
- Downloads from Castro and Telegram now use browser-like request behavior, which helps them load more reliably when sites block simple download traffic.
- Downloaded files are still streamed to disk in chunks, and failed HTTP responses are logged and returned as errors as before.
- Document summaries now retry after both regular upload SSL failures and download SSL failures, so temporary connection issues are less likely to stop the flow.
- The app no longer relies on the old shared browser header setting, and it keeps proxy support for transcript downloads through a direct dependency change.

### Impact
`✅ Fewer download blocks`
`✅ Fewer failed podcast and Telegram imports`
`✅ Fewer summary failures after temporary SSL errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated network-related dependencies and HTTP client used by the app.
* **Bug Fixes**
  * Improved download reliability and error handling for network requests and retries.
* **Tests**
  * Adjusted tests to reflect updated network behavior and ensure proper resource cleanup.
* **Documentation**
  * Updated README docs to reflect the revised networking libraries and usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->