### PR TITLE
fix(parsing): retry tavily.errors.TimeoutError in parse_url (STG-124)

### DIFF
--- a/src/parsing.py
+++ b/src/parsing.py
@@ -43,8 +43,8 @@ def parse_url(url: str) -> str:
     Raises:
         WebParseError: If Tavily returns no successful results or empty content.
         RetryError: If Tavily keeps timing out after all retry attempts. The
-            function is decorated with @retry and retries TavilyTimeoutError up
-            to 2 times with a 5-second wait before raising RetryError.
+            function is decorated with @retry and makes 2 total attempts (1
+            retry with a 5-second wait) before raising RetryError.
 
     """
     response = tavily_client.extract(urls=[url], format="markdown")

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -25,8 +25,8 @@ tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 
 @retry(
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(10),
+    stop=stop_after_attempt(2),
+    wait=wait_fixed(5),
     retry=retry_if_exception_type(TavilyTimeoutError),
     before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
     reraise=False,
@@ -44,7 +44,7 @@ def parse_url(url: str) -> str:
         WebParseError: If Tavily returns no successful results or empty content.
         RetryError: If Tavily keeps timing out after all retry attempts. The
             function is decorated with @retry and retries TavilyTimeoutError up
-            to 3 times with a 10-second wait before raising RetryError.
+            to 2 times with a 5-second wait before raising RetryError.
 
     """
     response = tavily_client.extract(urls=[url], format="markdown")

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -1,13 +1,36 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING, cast
+
+from tavily.errors import TimeoutError as TavilyTimeoutError
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_fixed,
+)
 
 from config import tavily_client
 from exceptions import WebParseError
 
+if TYPE_CHECKING:
+    from tenacity import (
+        _utils as tenacity_utils,
+    )
+
 logger = logging.getLogger(__name__)
+tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(10),
+    retry=retry_if_exception_type(TavilyTimeoutError),
+    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+    reraise=False,
+)
 def parse_url(url: str) -> str:
     """Extract main textual content from a URL using Tavily.
 
@@ -19,6 +42,9 @@ def parse_url(url: str) -> str:
 
     Raises:
         WebParseError: If Tavily returns no successful results or empty content.
+        RetryError: If Tavily keeps timing out after all retry attempts. The
+            function is decorated with @retry and retries TavilyTimeoutError up
+            to 3 times with a 10-second wait before raising RetryError.
 
     """
     response = tavily_client.extract(urls=[url], format="markdown")

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -90,4 +90,4 @@ def test_parse_url_raises_retry_error_when_timeout_persists(mocker):
     with pytest.raises(RetryError):
         parse_url("https://example.com")
 
-    assert mock_client.extract.call_count == 3
+    assert mock_client.extract.call_count == 2

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,4 +1,6 @@
 import pytest
+from tavily.errors import TimeoutError as TavilyTimeoutError
+from tenacity import RetryError
 
 from exceptions import WebParseError
 from parsing import parse_url
@@ -45,10 +47,47 @@ def test_parse_url_raises_on_empty_raw_content(mocker):
         parse_url("https://example.com")
 
 
-def test_parse_url_propagates_tavily_exception(mocker):
-    """parse_url lets Tavily exceptions propagate (no retry wrapper)."""
+def test_parse_url_propagates_non_retryable_exception(mocker):
+    """parse_url lets non-retryable Tavily exceptions propagate immediately.
+
+    Only TavilyTimeoutError is retried; other exceptions are not.
+    """
     mock_client = mocker.patch("parsing.tavily_client")
     mock_client.extract.side_effect = RuntimeError("boom")
 
     with pytest.raises(RuntimeError, match="boom"):
         parse_url("https://example.com")
+
+    mock_client.extract.assert_called_once()
+
+
+def test_parse_url_retries_on_timeout_then_succeeds(mocker):
+    """parse_url retries a TavilyTimeoutError and returns content on success."""
+    mocker.patch("time.sleep")
+    mock_client = mocker.patch("parsing.tavily_client")
+    mock_client.extract.side_effect = [
+        TavilyTimeoutError("Request timed out after 30 seconds."),
+        {
+            "results": [
+                {"url": "https://example.com", "raw_content": "Hello world."},
+            ],
+            "failed_results": [],
+        },
+    ]
+
+    assert parse_url("https://example.com") == "Hello world."
+    assert mock_client.extract.call_count == 2
+
+
+def test_parse_url_raises_retry_error_when_timeout_persists(mocker):
+    """parse_url raises RetryError when TavilyTimeoutError keeps occurring."""
+    mocker.patch("time.sleep")
+    mock_client = mocker.patch("parsing.tavily_client")
+    mock_client.extract.side_effect = TavilyTimeoutError(
+        "Request timed out after 30 seconds.",
+    )
+
+    with pytest.raises(RetryError):
+        parse_url("https://example.com")
+
+    assert mock_client.extract.call_count == 3


### PR DESCRIPTION
## **User description**
## Summary

- `parse_url` in `src/parsing.py` had no retry wrapper; a transient `tavily.errors.TimeoutError` ("Request timed out after 30 seconds.") propagated unhandled to Sentry (issue STG-124 / AI-SUMMARIZER-TELEGRAM-BOT-5C).
- Added a `@retry` decorator: `stop_after_attempt(3)`, `wait_fixed(10)`, retrying only `tavily.errors.TimeoutError`; `reraise=False` so exhaustion raises `RetryError`, which `handle_message` already catches gracefully.
- `tavily.errors.TimeoutError` is a custom exception (subclasses `Exception` directly, unrelated to the builtin `TimeoutError`), imported aliased as `TavilyTimeoutError` to avoid shadowing.

## Test plan

- [x] `test_parse_url_retries_on_timeout_then_succeeds` — retries on `TavilyTimeoutError`, returns content on second call
- [x] `test_parse_url_raises_retry_error_when_timeout_persists` — exhausts all 3 attempts, raises `RetryError`
- [x] `test_parse_url_propagates_non_retryable_exception` — non-timeout errors propagate immediately (not retried)
- [x] Full suite: 210 passed

Closes STG-124.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URL parsing now automatically retries on timeout errors (2 attempts with a short delay), reducing transient failures and improving success rates; retry attempts are recorded in logs.
* **Tests**
  * Added tests confirming retry-then-success behavior, that persistent timeouts surface as a retry failure, and that non-timeout errors continue to propagate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasiliadi/ai-summarizer-telegram-bot/pull/807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Retry Tavily timeouts during URL parsing**

### What Changed
- URL parsing now retries transient Tavily timeout errors instead of failing immediately
- If Tavily keeps timing out after 3 attempts, the failure surfaces as a retry error instead of an unhandled exception
- Added tests for successful retry, repeated timeout failure, and non-retryable errors

### Impact
`✅ Fewer failed page parses from temporary Tavily timeouts`
`✅ Fewer unhandled timeout errors`
`✅ Clearer retry behavior for URL extraction`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
