### PR TITLE
refactor(transcription): add backend fallback, retry transient errors, simplify error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,7 @@ docs/archive
 docs/summaries
 output/
 CLAUDE.local.md
+AGENTS.override.md
 
 # pixi environments
 .pixi/*

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -8,3 +8,11 @@ class WebParseError(Exception):
 
 class TranscriptDownloadError(Exception):
     """Exception raised when yt-dlp transiently fails to fetch subtitles."""
+
+
+class FetchTranscriptViaApiError(Exception):
+    """Exception raised when the API transcript backend fails."""
+
+
+class FetchTranscriptViaYtdlpError(Exception):
+    """Exception raised when the yt-dlp transcript backend fails."""

--- a/src/summary.py
+++ b/src/summary.py
@@ -19,11 +19,10 @@ from tenacity import (
     stop_after_attempt,
     wait_fixed,
 )
-from youtube_transcript_api._errors import CouldNotRetrieveTranscript
-from yt_dlp.utils import DownloadError
 
 from config import gemini_client
 from download import download_castro, download_tg, download_yt
+from exceptions import FetchTranscriptViaApiError, FetchTranscriptViaYtdlpError
 from prompts import PROMPTS
 from services import (
     check_quota,
@@ -389,7 +388,8 @@ def summarize(
 
     Returns:
         str: Generated summary of the content, prefixed with:
-            - 📹 for YouTube transcript summaries
+            - 📹 for default-backend YouTube transcript summaries
+            - 📺 for fallback-backend YouTube transcript summaries
             - 📝 for fallback transcription summaries
             - No prefix for direct file summaries
 
@@ -414,11 +414,10 @@ def summarize(
         ):
             if use_yt_transcription:
                 try:
-                    transcript = get_yt_transcript(data)
+                    transcript_result = get_yt_transcript(data)
                 except (
-                    CouldNotRetrieveTranscript,
-                    RetryError,
-                    DownloadError,
+                    FetchTranscriptViaApiError,
+                    FetchTranscriptViaYtdlpError,
                     ValueError,
                 ) as e:
                     logger.warning(
@@ -427,9 +426,9 @@ def summarize(
                     )
                 else:
                     return format_prefixed_summary(
-                        "📹",
+                        transcript_result.prefix,
                         summarize_with_transcript(
-                            transcript=transcript,
+                            transcript=transcript_result.text,
                             model=model,
                             prompt_key=prompt_key,
                             target_language=target_language,

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -307,14 +307,11 @@ def _fetch_transcript(source: str, url: str, video_id: str) -> str:
         except Exception as e:
             msg = "API transcript backend failed"
             raise FetchTranscriptViaApiError(msg) from e
-    if source == "ytdlp":
-        try:
-            return fetch_transcript_via_ytdlp(url)
-        except Exception as e:
-            msg = "yt-dlp transcript backend failed"
-            raise FetchTranscriptViaYtdlpError(msg) from e
-    msg = f"Unknown transcript source: {source}"
-    raise ValueError(msg)
+    try:
+        return fetch_transcript_via_ytdlp(url)
+    except Exception as e:
+        msg = "yt-dlp transcript backend failed"
+        raise FetchTranscriptViaYtdlpError(msg) from e
 
 
 def get_yt_transcript(

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -27,7 +28,11 @@ from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
 from config import YT_TRANSCRIPT_SOURCE, replicate_client
-from exceptions import TranscriptDownloadError
+from exceptions import (
+    FetchTranscriptViaApiError,
+    FetchTranscriptViaYtdlpError,
+    TranscriptDownloadError,
+)
 from utils import (
     clean_up,
     extract_youtube_video_id,
@@ -43,6 +48,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
+
+
+@dataclass(frozen=True)
+class TranscriptResult:
+    """Transcript text with the display prefix for the source that succeeded."""
+
+    text: str
+    prefix: str
 
 
 @retry(
@@ -92,7 +105,16 @@ def transcribe(file: str, sleep_time: int = 10) -> str:
 @retry(
     stop=stop_after_attempt(2),
     wait=wait_fixed(10),
-    retry=retry_if_exception_type((ParseError, IpBlocked, RequestBlocked)),
+    retry=retry_if_exception_type(
+        (
+            ParseError,
+            IpBlocked,
+            RequestBlocked,
+            ProxyError,
+            SSLError,
+            ChunkedEncodingError,
+        ),
+    ),
     before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
     reraise=False,
 )
@@ -109,7 +131,8 @@ def fetch_transcript_via_api(video_id: str) -> str:
         NoTranscriptFound: If no transcript is found in any language.
         CouldNotRetrieveTranscript: Subclasses (TranscriptsDisabled, VideoUnavailable,
             AgeRestricted, etc.) propagate to the caller.
-        RetryError: If IpBlocked, RequestBlocked, or ParseError persist after retries.
+        RetryError: If IpBlocked, RequestBlocked, ParseError, ProxyError, SSLError,
+            or ChunkedEncodingError persist after retries.
 
     """
     proxy = get_proxy()
@@ -271,25 +294,37 @@ def fetch_transcript_via_ytdlp(url: str) -> str:  # noqa: C901, PLR0912, PLR0915
             clean_up(file=str(f))
 
 
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(10),
-    retry=retry_if_exception_type(
-        (
-            ProxyError,
-            SSLError,
-            ChunkedEncodingError,
-        ),
-    ),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def get_yt_transcript(url: str, source: str = YT_TRANSCRIPT_SOURCE) -> str:
+def _fallback_source(source: str) -> str:
+    if source == "api":
+        return "ytdlp"
+    return "api"
+
+
+def _fetch_transcript(source: str, url: str, video_id: str) -> str:
+    if source == "api":
+        try:
+            return fetch_transcript_via_api(video_id)
+        except Exception as e:
+            msg = "API transcript backend failed"
+            raise FetchTranscriptViaApiError(msg) from e
+    if source == "ytdlp":
+        try:
+            return fetch_transcript_via_ytdlp(url)
+        except Exception as e:
+            msg = "yt-dlp transcript backend failed"
+            raise FetchTranscriptViaYtdlpError(msg) from e
+    msg = f"Unknown transcript source: {source}"
+    raise ValueError(msg)
+
+
+def get_yt_transcript(
+    url: str,
+    source: str = YT_TRANSCRIPT_SOURCE,
+) -> TranscriptResult:
     """Retrieve and format the transcript from a YouTube video URL.
 
-    Dispatches to a single transcript backend based on `source`; there is no
-    fallback between backends. Transient transport errors (proxy/SSL/network)
-    are retried up to 3 times before raising RetryError.
+    Dispatches to the configured transcript backend first and tries the other
+    backend as a fallback when retrieval fails.
 
     Args:
         url (str): The YouTube video URL.
@@ -297,29 +332,44 @@ def get_yt_transcript(url: str, source: str = YT_TRANSCRIPT_SOURCE) -> str:
             (youtube_transcript_api) or "ytdlp" (yt-dlp subtitle download).
 
     Returns:
-        str: The formatted transcript text from the video.
+        TranscriptResult: The transcript text and display prefix. The 📹
+            prefix means the configured backend succeeded; 📺 means the
+            fallback backend succeeded.
 
     Raises:
         ValueError: If the URL format is not recognized, or if `source` is not
             a known backend.
-        NoTranscriptFound: If the API backend cannot find a transcript.
-        CouldNotRetrieveTranscript: Subclasses raised by the API backend
-            (TranscriptsDisabled, VideoUnavailable, AgeRestricted, etc.).
-        DownloadError: If the yt-dlp backend cannot fetch subtitles.
-        RetryError: If proxy/SSL/network errors persist after all retry attempts,
-            if API-internal retries (IpBlocked/RequestBlocked/ParseError) are
-            exhausted, or if the yt-dlp backend's TranscriptDownloadError
-            retries are exhausted.
+        FetchTranscriptViaApiError: If the API backend fails and is the final
+            attempted backend.
+        FetchTranscriptViaYtdlpError: If the yt-dlp backend fails and is the
+            final attempted backend.
 
     """
+    if source not in {"api", "ytdlp"}:
+        msg = f"Unknown transcript source: {source}"
+        raise ValueError(msg)
+
     video_id = extract_youtube_video_id(url)
     if video_id is None:
         msg = "Unknown URL"
         raise ValueError(msg)
 
-    if source == "api":
-        return fetch_transcript_via_api(video_id)
-    if source == "ytdlp":
-        return fetch_transcript_via_ytdlp(url)
-    msg = f"Unknown transcript source: {source}"
-    raise ValueError(msg)
+    try:
+        text = _fetch_transcript(source, url, video_id)
+    except (FetchTranscriptViaApiError, FetchTranscriptViaYtdlpError) as primary_error:
+        fallback = _fallback_source(source)
+        logger.warning(
+            "Transcript backend %s failed, falling back to %s: %s",
+            source,
+            fallback,
+            primary_error,
+        )
+        try:
+            text = _fetch_transcript(fallback, url, video_id)
+        except (
+            FetchTranscriptViaApiError,
+            FetchTranscriptViaYtdlpError,
+        ) as fallback_error:
+            raise fallback_error from primary_error
+        return TranscriptResult(text=text, prefix="📺")
+    return TranscriptResult(text=text, prefix="📹")

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -370,6 +370,11 @@ def get_yt_transcript(
             FetchTranscriptViaApiError,
             FetchTranscriptViaYtdlpError,
         ) as fallback_error:
+            logger.warning(
+                "Fallback backend %s also failed: %s",
+                fallback,
+                fallback_error,
+            )
             raise fallback_error from primary_error
         return TranscriptResult(text=text, prefix="📺")
     return TranscriptResult(text=text, prefix="📹")

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -3,8 +3,8 @@ from types import SimpleNamespace
 import pytest
 from google.genai.errors import ClientError
 from tenacity import RetryError
-from youtube_transcript_api._errors import NoTranscriptFound, TranscriptsDisabled
 
+from exceptions import FetchTranscriptViaApiError, FetchTranscriptViaYtdlpError
 from services import resolve_mime_type
 from summary import (
     format_prefixed_summary,
@@ -297,7 +297,10 @@ def test_summarize_youtube_direct_transcript(mocker):
     """Test summarize() using direct YouTube transcript (📹 prefix)."""
     url = "https://youtube.com/watch?v=123"
     mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.get_yt_transcript", return_value="YT Transcript content")
+    mocker.patch(
+        "summary.get_yt_transcript",
+        return_value=SimpleNamespace(text="YT Transcript content", prefix="📹"),
+    )
     mock_sum_transcript = mocker.patch(
         "summary.summarize_with_transcript",
         return_value="- first point\n- second point",
@@ -332,7 +335,10 @@ def test_summarize_youtube_direct_transcript_uses_blank_line_separator(mocker):
     """Test YouTube transcript summaries keep a blank line after the prefix."""
     url = "https://youtube.com/watch?v=123"
     mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.get_yt_transcript", return_value="YT Transcript content")
+    mocker.patch(
+        "summary.get_yt_transcript",
+        return_value=SimpleNamespace(text="YT Transcript content", prefix="📹"),
+    )
     mocker.patch(
         "summary.summarize_with_transcript",
         return_value="- first point\n- second point",
@@ -353,12 +359,43 @@ def test_summarize_youtube_direct_transcript_uses_blank_line_separator(mocker):
     assert result == "📹\n\n- first point\n- second point"
 
 
+def test_summarize_youtube_fallback_transcript_uses_fallback_prefix(mocker):
+    """Test fallback YouTube transcript summaries use the 📺 prefix."""
+    url = "https://youtube.com/watch?v=123"
+    mocker.patch("summary.check_quota", return_value=True)
+    mocker.patch(
+        "summary.get_yt_transcript",
+        return_value=SimpleNamespace(text="YT Transcript content", prefix="📺"),
+    )
+    mocker.patch(
+        "summary.summarize_with_transcript",
+        return_value="- first point\n- second point",
+    )
+
+    result = summarize(
+        data=url,
+        use_transcription=True,
+        model="test-model",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        user_id=123,
+        daily_limit=10,
+        thinking_level="MINIMAL",
+        use_yt_transcription=True,
+    )
+
+    assert result == "📺\n\n- first point\n- second point"
+
+
 def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
     """Test transcript summary retry errors do not trigger audio fallback paths."""
     url = "https://youtube.com/watch?v=123"
     retry_error = RetryError(mocker.MagicMock())
     mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.get_yt_transcript", return_value="YT Transcript content")
+    mocker.patch(
+        "summary.get_yt_transcript",
+        return_value=SimpleNamespace(text="YT Transcript content", prefix="📹"),
+    )
     mock_download = mocker.patch("summary.download_yt")
     mock_file_summary = mocker.patch("summary.summarize_with_file")
     mock_transcribe = mocker.patch("summary.transcribe")
@@ -386,7 +423,10 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(mocker):
     """Test summarize() falls back to downloading YouTube audio when transcript fetch fails."""
     url = "https://youtube.com/watch?v=123"
     mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.get_yt_transcript", side_effect=TranscriptsDisabled("123"))
+    mocker.patch(
+        "summary.get_yt_transcript",
+        side_effect=FetchTranscriptViaApiError("api failed"),
+    )
     mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
     mocker.patch("summary.summarize_with_file", return_value="File summary")
     mock_clean_up = mocker.patch("summary.clean_up")
@@ -413,44 +453,47 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(mocker):
     )
 
 
-def test_summarize_youtube_transcript_retry_error_falls_back_to_download(mocker):
-    """Test summarize() falls back to downloading YouTube audio when get_yt_transcript raises RetryError."""
-    url = "https://youtube.com/watch?v=123"
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.get_yt_transcript", side_effect=RetryError(mocker.MagicMock()))
-    mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
-    mocker.patch("summary.summarize_with_file", return_value="File summary")
-    mock_clean_up = mocker.patch("summary.clean_up")
-    mock_logger = mocker.patch("summary.logger")
-
-    result = summarize(
-        data=url,
-        use_transcription=True,
-        model="test-model",
-        prompt_key="basic_prompt_for_transcript",
-        target_language="English",
-        user_id=123,
-        daily_limit=10,
-        thinking_level="MINIMAL",
-        use_yt_transcription=True,
-    )
-
-    assert result == "File summary"
-    mock_download.assert_called_once_with(url)
-    mock_clean_up.assert_called_once_with(file="downloaded.ogg")
-    mock_logger.warning.assert_called_once_with(
-        "get_yt_transcript failed, falling back to download: %s",
-        mocker.ANY,
-    )
-
-
-def test_summarize_youtube_no_transcript_found_falls_back_to_download(mocker):
-    """Test summarize() falls back to audio when get_yt_transcript raises NoTranscriptFound."""
+def test_summarize_youtube_transcript_backend_error_falls_back_to_download(mocker):
+    """Test summarize() falls back to downloading YouTube audio on transcript backend failure."""
     url = "https://youtube.com/watch?v=123"
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch(
         "summary.get_yt_transcript",
-        side_effect=NoTranscriptFound("123", "en", []),
+        side_effect=FetchTranscriptViaYtdlpError("ytdlp failed"),
+    )
+    mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
+    mocker.patch("summary.summarize_with_file", return_value="File summary")
+    mock_clean_up = mocker.patch("summary.clean_up")
+    mock_logger = mocker.patch("summary.logger")
+
+    result = summarize(
+        data=url,
+        use_transcription=True,
+        model="test-model",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        user_id=123,
+        daily_limit=10,
+        thinking_level="MINIMAL",
+        use_yt_transcription=True,
+    )
+
+    assert result == "File summary"
+    mock_download.assert_called_once_with(url)
+    mock_clean_up.assert_called_once_with(file="downloaded.ogg")
+    mock_logger.warning.assert_called_once_with(
+        "get_yt_transcript failed, falling back to download: %s",
+        mocker.ANY,
+    )
+
+
+def test_summarize_youtube_transcript_api_failure_falls_back_to_download(mocker):
+    """Test summarize() falls back to audio when the API transcript backend fails."""
+    url = "https://youtube.com/watch?v=123"
+    mocker.patch("summary.check_quota", return_value=True)
+    mocker.patch(
+        "summary.get_yt_transcript",
+        side_effect=FetchTranscriptViaApiError("api failed"),
     )
     mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
     mocker.patch("summary.summarize_with_file", return_value="File summary")

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -2,6 +2,7 @@ import textwrap
 
 import pytest
 from replicate.exceptions import ModelError
+from requests.exceptions import ChunkedEncodingError, ProxyError, SSLError
 from tenacity import RetryError
 from defusedxml.ElementTree import ParseError
 from youtube_transcript_api._errors import (
@@ -12,8 +13,13 @@ from youtube_transcript_api._errors import (
 )
 from yt_dlp.utils import DownloadError
 
-from exceptions import TranscriptDownloadError
+from exceptions import (
+    FetchTranscriptViaApiError,
+    FetchTranscriptViaYtdlpError,
+    TranscriptDownloadError,
+)
 from transcription import (
+    TranscriptResult,
     fetch_transcript_via_api,
     fetch_transcript_via_ytdlp,
     get_yt_transcript,
@@ -36,7 +42,7 @@ def test_get_yt_transcript_youtube_watch_url(mocker):
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     result = get_yt_transcript(url, source="api")
 
-    assert result == "Hello"
+    assert result == TranscriptResult(text="Hello", prefix="📹")
     mock_ytt.return_value.fetch.assert_called_once_with("dQw4w9WgXcQ")
 
 
@@ -51,7 +57,7 @@ def test_get_yt_transcript_youtu_be_url(mocker):
     url = "https://youtu.be/dQw4w9WgXcQ"
     result = get_yt_transcript(url, source="api")
 
-    assert result == "Hello short"
+    assert result == TranscriptResult(text="Hello short", prefix="📹")
     mock_ytt.return_value.fetch.assert_called_once_with("dQw4w9WgXcQ")
 
 
@@ -66,14 +72,20 @@ def test_get_yt_transcript_youtube_live_url(mocker):
     url = "https://www.youtube.com/live/dQw4w9WgXcQ"
     result = get_yt_transcript(url, source="api")
 
-    assert result == "Hello live"
+    assert result == TranscriptResult(text="Hello live", prefix="📹")
     mock_ytt.return_value.fetch.assert_called_once_with("dQw4w9WgXcQ")
 
 
-def test_get_yt_transcript_unknown_url():
+def test_get_yt_transcript_unknown_url(mocker):
     """Test get_yt_transcript raises ValueError for unknown URL formats."""
+    mock_api = mocker.patch("transcription.fetch_transcript_via_api")
+    mock_ytdlp = mocker.patch("transcription.fetch_transcript_via_ytdlp")
+
     with pytest.raises(ValueError, match="Unknown URL"):
         get_yt_transcript("https://example.com/not-youtube", source="api")
+
+    mock_api.assert_not_called()
+    mock_ytdlp.assert_not_called()
 
 
 def test_get_yt_transcript_fallback_languages(mocker):
@@ -96,7 +108,7 @@ def test_get_yt_transcript_fallback_languages(mocker):
     url = "https://youtu.be/dQw4w9WgXcQ"
     result = get_yt_transcript(url, source="api")
 
-    assert result == "Hola"
+    assert result == TranscriptResult(text="Hola", prefix="📹")
     # Verify it was called twice, once without languages, once with languages
     calls = mock_ytt.return_value.fetch.call_args_list
     assert calls[0].args == ("dQw4w9WgXcQ",)
@@ -130,47 +142,74 @@ def test_get_yt_transcript_source_ytdlp(mocker, tmp_path):
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     result = get_yt_transcript(url, source="ytdlp")
 
-    assert "Hello world" in result
+    assert "Hello world" in result.text
+    assert result.prefix == "📹"
     mock_ydl_inst.download.assert_called_once_with([url])
     mock_api.assert_not_called()
 
 
-def test_get_yt_transcript_source_api_does_not_fall_back(mocker):
-    """Test get_yt_transcript with source='api' propagates errors without falling back to yt-dlp."""
-    mocker.patch("time.sleep")
+def test_get_yt_transcript_source_api_falls_back_to_ytdlp(mocker):
+    """Test get_yt_transcript with source='api' falls back to yt-dlp."""
     mocker.patch(
         "transcription.fetch_transcript_via_api",
-        side_effect=RetryError(mocker.MagicMock()),
+        side_effect=TranscriptsDisabled("dQw4w9WgXcQ"),
     )
-    mock_ytdlp = mocker.patch("transcription.fetch_transcript_via_ytdlp")
+    mock_ytdlp = mocker.patch(
+        "transcription.fetch_transcript_via_ytdlp",
+        return_value="from fallback",
+    )
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-    with pytest.raises(RetryError):
-        get_yt_transcript(url, source="api")
+    result = get_yt_transcript(url, source="api")
 
-    mock_ytdlp.assert_not_called()
+    assert result == TranscriptResult(text="from fallback", prefix="📺")
+    mock_ytdlp.assert_called_once_with(url)
 
 
-def test_get_yt_transcript_source_ytdlp_does_not_fall_back(mocker):
-    """Test get_yt_transcript with source='ytdlp' propagates errors without falling back to the API."""
+def test_get_yt_transcript_source_ytdlp_falls_back_to_api(mocker):
+    """Test get_yt_transcript with source='ytdlp' falls back to the API."""
     mocker.patch(
         "transcription.fetch_transcript_via_ytdlp",
         side_effect=DownloadError("no subs"),
     )
-    mock_api = mocker.patch("transcription.fetch_transcript_via_api")
+    mock_api = mocker.patch(
+        "transcription.fetch_transcript_via_api",
+        return_value="from fallback",
+    )
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-    with pytest.raises(DownloadError):
-        get_yt_transcript(url, source="ytdlp")
+    result = get_yt_transcript(url, source="ytdlp")
 
-    mock_api.assert_not_called()
+    assert result == TranscriptResult(text="from fallback", prefix="📺")
+    mock_api.assert_called_once_with("dQw4w9WgXcQ")
 
 
-def test_get_yt_transcript_unknown_source_raises_value_error():
+def test_get_yt_transcript_source_fallback_failure_raises_fallback_error(mocker):
+    """Test get_yt_transcript raises fallback errors chained from primary failures."""
+    primary_error = TranscriptsDisabled("dQw4w9WgXcQ")
+    fallback_error = DownloadError("no subs")
+    mocker.patch("transcription.fetch_transcript_via_api", side_effect=primary_error)
+    mocker.patch("transcription.fetch_transcript_via_ytdlp", side_effect=fallback_error)
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    with pytest.raises(FetchTranscriptViaYtdlpError) as exc_info:
+        get_yt_transcript(url, source="api")
+
+    assert isinstance(exc_info.value.__cause__, FetchTranscriptViaApiError)
+    assert exc_info.value.__cause__.__cause__ is primary_error
+
+
+def test_get_yt_transcript_unknown_source_raises_value_error(mocker):
     """Test get_yt_transcript raises ValueError for an unknown source."""
+    mock_api = mocker.patch("transcription.fetch_transcript_via_api")
+    mock_ytdlp = mocker.patch("transcription.fetch_transcript_via_ytdlp")
+
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with pytest.raises(ValueError, match="Unknown transcript source"):
         get_yt_transcript(url, source="bogus")
+
+    mock_api.assert_not_called()
+    mock_ytdlp.assert_not_called()
 
 
 def test_get_yt_transcript_defaults_source_to_config(mocker):
@@ -184,7 +223,7 @@ def test_get_yt_transcript_defaults_source_to_config(mocker):
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     result = get_yt_transcript(url)
 
-    assert result == "from config"
+    assert result == TranscriptResult(text="from config", prefix="📹")
     mock_ytdlp.assert_called_once_with(url)
     mock_api.assert_not_called()
 
@@ -480,7 +519,17 @@ def test_fetch_transcript_via_api_propagates_non_retryable_error(mocker):
         fetch_transcript_via_api("vid")
 
 
-@pytest.mark.parametrize("exc", [IpBlocked("vid"), RequestBlocked("vid"), ParseError()])
+@pytest.mark.parametrize(
+    "exc",
+    [
+        IpBlocked("vid"),
+        RequestBlocked("vid"),
+        ParseError(),
+        ProxyError(),
+        SSLError(),
+        ChunkedEncodingError(),
+    ],
+)
 def test_fetch_transcript_via_api_retries_on_retryable_exception(mocker, exc):
     """Test fetch_transcript_via_api retries on each retryable exception then raises RetryError."""
     mocker.patch("time.sleep")


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Use the first working YouTube transcript source and show which source succeeded**

### What Changed
- YouTube transcript fetching now tries the configured source first, then falls back to the other source if that one fails.
- Successful transcript results now carry a visible prefix: 📹 for the configured source and 📺 for the fallback source.
- Transcript failures now keep both failure reasons in the logs when the fallback also fails.
- Summary output now uses the transcript prefix it received, so fallback-based YouTube summaries are clearly marked.
- Transcript backend failures are handled as backend errors instead of surfacing lower-level network errors directly.

### Impact
`✅ Fewer YouTube transcript failures`
`✅ Clearer source labels on transcript summaries`
`✅ Better logs for failed transcript lookups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcript retrieval now automatically falls back to an alternate source when the primary method fails, improving reliability.
  * Clearer visual distinction between directly fetched and fallback-sourced transcripts.

* **Bug Fixes**
  * Expanded retry and error-handling for transcript API requests to cover more network/proxy/SSL failure scenarios.

* **Tests**
  * Updated and added tests to validate fallback behavior, prefix formatting, and expanded error cases.

* **Chores**
  * Updated ignore patterns to exclude an additional override file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->