### PR TITLE
fix(parsing): log warnings in _parse_with_exa before raising WebParseError

### DIFF
--- a/src/parsing.py
+++ b/src/parsing.py
@@ -80,10 +80,12 @@ def _parse_with_exa(url: str) -> str:
     results = result.results or []
     if not results:
         msg = f"Exa could not extract content from {url}"
+        logger.warning(msg)
         raise WebParseError(msg)
     content = (results[0].text or "").strip()
     if not content:
         msg = f"Exa returned empty content for {url}"
+        logger.warning(msg)
         raise WebParseError(msg)
     return content
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from tavily.errors import TimeoutError as TavilyTimeoutError
 from tenacity import RetryError
@@ -107,24 +109,26 @@ def test_parse_url_exa_returns_text(mocker):
     )
 
 
-def test_parse_url_exa_raises_when_no_results(mocker):
+def test_parse_url_exa_raises_when_no_results(mocker, caplog):
     """parse_url(backend="exa") raises WebParseError when Exa returns no results."""
     mock_client = mocker.patch("parsing.exa_client")
     mock_client.get_contents.return_value = mocker.Mock(results=[])
 
-    with pytest.raises(WebParseError):
+    with caplog.at_level(logging.WARNING, logger="parsing"), pytest.raises(WebParseError):
         parse_url("https://example.com", backend="exa")
+    assert "Exa could not extract content from" in caplog.text
 
 
-def test_parse_url_exa_raises_on_empty_text(mocker):
+def test_parse_url_exa_raises_on_empty_text(mocker, caplog):
     """parse_url(backend="exa") raises WebParseError when text is empty/whitespace."""
     mock_client = mocker.patch("parsing.exa_client")
     mock_client.get_contents.return_value = mocker.Mock(
         results=[mocker.Mock(text="   ")],
     )
 
-    with pytest.raises(WebParseError):
+    with caplog.at_level(logging.WARNING, logger="parsing"), pytest.raises(WebParseError):
         parse_url("https://example.com", backend="exa")
+    assert "Exa returned empty content for" in caplog.text
 
 
 def test_parse_url_raises_on_unknown_backend():


### PR DESCRIPTION
## **User description**
## Summary

- Added `logger.warning(msg)` before each `raise WebParseError` in `_parse_with_exa` (no-results path and empty-content path)
- Updated the two existing Exa error-path tests with `caplog` assertions to verify the warnings are emitted

## Why

`WebParseError` raised in `_parse_with_exa` propagates through `handle_url` and reaches Sentry with some delay. The pre-raise log lines provide immediate local/stdout visibility into Exa failures without waiting on Sentry.

## Reviewer notes

- The Tavily backend does not get the same treatment — it's out of scope for this PR but could be a follow-up.
- Log level is `warning`, matching the dominant convention elsewhere in the codebase (`transcription.py`, `summary.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show Exa parsing failures in logs before the error is raised**

### What Changed
- Exa parsing failures now write a warning message before returning an error when no content is found or when the content is empty
- Tests now check that both Exa failure paths still raise an error and also produce the expected warning message

### Impact
`✅ Faster visibility into parsing failures`
`✅ Clearer error logs for empty-page results`
`✅ Easier debugging of Exa extraction issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
