### PR TITLE
fix(transcription): prefer original-language subtitles over translated English in yt-dlp path

### DIFF
--- a/src/transcription.py
+++ b/src/transcription.py
@@ -135,10 +135,12 @@ def fetch_transcript_via_api(video_id: str) -> str:
     before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
     reraise=False,
 )
-def fetch_transcript_via_ytdlp(url: str) -> str:
+def fetch_transcript_via_ytdlp(url: str) -> str:  # noqa: C901, PLR0912, PLR0915
     """Retrieve a YouTube transcript by downloading subtitles via yt-dlp.
 
-    Probes available tracks first, prefers English, converts to vtt via ffmpeg.
+    Probes available tracks first, preferring genuine manual subtitles (English
+    when present) and otherwise the video's original-language automatic captions,
+    then converts to vtt via ffmpeg.
 
     Args:
         url (str): The YouTube video URL.
@@ -185,15 +187,32 @@ def fetch_transcript_via_ytdlp(url: str) -> str:
 
     manual = info.get("subtitles") or {}
     auto = info.get("automatic_captions") or {}
-    available = list(dict.fromkeys([*manual.keys(), *auto.keys()]))
 
-    if not available:
+    # yt-dlp lists "live_chat" under subtitles for live-stream replays; it is not a
+    # real subtitle track and cannot be converted to vtt, so drop it.
+    manual_langs = [lang for lang in manual if lang != "live_chat"]
+
+    if manual_langs:
+        # Human-uploaded tracks are genuine: prefer English, else the first offered.
+        en_manual = next((lang for lang in manual_langs if lang.startswith("en")), None)
+        chosen_langs = [en_manual or manual_langs[0]]
+    elif auto:
+        # automatic_captions include machine translations for ~every language, so an
+        # "en" key here is usually a translation, not a real track — request the
+        # video's original language and let the summarizer translate.
+        orig = info.get("language")
+        if orig and orig in auto:
+            chosen_langs = [orig]
+        else:
+            chosen_langs = [
+                next(
+                    (lang for lang in auto if lang.endswith("-orig")),
+                    next(iter(auto)),
+                ),
+            ]
+    else:
         msg = "No subtitles available via yt-dlp"
         raise DownloadError(msg)
-
-    chosen_langs = (
-        ["en.*"] if any(lang.startswith("en") for lang in available) else [available[0]]
-    )
 
     ydl_opts: dict[str, Any] = {
         "proxy": proxy,

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -193,9 +193,13 @@ def fetch_transcript_via_ytdlp(url: str) -> str:  # noqa: C901, PLR0912, PLR0915
     manual_langs = [lang for lang in manual if lang != "live_chat"]
 
     if manual_langs:
-        # Human-uploaded tracks are genuine: prefer English, else the first offered.
+        # Human-uploaded tracks are genuine: prefer English, then the video's original
+        # language, then the first offered key.
         en_manual = next((lang for lang in manual_langs if lang.startswith("en")), None)
-        chosen_langs = [en_manual or manual_langs[0]]
+        orig = info.get("language")
+        chosen_langs = [
+            en_manual or (orig if orig in manual_langs else manual_langs[0]),
+        ]
     elif auto:
         # automatic_captions include machine translations for ~every language, so an
         # "en" key here is usually a translation, not a real track — request the

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -551,6 +551,56 @@ def test_fetch_transcript_via_ytdlp_prefers_english_when_available(mocker, tmp_p
     assert download_calls == [["en"]]
 
 
+def test_fetch_transcript_via_ytdlp_manual_prefers_original_language_over_first_key(
+    mocker,
+    tmp_path,
+):
+    """Test manual-subtitle branch prefers info['language'] when no English track exists.
+
+    When a video has multiple manual subtitle languages but none is English, the
+    selection should prefer the video's original language (info['language']) rather
+    than the first dict key (which is insertion-order dependent).
+    """
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.clean_up")
+
+    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nGuten Tag\n"
+    vtt_path = tmp_path / "fake-uuid.de.vtt"
+    download_calls: list[list[str]] = []
+
+    class MockYDL:
+        def __init__(self, opts: object) -> None:
+            self.opts = opts
+
+        def __enter__(self) -> "MockYDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool = True) -> dict:
+            # "fr" comes first in the dict, but the video's original language is "de"
+            return {
+                "subtitles": {"fr": [{}], "de": [{}]},
+                "automatic_captions": {},
+                "language": "de",
+            }
+
+        def download(self, url_list: list[str]) -> int:
+            langs = self.opts.get("subtitleslangs", [])
+            download_calls.append(langs)
+            vtt_path.write_text(vtt_content, encoding="utf-8")
+            return 0
+
+    mocker.patch("transcription.YoutubeDL", MockYDL)
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+
+    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert result == "Guten Tag"
+    assert download_calls == [["de"]]
+
+
 def test_fetch_transcript_via_ytdlp_auto_captions_uses_original_language(
     mocker,
     tmp_path,
@@ -598,6 +648,102 @@ def test_fetch_transcript_via_ytdlp_auto_captions_uses_original_language(
 
     assert result == "Bonjour"
     assert download_calls == [["fr"]]
+
+
+def test_fetch_transcript_via_ytdlp_auto_captions_prefers_orig_key_when_language_missing(
+    mocker,
+    tmp_path,
+):
+    """Test auto-captions branch picks the *-orig key when info['language'] is absent.
+
+    When no info['language'] is available (or it isn't in auto) but a '*-orig' key
+    exists in automatic_captions, that key should be preferred over the first dict key.
+    """
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.clean_up")
+
+    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHallo\n"
+    vtt_path = tmp_path / "fake-uuid.de-orig.vtt"
+    download_calls: list[list[str]] = []
+
+    class MockYDL:
+        def __init__(self, opts: object) -> None:
+            self.opts = opts
+
+        def __enter__(self) -> "MockYDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool = True) -> dict:
+            # no 'language' key; auto has a '*-orig' key that should be preferred
+            return {
+                "subtitles": {},
+                "automatic_captions": {"en": [{}], "de-orig": [{}], "fr": [{}]},
+            }
+
+        def download(self, url_list: list[str]) -> int:
+            langs = self.opts.get("subtitleslangs", [])
+            download_calls.append(langs)
+            vtt_path.write_text(vtt_content, encoding="utf-8")
+            return 0
+
+    mocker.patch("transcription.YoutubeDL", MockYDL)
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+
+    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert result == "Hallo"
+    assert download_calls == [["de-orig"]]
+
+
+def test_fetch_transcript_via_ytdlp_auto_captions_falls_back_to_first_key(
+    mocker,
+    tmp_path,
+):
+    """Test auto-captions branch falls back to first key when no language or *-orig key.
+
+    When info['language'] is absent and no '*-orig' key exists in automatic_captions,
+    the first key in the dict is used as a last resort.
+    """
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.clean_up")
+
+    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHola\n"
+    vtt_path = tmp_path / "fake-uuid.es.vtt"
+    download_calls: list[list[str]] = []
+
+    class MockYDL:
+        def __init__(self, opts: object) -> None:
+            self.opts = opts
+
+        def __enter__(self) -> "MockYDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool = True) -> dict:
+            # no 'language' key, no '*-orig' key → must fall back to first key ("es")
+            return {
+                "subtitles": {},
+                "automatic_captions": {"es": [{}], "fr": [{}]},
+            }
+
+        def download(self, url_list: list[str]) -> int:
+            langs = self.opts.get("subtitleslangs", [])
+            download_calls.append(langs)
+            vtt_path.write_text(vtt_content, encoding="utf-8")
+            return 0
+
+    mocker.patch("transcription.YoutubeDL", MockYDL)
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+
+    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert result == "Hola"
+    assert download_calls == [["es"]]
 
 
 def test_fetch_transcript_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_path):

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -548,7 +548,102 @@ def test_fetch_transcript_via_ytdlp_prefers_english_when_available(mocker, tmp_p
     result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
 
     assert result == "Hello"
-    assert download_calls == [["en.*"]]
+    assert download_calls == [["en"]]
+
+
+def test_fetch_transcript_via_ytdlp_auto_captions_uses_original_language(
+    mocker,
+    tmp_path,
+):
+    """Test fetch_transcript_via_ytdlp requests the original language, not translated English.
+
+    automatic_captions list machine translations (incl. "en") for ~every language,
+    so for a non-English video with no manual subs we must request the original
+    language (info["language"]) rather than the translated "en" track.
+    """
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.clean_up")
+
+    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
+    vtt_path = tmp_path / "fake-uuid.fr.vtt"
+    download_calls: list[list[str]] = []
+
+    class MockYDL:
+        def __init__(self, opts: object) -> None:
+            self.opts = opts
+
+        def __enter__(self) -> "MockYDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool = True) -> dict:
+            return {
+                "subtitles": {},
+                "automatic_captions": {"en": [{}], "fr": [{}]},
+                "language": "fr",
+            }
+
+        def download(self, url_list: list[str]) -> int:
+            langs = self.opts.get("subtitleslangs", [])
+            download_calls.append(langs)
+            vtt_path.write_text(vtt_content, encoding="utf-8")
+            return 0
+
+    mocker.patch("transcription.YoutubeDL", MockYDL)
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+
+    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert result == "Bonjour"
+    assert download_calls == [["fr"]]
+
+
+def test_fetch_transcript_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_path):
+    """Test fetch_transcript_via_ytdlp skips the "live_chat" subtitles entry.
+
+    yt-dlp lists a "live_chat" key under subtitles for live-stream replays; it is
+    not a real subtitle track. It must be ignored so selection falls through to the
+    video's original-language automatic captions rather than requesting "live_chat".
+    """
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.clean_up")
+
+    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
+    vtt_path = tmp_path / "fake-uuid.fr.vtt"
+    download_calls: list[list[str]] = []
+
+    class MockYDL:
+        def __init__(self, opts: object) -> None:
+            self.opts = opts
+
+        def __enter__(self) -> "MockYDL":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool = True) -> dict:
+            return {
+                "subtitles": {"live_chat": [{}]},
+                "automatic_captions": {"fr": [{}]},
+                "language": "fr",
+            }
+
+        def download(self, url_list: list[str]) -> int:
+            langs = self.opts.get("subtitleslangs", [])
+            download_calls.append(langs)
+            vtt_path.write_text(vtt_content, encoding="utf-8")
+            return 0
+
+    mocker.patch("transcription.YoutubeDL", MockYDL)
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+
+    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert result == "Bonjour"
+    assert download_calls == [["fr"]]
 
 
 def test_fetch_transcript_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path):


### PR DESCRIPTION
## What

Fixes `fetch_transcript_via_ytdlp` in `src/transcription.py` to select subtitle tracks correctly, avoiding HTTP 429 errors on non-English videos.

## Why

YouTube's `automatic_captions` always lists machine-translated tracks for ~100 languages (including `en`, `en-US`, `en-orig`) regardless of the video's real language. The old code merged `subtitles` and `automatic_captions` into one flat list, then forced `["en.*"]` whenever any `en*` key appeared. For non-English videos this always hit — causing yt-dlp to request a translated-English timedtext track, the `en.*` wildcard expanding to several `en` variants, multiple timedtext requests, and HTTP 429. The 429 was retried once after 10s (still rate-limited), then raised `RetryError`, triggering a fallback to a full audio download + WhisperX.

Root cause confirmed via production logs: video `censored` (no genuine English subtitles) hit 429 twice then fell back to audio.

## New selection logic

Priority order:
1. **Manual (human-uploaded) subtitles** — genuine tracks. Prefer an English key; else the first offered key. The `live_chat` pseudo-track (populated by yt-dlp for live-stream VODs but not a real subtitle) is filtered out before selection so it can't block fallthrough to auto-captions.
2. **Automatic captions only** — request the video's **original** language (`info["language"]` → key ending in `-orig` → first key), never a translation. The Gemini summarizer handles target-language translation.
3. **Neither present** — `DownloadError` (unchanged).

## Tests

- Updated `test_fetch_transcript_via_ytdlp_prefers_english_when_available`: expects `[["en"]]` (was `[["en.*"]]`) for manual subtitles with both `en` and `fr`.
- Added `test_fetch_transcript_via_ytdlp_auto_captions_uses_original_language`: non-English video, auto-captions only, `language="fr"` → requests `["fr"]`, not `["en"]`.
- Added `test_fetch_transcript_via_ytdlp_ignores_live_chat_pseudo_track`: `subtitles={"live_chat": ...}` → falls through to original-language auto-captions.

All existing tests continue to pass (205 total).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subtitle-language selection for transcript downloads: prefer manual subtitles (English if available), otherwise prefer original-language automatic captions, with clearer fallbacks and proper handling when no subtitles exist.

* **Tests**
  * Expanded test coverage for subtitle selection logic, including manual vs automatic preference, original-language selection, live-chat exclusion, and fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->