### PR TITLE
ci: add typechecking workflow, rename lint.yml to linting.yml

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,9 @@ jobs:
 
       - name: Run ruff format check
         run: ruff format --check src/
+
+      - name: Install ty
+        run: pip install ty
+
+      - name: Run ty check
+        run: ty check src/

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Install ruff
         run: pip install ruff

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Linting
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    name: Lint
+  linting:
+    name: Linting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -21,9 +21,3 @@ jobs:
 
       - name: Run ruff format check
         run: ruff format --check src/
-
-      - name: Install ty
-        run: pip install ty
-
-      - name: Run ty check
-        run: ty check src/

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -1,4 +1,4 @@
-name: Type check
+name: Type checking
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 jobs:
-  typecheck:
-    name: Type check
+  typechecking:
+    name: Type checking
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -1,0 +1,30 @@
+name: Type check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run ty check
+        run: uvx ty check src/

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/README.md
+++ b/README.md
@@ -239,11 +239,11 @@ Redis: [Redis.io](https://redis.io/), [Upstash x Redis](https://upstash.com/), [
 
 ### Linters and Checkers
 
-[isort](https://pycqa.github.io/isort/), [black](https://github.com/psf/black), [mypy](https://mypy-lang.org/), [pylint](https://pylint.readthedocs.io/en/latest/), [ruff](https://github.com/astral-sh/ruff), [ty](https://docs.astral.sh/ty/)
+[black](https://github.com/psf/black), [ruff](https://github.com/astral-sh/ruff), [ty](https://docs.astral.sh/ty/), [pyrefly](https://pyrefly.org/)
 
 #### Error suppression
 
-[ruff error suppression](https://docs.astral.sh/ruff/linter/#error-suppression) and [ruff block-level](https://docs.astral.sh/ruff/linter/#block-level), [pylint](https://pylint.pycqa.org/en/latest/user_guide/messages/message_control.html#block-disables), [mypy](https://mypy.readthedocs.io/en/stable/error_codes.html#error-codes), [ty](https://docs.astral.sh/ty/suppression/), [pyrefly](https://pyrefly.org/en/docs/error-suppressions/)
+[ruff error suppression](https://docs.astral.sh/ruff/linter/#error-suppression) and [ruff block-level](https://docs.astral.sh/ruff/linter/#block-level), [ty](https://docs.astral.sh/ty/suppression/), [pyrefly](https://pyrefly.org/en/docs/error-suppressions/)
 
 ### Easy deploy
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ brew install pixi
 pixi run start  # ffmpeg available
 ```
 
-Install `ruff` and `ty` as system-wide tools:
+Install `ruff` and `ty` as system-wide tools or use `uvx`:
 
 ```bash
 uv tool install ruff


### PR DESCRIPTION
## Summary

- Adds `typechecking.yml`: a dedicated workflow that installs project deps via `uv sync` then runs `uvx ty check src/` — matching the local pre-commit hook
- Removes the broken `pip install ty` + `ty check src/` steps from `lint.yml` (no deps = 62 unresolved-import errors, exit 1)
- Renames `lint.yml` → `linting.yml` for consistent gerund naming alongside `typechecking.yml`

## Why a separate workflow

`ty` is a type checker — it must resolve imported packages. Without `uv sync`, the runner's bare environment lacks `yt_dlp`, `tenacity`, `google-genai`, etc., causing CI to fail on every push. `ruff` (a linter/formatter) needs no deps and fits the lightweight lint job; `ty` does not.

## Test plan
- [x] Lint job (ruff check + format) passes as before
- [x] New Type check job runs `uvx ty check src/` and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI workflow names for consistency.
  * Added an automated type-checking workflow to CI.
  * Adjusted CI credential handling for code coverage uploads.
* **Documentation**
  * Updated developer README with refreshed tooling and linter/checker guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->