### PR TITLE
ci(renovate): automerge all github-actions update types

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -83,9 +83,8 @@
       "automerge": true
     },
     {
-      "description": "github-actions minor bumps: safe to auto-merge (digests are pinned)",
+      "description": "github-actions: auto-merge all update types (digests are pinned)",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Summary

- Removes the `matchUpdateTypes: ["minor"]` restriction from the `github-actions` Renovate rule
- All update types (major, minor, patch, pin, digest) for GitHub Actions will now be auto-merged
- Safe because the repo pins action versions to SHA digests via `helpers:pinGitHubActionDigests`

## Why

The previous rule only auto-merged minor bumps (added in #815). Since digests are pinned, all update types carry the same safety guarantee and there's no reason to hold major/patch/digest bumps for manual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependency update automation to apply auto-merge across all update types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->