### PR TITLE
refactor(commands): remove /limit command in favor of /myinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ docs/strategy
 docs/archive
 docs/summaries
 output/
+CLAUDE.local.md
 
 # pixi environments
 .pixi/*

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ toggle_transcription - Toggle transcription for summary (fallback on failure)
 toggle_yt_transcription - Toggle YouTube transcription
 set_thinking_level - Choose AI thinking level
 set_target_language - Choose which language you want to translate into
-limit - Show remaining limit
 myinfo - Show my settings
 ```
 

--- a/src/main.py
+++ b/src/main.py
@@ -156,36 +156,6 @@ def handle_myinfo(message: Message) -> None:
     bot.send_message(message.chat.id, msg)
 
 
-# /limit
-@bot.message_handler(
-    commands=["limit"],
-    func=lambda message: (
-        message.from_user is not None and check_auth(message.from_user.id)
-    ),
-)
-def handle_limit(message: Message) -> None:
-    """Handle the /limit command for the bot.
-
-    This function checks the user's remaining daily limit and sends a message
-    with the remaining count. It ensures that the user is authenticated before
-    performing the check.
-
-    Args:
-        message (Message): The message object from Telegram containing user information
-                           and chat details.
-
-    Returns:
-        None
-
-    """
-    if message.from_user is None:
-        return
-    user = select_user(message.from_user.id)
-    remaining = get_remaining_quota(user.user_id, user.daily_limit)
-    msg = f"Remaining limit: {remaining}"
-    bot.send_message(message.chat.id, msg)
-
-
 # /toggle_transcription
 @bot.message_handler(
     commands=["toggle_transcription"],

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,5 @@
 from main import (
     handle_info,
-    handle_limit,
     handle_myinfo,
     handle_set_prompt_strategy,
     handle_set_summarizing_model,
@@ -114,30 +113,6 @@ def test_handle_myinfo_missing_user(message_factory, mocker):
     handle_myinfo(msg)
 
     mock_reply.assert_called_once_with(msg, "User information is missing.")
-
-
-def test_handle_limit(message_factory, mocker):
-    """Test /limit command."""
-    msg = message_factory(content_type="text", text="/limit")
-    mock_user = mocker.MagicMock(user_id=123, daily_limit=20)
-    mocker.patch("main.select_user", return_value=mock_user)
-    mocker.patch("main.get_remaining_quota", return_value=15)
-    mock_send = mocker.patch("main.bot.send_message")
-
-    handle_limit(msg)
-
-    assert "Remaining limit: 15" in mock_send.call_args[0][1]
-
-
-def test_handle_limit_missing_user(message_factory, mocker):
-    """Test /limit silently returns when Telegram user metadata is absent."""
-    msg = message_factory(content_type="text", text="/limit")
-    msg.from_user = None
-    mock_select = mocker.patch("main.select_user")
-
-    handle_limit(msg)
-
-    mock_select.assert_not_called()
 
 
 def test_handle_toggle_transcription(message_factory, mocker):


### PR DESCRIPTION
## **User description**
## Summary

- Removes the `/limit` command from `src/main.py` (handler + decorator)
- Removes the `limit - Show remaining limit` entry from the BotFather command list in `README.md`
- Removes the two corresponding tests (`test_handle_limit`, `test_handle_limit_missing_user`) from `tests/test_commands.py`

## Why

`/limit` only reported the remaining daily quota — the same value already shown as `Remaining quota:` in the `/myinfo` output. Having two commands return overlapping information adds unnecessary surface area. All 205 tests pass.

## Notes for reviewer

- `get_remaining_quota` import in `src/main.py` is retained — still used by `handle_myinfo`.
- The live BotFather command list should be updated separately to drop `/limit` (Telegram-side change, outside the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove the duplicate `/limit` command and keep quota details in `/myinfo`**

### What Changed
- Removed the `/limit` command from the bot, so users now check remaining quota from `/myinfo` instead
- Updated the command list shown in the README to no longer advertise `/limit`
- Removed the `/limit` test coverage that is no longer needed

### Impact
`✅ Fewer duplicate commands`
`✅ Clearer bot command list`
`✅ Quota details available in one place`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `/limit` command that displayed remaining daily quota for authenticated users.

* **Documentation**
  * Updated command reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->