### PR TITLE
fix(handlers): reply with user-friendly message on WebParseError

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,7 +34,7 @@ from database import (
     toggle_transcription,
     toggle_yt_transcription,
 )
-from exceptions import LimitExceededError
+from exceptions import LimitExceededError, WebParseError
 from handlers import (
     handle_audio,
     handle_document,
@@ -528,6 +528,7 @@ def handle_message(message: Message) -> None:
     Raises:
         LimitExceededError: When user exceeds daily limit
         RetryError: When multiple processing attempts fail
+        WebParseError: When a webpage URL cannot be parsed
         Exception: For any other unexpected errors
 
     Returns:
@@ -549,6 +550,12 @@ def handle_message(message: Message) -> None:
     except LimitExceededError as e:
         capture_exception(e)
         bot.reply_to(message, "Daily limit has been exceeded, try again tomorrow.")
+    except WebParseError as e:
+        capture_exception(e)
+        bot.reply_to(
+            message,
+            "Check provided URL, looks like the page is not available.",
+        )
     except RetryError as e:
         capture_exception(e)
         bot.reply_to(

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,7 +1,7 @@
 from telebot import types
 from tenacity import RetryError
 
-from exceptions import LimitExceededError
+from exceptions import LimitExceededError, WebParseError
 from main import handle_message, process_message_content
 
 
@@ -390,6 +390,24 @@ def test_handle_message_retry_error(message_factory, mocker):
     mock_reply.assert_called_once_with(
         msg,
         "An error occurred during execution. Please try again in 10 minutes.",
+    )
+
+
+def test_handle_message_web_parse_error(message_factory, mocker):
+    """Test handle_message when a webpage URL cannot be parsed."""
+    msg = message_factory(content_type="text", text="http://example.com/dead")
+    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
+    mocker.patch(
+        "main.process_message_content",
+        side_effect=WebParseError("Tavily could not extract content"),
+    )
+    mock_reply = mocker.patch("main.bot.reply_to")
+
+    handle_message(msg)
+
+    mock_reply.assert_called_once_with(
+        msg,
+        "Check provided URL, looks like the page is not available.",
     )
 
 


### PR DESCRIPTION
## **User description**
## What

Catch `WebParseError` explicitly in `handle_message` and reply with an actionable message instead of letting it fall through to the generic `except Exception` handler.

## Why

When a user sends a URL to a dead or unavailable page, `parse_url` raises `WebParseError` (e.g. "Tavily could not extract content from …"). Previously this hit the catch-all branch, showing the user `"Unexpected: WebParseError"` and logging it to Sentry as a crash. This is a user-side condition (bad URL), not a bug.

Fixes Sentry issue AI-SUMMARIZER-TELEGRAM-BOT-5D / Linear STG-125.

## Changes

- `src/main.py` — import `WebParseError`; add `except WebParseError` branch before `except RetryError` (calls `capture_exception` + replies `"Check provided URL, looks like the page is not available."`)
- `tests/test_handlers.py` — `test_handle_message_web_parse_error` mirroring the existing `test_handle_message_limit_exceeded` pattern

## Test

207 passed (was 206, +1 new test). All pre-commit hooks passed.


___

## **CodeAnt-AI Description**
Handle unavailable webpage links with a clear message

### What Changed
- When a webpage link cannot be parsed because the page is unavailable, the bot now replies with a direct, user-friendly message instead of treating it like an unexpected crash
- The error is still logged, but users no longer see a generic failure for this case
- Added a test to confirm the bot returns the new message for an unparseable webpage link

### Impact
`✅ Clearer URL error messages`
`✅ Fewer confusing crash-like replies`
`✅ Better coverage for broken-link handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for web content extraction to gracefully manage failures with clear, user-friendly error messages when pages are unavailable or their content cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->