### PR TITLE
fix(parsing): add retry to _parse_with_exa for transient empty results

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,20 +17,16 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    # uv version.
     rev: 0.11.16
     hooks:
       - id: uv-lock
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: v0.15.15
     hooks:
-      # Run the linter.
       - id: ruff-check
         args: [--fix]
         files: ^src/
-      # Run the formatter.
       - id: ruff-format
         files: ^src/
 

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -62,6 +62,13 @@ def _parse_with_tavily(url: str) -> str:
     return content
 
 
+@retry(
+    stop=stop_after_attempt(2),
+    wait=wait_fixed(5),
+    retry=retry_if_exception_type(WebParseError),
+    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+    reraise=True,
+)
 def _parse_with_exa(url: str) -> str:
     """Extract main textual content from a URL using Exa.ai.
 
@@ -72,7 +79,11 @@ def _parse_with_exa(url: str) -> str:
         str: The extracted page content as text (HTML tags included).
 
     Raises:
-        WebParseError: If Exa returns no results or empty content.
+        WebParseError: If Exa returns no results or empty content. Exa's
+            get_contents is intermittent and may return an empty result for a
+            URL it can normally extract, so the function is decorated with
+            @retry and makes 2 total attempts (1 retry with a 5-second wait)
+            before re-raising WebParseError.
 
     """
     response = exa_client.get_contents(

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -113,16 +113,19 @@ def test_parse_url_exa_returns_text(mocker):
 
 def test_parse_url_exa_raises_when_no_results(mocker, caplog):
     """parse_url(backend="exa") raises WebParseError when Exa returns no results."""
+    mocker.patch("time.sleep")
     mock_client = mocker.patch("parsing.exa_client")
     mock_client.get_contents.return_value = mocker.Mock(results=[])
 
     with caplog.at_level(logging.WARNING, logger="parsing"), pytest.raises(WebParseError):
         parse_url("https://example.com", backend="exa")
     assert "Exa could not extract content from" in caplog.text
+    assert mock_client.get_contents.call_count == 2
 
 
 def test_parse_url_exa_raises_on_empty_text(mocker, caplog):
     """parse_url(backend="exa") raises WebParseError when text is empty/whitespace."""
+    mocker.patch("time.sleep")
     mock_client = mocker.patch("parsing.exa_client")
     mock_client.get_contents.return_value = mocker.Mock(
         results=[mocker.Mock(text="   ")],
@@ -131,6 +134,20 @@ def test_parse_url_exa_raises_on_empty_text(mocker, caplog):
     with caplog.at_level(logging.WARNING, logger="parsing"), pytest.raises(WebParseError):
         parse_url("https://example.com", backend="exa")
     assert "Exa returned empty content for" in caplog.text
+    assert mock_client.get_contents.call_count == 2
+
+
+def test_parse_url_exa_retries_empty_then_succeeds(mocker):
+    """parse_url(backend="exa") retries a transient empty result then returns content."""
+    mocker.patch("time.sleep")
+    mock_client = mocker.patch("parsing.exa_client")
+    mock_client.get_contents.side_effect = [
+        mocker.Mock(results=[]),
+        mocker.Mock(results=[mocker.Mock(text="Hello world.")]),
+    ]
+
+    assert parse_url("https://example.com", backend="exa") == "Hello world."
+    assert mock_client.get_contents.call_count == 2
 
 
 def test_parse_url_raises_on_unknown_backend():


### PR DESCRIPTION
## **User description**
## Summary

- `_parse_with_exa` now retries once (5s wait) before re-raising `WebParseError`, matching the existing retry budget of `_parse_with_tavily`
- Fixes Sentry issue: Exa's `get_contents` intermittently returns an empty `results` array for URLs it can normally extract, causing immediate `WebParseError` with no recovery attempt
- `reraise=True` preserves the existing `WebParseError` contract for callers — no new `RetryError` path is introduced for Exa

## Changes

**`src/parsing.py`** — added `@retry` decorator to `_parse_with_exa`:
```python
@retry(
    stop=stop_after_attempt(2),
    wait=wait_fixed(5),
    retry=retry_if_exception_type(WebParseError),
    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
    reraise=True,
)
```
No new imports needed — all tenacity symbols were already imported for the Tavily backend.

**`tests/test_parsing.py`** — two updated tests + one new test:
- Patched `time.sleep` on the two existing empty-result failure tests; asserted `call_count == 2`
- New `test_parse_url_exa_retries_empty_then_succeeds` covers the transient-failure-then-success path

## Test plan

- [x] All 206 tests pass (`uv run pytest`)
- [x] Test suite finishes fast — `time.sleep` is patched, no real sleeping
- [x] `ruff format`, `ruff check`, `ty check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Retry Exa parsing when it returns an empty result once**

### What Changed
- Exa URL parsing now tries again after a temporary empty response before failing
- If Exa still cannot extract content, it raises the same parsing error as before
- Tests now cover both the retry-and-succeed path and the repeated failure cases

### Impact
`✅ Fewer parse failures from flaky Exa responses`
`✅ More successful article extraction on retry`
`✅ Clearer handling of temporary empty results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the retry mechanism for web content parsing to improve error handling. The system now retries on parsing errors and properly propagates exceptions when content retrieval fails.

* **Documentation**
  * Expanded documentation to clarify that content extraction services may intermittently return empty results and explain the automatic retry behavior used.

* **Chores**
  * Cleaned up pre-commit configuration file formatting and removed unnecessary comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->