### PR TITLE
tests: cover 100% lines, fix ResourceWarnings, add --cov to pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         files: ^src/
       - id: pytest
         name: pytest
-        entry: uv run pytest
+        entry: uv run pytest --cov
         language: system
         pass_filenames: false
         always_run: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Before starting work, state: what you understand the project state to be, what y
 6. Do not bulk-read documents. Process one at a time: read, summarize to disk, release from context before reading next. For the detailed protocol, read `docs/context/processing-protocol.md`.
 7. Sub-agent returns must be structured (numbers, file paths, decisions, open items), not free-form prose. See `docs/context/subagent-rules.md`.
 8. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.
-9. Before every commit, pass: `uvx ruff format .`, `uvx ruff check .`, `uvx ty check .`, `uv run pytest`. See `docs/context/git-guide.md` for the full sequence.
+9. Before every commit, pass: `uvx ruff format .`, `uvx ruff check .`, `uvx ty check .`, `uv run pytest --cov`. Review the coverage report and do not introduce new uncovered lines. See `docs/context/git-guide.md` for the full sequence.
 10. When changing code, update or add tests in the same PR. Treat test maintenance as mandatory — skipping it is equivalent to skipping the pre-commit checks in Rule 9.
 
 ## Session Summary / Handoff Template

--- a/docs/context/git-guide.md
+++ b/docs/context/git-guide.md
@@ -43,6 +43,8 @@ All four checks also run automatically via pre-commit hooks. Still run them manu
 1. `uvx ruff format .`
 2. `uvx ruff check .`
 3. `uvx ty check .`
-4. `uv run pytest`
+4. `uv run pytest --cov`
+
+**Coverage:** The project is at 100% line coverage — keep it there by covering new or changed code in the same commit. There is no `--cov-fail-under` gate; review the report from step 4 manually and make sure your commit does not introduce new uncovered lines. CI separately uploads branch coverage to Codecov.
 
 **Workflow:** Run `uvx ruff format .` before committing to automatically format your code. Run `uvx ruff check --fix` to automatically resolve fixable linting errors.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,11 +7,23 @@ from database import (
     register_user,
     select_user,
     set_prompt_strategy,
+    set_summarizing_model,
     set_target_language,
     set_thinking_level,
     toggle_transcription,
+    toggle_yt_transcription,
 )
 from models import Base, UsersOrm
+
+
+@pytest.fixture
+def sqlite_session_factory(tmp_path):
+    """Provide an isolated SQLite session factory for integration-style tests."""
+    sqlite_path = tmp_path / "test-db.sqlite"
+    engine = create_engine(f"sqlite:///{sqlite_path}")
+    Base.metadata.create_all(engine)
+    yield sessionmaker(engine)
+    engine.dispose()
 
 
 def test_register_user_success(mock_db_session):
@@ -41,82 +53,158 @@ def test_select_user_missing(mock_db_session):
         select_user(999)
 
 
-def test_toggle_transcription_persists(monkeypatch, tmp_path):
+def test_toggle_transcription_persists(monkeypatch, sqlite_session_factory):
     """Test toggling transcription persists to a real SQLite database."""
-    session_factory = _sqlite_session_factory(tmp_path)
-    monkeypatch.setattr("database.Session", session_factory)
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
     register_user(123, "First", "Last", "user")
 
     toggle_transcription(123)
 
-    with session_factory() as session:
+    with sqlite_session_factory() as session:
         user = session.get(UsersOrm, 123)
         assert user is not None
         assert user.use_transcription is True
 
 
-def test_set_target_language_returns_false_for_missing_user(monkeypatch, tmp_path):
+def test_set_target_language_persists(monkeypatch, sqlite_session_factory):
+    """Test setting target language persists to a real SQLite database."""
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+    register_user(123, "First", "Last", "user")
+
+    result = set_target_language(123, "English")
+
+    assert result is True
+    with sqlite_session_factory() as session:
+        user = session.get(UsersOrm, 123)
+        assert user is not None
+        assert user.target_language == "English"
+
+
+def test_set_target_language_rejects_unsupported(monkeypatch, sqlite_session_factory):
+    """Test set_target_language returns False for unsupported languages."""
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+    register_user(123, "First", "Last", "user")
+
+    assert set_target_language(123, "Klingon") is False
+
+
+def test_set_target_language_returns_false_for_missing_user(
+    monkeypatch, sqlite_session_factory
+):
     """Test set_target_language returns False when the user does not exist."""
-    session_factory = _sqlite_session_factory(tmp_path)
-    monkeypatch.setattr("database.Session", session_factory)
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
 
     assert set_target_language(123, "English") is False
 
 
-def test_set_prompt_strategy_persists(monkeypatch, tmp_path):
+def test_toggle_yt_transcription_persists(monkeypatch, sqlite_session_factory):
+    """Test toggling YouTube transcription persists to a real SQLite database."""
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+    register_user(123, "First", "Last", "user")
+
+    toggle_yt_transcription(123)
+
+    with sqlite_session_factory() as session:
+        user = session.get(UsersOrm, 123)
+        assert user is not None
+        assert user.use_yt_transcription is True
+
+
+def test_toggle_yt_transcription_missing_user_is_noop(
+    monkeypatch, sqlite_session_factory
+):
+    """Test toggle_yt_transcription silently does nothing for unknown users."""
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+
+    toggle_yt_transcription(999)  # must not raise
+
+
+def test_set_summarizing_model_persists(monkeypatch, sqlite_session_factory):
+    """Test setting summarizing model persists to a real SQLite database."""
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+    register_user(123, "First", "Last", "user")
+
+    result = set_summarizing_model(123, "gemini-3.5-flash")
+
+    assert result is True
+    with sqlite_session_factory() as session:
+        user = session.get(UsersOrm, 123)
+        assert user is not None
+        assert user.summarizing_model == "gemini-3.5-flash"
+
+
+def test_set_summarizing_model_rejects_unknown(monkeypatch, sqlite_session_factory):
+    """Test set_summarizing_model returns False for unsupported models."""
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+    register_user(123, "First", "Last", "user")
+
+    assert set_summarizing_model(123, "gpt-4") is False
+
+
+def test_set_summarizing_model_missing_user(monkeypatch, sqlite_session_factory):
+    """Test set_summarizing_model returns False when the user does not exist."""
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+
+    assert set_summarizing_model(999, "gemini-3.5-flash") is False
+
+
+def test_set_prompt_strategy_persists(monkeypatch, sqlite_session_factory):
     """Test setting prompt strategy persists to a real SQLite database."""
-    session_factory = _sqlite_session_factory(tmp_path)
-    monkeypatch.setattr("database.Session", session_factory)
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
     register_user(123, "First", "Last", "user")
 
     result = set_prompt_strategy(123, "basic_prompt_for_transcript")
 
     assert result is True
-    with session_factory() as session:
+    with sqlite_session_factory() as session:
         user = session.get(UsersOrm, 123)
         assert user is not None
         assert user.prompt_key_for_summary == "basic_prompt_for_transcript"
 
 
-def test_set_thinking_level_persists(monkeypatch, tmp_path):
+def test_set_prompt_strategy_rejects_unknown(monkeypatch, sqlite_session_factory):
+    """Test set_prompt_strategy returns False for unsupported prompt keys."""
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+    register_user(123, "First", "Last", "user")
+
+    assert set_prompt_strategy(123, "bogus") is False
+
+
+def test_set_prompt_strategy_missing_user(monkeypatch, sqlite_session_factory):
+    """Test set_prompt_strategy returns False when the user does not exist."""
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+
+    assert set_prompt_strategy(999, "key_points_for_transcript") is False
+
+
+def test_set_thinking_level_persists(monkeypatch, sqlite_session_factory):
     """Test setting thinking level persists to a real SQLite database."""
-    session_factory = _sqlite_session_factory(tmp_path)
-    monkeypatch.setattr("database.Session", session_factory)
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
     register_user(123, "First", "Last", "user")
 
     result = set_thinking_level(123, "high")
 
     assert result is True
-    with session_factory() as session:
+    with sqlite_session_factory() as session:
         user = session.get(UsersOrm, 123)
         assert user is not None
         assert user.thinking_level == "HIGH"
 
 
-def test_set_thinking_level_rejects_unknown_value(monkeypatch, tmp_path):
+def test_set_thinking_level_rejects_unknown_value(monkeypatch, sqlite_session_factory):
     """Test set_thinking_level returns False for unsupported values."""
-    session_factory = _sqlite_session_factory(tmp_path)
-    monkeypatch.setattr("database.Session", session_factory)
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
     register_user(123, "First", "Last", "user")
 
     assert set_thinking_level(123, "bogus") is False
-    with session_factory() as session:
+    with sqlite_session_factory() as session:
         user = session.get(UsersOrm, 123)
         assert user is not None
         assert user.thinking_level == "MINIMAL"
 
 
-def test_set_thinking_level_missing_user(monkeypatch, tmp_path):
+def test_set_thinking_level_missing_user(monkeypatch, sqlite_session_factory):
     """Test set_thinking_level returns False when the user does not exist."""
-    session_factory = _sqlite_session_factory(tmp_path)
-    monkeypatch.setattr("database.Session", session_factory)
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
 
     assert set_thinking_level(999, "HIGH") is False
-
-
-def _sqlite_session_factory(tmp_path):
-    """Create an isolated SQLite session factory for integration-style tests."""
-    sqlite_path = tmp_path / "test-db.sqlite"
-    engine = create_engine(f"sqlite:///{sqlite_path}")
-    Base.metadata.create_all(engine)
-    return sessionmaker(engine)

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -926,3 +926,20 @@ def test_transcribe_null_output(mocker):
 
     with pytest.raises(ModelError):
         transcribe("test.ogg")
+
+
+def test_transcribe_invalid_segments_raises_model_error(mocker):
+    """Test transcribe raises ModelError when output segments is not a list."""
+    mock_replicate = mocker.patch("transcription.replicate_client")
+    mocker.patch("transcription.Path.open", mocker.mock_open())
+
+    mock_prediction = mocker.MagicMock()
+    mock_prediction.status = "succeeded"
+    mock_prediction.output = {"segments": "not-a-list"}
+    mock_replicate.predictions.create.return_value = mock_prediction
+    mock_replicate.models.get.return_value.versions.list.return_value = [
+        mocker.MagicMock(id="v1")
+    ]
+
+    with pytest.raises(ModelError):
+        transcribe("test.ogg")


### PR DESCRIPTION
## **User description**
## Summary

- **100% line coverage** — 10 new `test_database.py` tests covering `set_target_language`, `toggle_yt_transcription`, `set_summarizing_model`, and `set_prompt_strategy` (success, rejected-value, and missing-user paths); 1 new `test_transcription.py` test for the non-list `segments` path
- **ResourceWarning fix** — converted the `_sqlite_session_factory` helper into a `sqlite_session_factory` fixture that calls `engine.dispose()` on teardown; eliminates 6 "unclosed database" warnings that were surfacing under unrelated tests during GC
- **Coverage in checks** — `AGENTS.md` Rule 9, `docs/context/git-guide.md` pre-commit step 4, and the `.pre-commit-config.yaml` pytest hook all updated to `uv run pytest --cov`; a note documents the 100% line-coverage convention (soft gate — no `--cov-fail-under`)

## Test plan

- [x] `uv run pytest --cov` → 216 passed, 1 warning (pre-existing google.genai DeprecationWarning), TOTAL 100% line coverage
- [x] `uvx ruff format .`, `uvx ruff check .`, `uvx ty check .` — all pass
- [x] Pre-commit hook runs cleanly on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add coverage for database settings, transcription errors, and enforce coverage checks**

### What Changed
- Added tests for saving user settings, including target language, YouTube transcription, summarizing model, prompt strategy, and thinking level
- Covered unsupported values and missing-user cases so these actions now fail cleanly instead of going untested
- Added a transcription test for invalid segment output, which now raises a model error
- Updated commit and guide instructions so the test suite runs with coverage reporting, and kept the 100% coverage expectation visible
- Fixed the SQLite test setup so database tests close cleanly after running

### Impact
`✅ Fewer untested settings regressions`
`✅ Clearer transcription failure coverage`
`✅ Fewer database warning leaks during tests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines to reflect 100% test coverage requirement for the project.

* **Tests**
  * Enhanced test suite with expanded database configuration and transcription validation coverage.
  * Configured pytest to run with code coverage analysis by default.

* **Chores**
  * Updated pre-commit configuration to include coverage metrics in test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->