### PR TITLE
refactor(parsing): standardize variable naming and warning logging across backends

### DIFF
--- a/src/parsing.py
+++ b/src/parsing.py
@@ -52,10 +52,12 @@ def _parse_with_tavily(url: str) -> str:
     if not results:
         failed = response.get("failed_results") or []
         msg = f"Tavily could not extract content from {url}: {failed}"
+        logger.warning(msg)
         raise WebParseError(msg)
     content = (results[0].get("raw_content") or "").strip()
     if not content:
         msg = f"Tavily returned empty content for {url}"
+        logger.warning(msg)
         raise WebParseError(msg)
     return content
 
@@ -73,11 +75,11 @@ def _parse_with_exa(url: str) -> str:
         WebParseError: If Exa returns no results or empty content.
 
     """
-    result = exa_client.get_contents(
+    response = exa_client.get_contents(
         urls=[url],
         text={"max_characters": 20000, "include_html_tags": True},
     )
-    results = result.results or []
+    results = response.results or []
     if not results:
         msg = f"Exa could not extract content from {url}"
         logger.warning(msg)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -25,7 +25,7 @@ def test_parse_url_returns_raw_content(mocker):
     )
 
 
-def test_parse_url_raises_when_no_results(mocker):
+def test_parse_url_raises_when_no_results(mocker, caplog):
     """parse_url raises WebParseError when Tavily returns no successful results."""
     mock_client = mocker.patch("parsing.tavily_client")
     mock_client.extract.return_value = {
@@ -33,11 +33,12 @@ def test_parse_url_raises_when_no_results(mocker):
         "failed_results": [{"url": "https://example.com", "error": "not found"}],
     }
 
-    with pytest.raises(WebParseError):
+    with caplog.at_level(logging.WARNING, logger="parsing"), pytest.raises(WebParseError):
         parse_url("https://example.com")
+    assert "Tavily could not extract content from" in caplog.text
 
 
-def test_parse_url_raises_on_empty_raw_content(mocker):
+def test_parse_url_raises_on_empty_raw_content(mocker, caplog):
     """parse_url raises WebParseError when raw_content is empty/whitespace."""
     mock_client = mocker.patch("parsing.tavily_client")
     mock_client.extract.return_value = {
@@ -45,8 +46,9 @@ def test_parse_url_raises_on_empty_raw_content(mocker):
         "failed_results": [],
     }
 
-    with pytest.raises(WebParseError):
+    with caplog.at_level(logging.WARNING, logger="parsing"), pytest.raises(WebParseError):
         parse_url("https://example.com")
+    assert "Tavily returned empty content for" in caplog.text
 
 
 def test_parse_url_propagates_non_retryable_exception(mocker):


### PR DESCRIPTION
## **User description**
## What changed

- Renamed `result` → `response` in `_parse_with_exa` so both private functions use the same local name for the raw API return value.
- Added `logger.warning(msg)` before each `raise WebParseError` in `_parse_with_tavily`, matching the logging pattern already established for `_parse_with_exa` in #823.
- Updated the two Tavily error-path tests to assert the new warning logs via `caplog`, mirroring the existing Exa tests.

## Why

`_parse_with_tavily` and `_parse_with_exa` diverged in naming and logging style. This aligns them to the same shape:

```python
response = <backend call>
results  = <response results> or []
if not results:
    msg = ...
    logger.warning(msg)
    raise WebParseError(msg)
content = (<first result field> or "").strip()
if not content:
    msg = ...
    logger.warning(msg)
    raise WebParseError(msg)
return content
```

The access mechanism (`.get()` for Tavily's `dict` vs attribute access for Exa's typed `SearchResponse`) intentionally differs — it is idiomatic to each SDK's return type.

## Notes for reviewer

No behavioral change; purely naming and logging consistency. All 10 parsing tests pass and the pre-commit gate (ruff format, ruff check, ty check, pytest) is clean.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


___

## **CodeAnt-AI Description**
Log parsing failures before they are returned to the caller

### What Changed
- When Tavily cannot extract content or returns empty content, the error is now logged before the failure is raised
- Exa and Tavily parsing paths now follow the same naming and error-reporting pattern
- Tests now verify the warning logs for Tavily failure cases

### Impact
`✅ Clearer parsing error logs`
`✅ Easier troubleshooting for failed page extraction`
`✅ Consistent failure reporting across parsing backends`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added warning logs before raising parsing errors when data retrieval fails or returns empty content.

* **Tests**
  * Extended test coverage to capture and verify warning messages emitted during parsing failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->