### PR TITLE
parsing: swap primary/fallback order — Exa now default, Tavily fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ pre-commit install --hook-type post-rewrite
 
 Webpage URLs are parsed into clean text before being passed to Gemini. This gives every model version identical, well-structured input and removes the variability introduced by Gemini's server-side `UrlContext` tool.
 
-Parsing runs a fixed two-stage flow: [Tavily](https://tavily.com) is tried first, and [Exa.ai](https://exa.ai) is used as an automatic fallback when Tavily fails.
+Parsing runs a fixed two-stage flow: [Exa.ai](https://exa.ai) is tried first, and [Tavily](https://tavily.com) is used as an automatic fallback when Exa.ai fails.
 
 #### Remote functions
 

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -107,7 +107,7 @@ def _parse_with_exa(url: str) -> str:
 def parse_url(url: str) -> str:
     """Extract main textual content from a URL.
 
-    Parses with Tavily first and falls back to Exa.ai when Tavily fails.
+    Parses with Exa.ai first and falls back to Tavily when Exa.ai fails.
 
     Args:
         url (str): The webpage URL to parse.
@@ -116,22 +116,22 @@ def parse_url(url: str) -> str:
         str: The extracted page content.
 
     Raises:
-        WebParseError: If both the Tavily and Exa.ai backends fail to return
+        WebParseError: If both the Exa.ai and Tavily backends fail to return
             usable content.
-        Exception: Any non-retryable error raised by the Tavily backend
-            propagates immediately without attempting the Exa.ai fallback.
+        Exception: Any non-retryable error raised by the Exa.ai backend
+            propagates immediately without attempting the Tavily fallback.
 
     """
     try:
-        return _parse_with_tavily(url)
-    except (WebParseError, RetryError) as tavily_error:
+        return _parse_with_exa(url)
+    except WebParseError as exa_error:
         logger.warning(
-            "Tavily parsing backend failed, falling back to Exa: %s",
-            tavily_error,
+            "Exa parsing backend failed, falling back to Tavily: %s",
+            exa_error,
         )
         try:
-            return _parse_with_exa(url)
-        except WebParseError as exa_error:
-            logger.warning("Exa fallback backend also failed: %s", exa_error)
+            return _parse_with_tavily(url)
+        except (WebParseError, RetryError) as tavily_error:
+            logger.warning("Tavily fallback backend also failed: %s", tavily_error)
             msg = "Both parsing backends failed"
-            raise WebParseError(msg) from exa_error
+            raise WebParseError(msg) from tavily_error

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 from tavily.errors import TimeoutError as TavilyTimeoutError
+from tenacity import RetryError
 
 from exceptions import WebParseError
 from parsing import parse_url
@@ -122,12 +123,13 @@ def test_parse_url_raises_when_both_backends_fail(mocker, caplog):
 
     with (
         caplog.at_level(logging.WARNING, logger="parsing"),
-        pytest.raises(WebParseError, match="Both parsing backends failed"),
+        pytest.raises(WebParseError, match="Both parsing backends failed") as exc_info,
     ):
         parse_url("https://example.com")
     assert "Exa parsing backend failed, falling back to Tavily" in caplog.text
     assert "Tavily fallback backend also failed" in caplog.text
     assert mock_exa.get_contents.call_count == 2
+    assert isinstance(exc_info.value.__cause__, WebParseError)
 
 
 def test_parse_url_raises_when_tavily_fallback_returns_empty_content(mocker, caplog):
@@ -143,11 +145,12 @@ def test_parse_url_raises_when_tavily_fallback_returns_empty_content(mocker, cap
 
     with (
         caplog.at_level(logging.WARNING, logger="parsing"),
-        pytest.raises(WebParseError, match="Both parsing backends failed"),
+        pytest.raises(WebParseError, match="Both parsing backends failed") as exc_info,
     ):
         parse_url("https://example.com")
     assert "Tavily returned empty content for" in caplog.text
     mock_tavily.extract.assert_called_once()
+    assert isinstance(exc_info.value.__cause__, WebParseError)
 
 
 def test_parse_url_falls_back_when_tavily_times_out(mocker, caplog):
@@ -162,11 +165,12 @@ def test_parse_url_falls_back_when_tavily_times_out(mocker, caplog):
 
     with (
         caplog.at_level(logging.WARNING, logger="parsing"),
-        pytest.raises(WebParseError, match="Both parsing backends failed"),
+        pytest.raises(WebParseError, match="Both parsing backends failed") as exc_info,
     ):
         parse_url("https://example.com")
     assert mock_tavily.extract.call_count == 2
     assert "Tavily fallback backend also failed" in caplog.text
+    assert isinstance(exc_info.value.__cause__, RetryError)
 
 
 def test_parse_url_propagates_non_retryable_exa_error(mocker):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -7,139 +7,157 @@ from exceptions import WebParseError
 from parsing import parse_url
 
 
-def test_parse_url_returns_tavily_content(mocker):
-    """parse_url returns Tavily's raw_content and does not call Exa on success."""
-    mock_tavily = mocker.patch("parsing.tavily_client")
-    mock_tavily.extract.return_value = {
-        "results": [
-            {"url": "https://example.com", "raw_content": "Hello world."},
-        ],
-        "failed_results": [],
-    }
-    mock_exa = mocker.patch("parsing.exa_client")
-
-    assert parse_url("https://example.com") == "Hello world."
-    mock_tavily.extract.assert_called_once_with(
-        urls=["https://example.com"],
-        format="markdown",
-    )
-    mock_exa.get_contents.assert_not_called()
-
-
-def test_parse_url_falls_back_to_exa_when_tavily_has_no_results(mocker, caplog):
-    """parse_url falls back to Exa when Tavily returns no successful results."""
-    mock_tavily = mocker.patch("parsing.tavily_client")
-    mock_tavily.extract.return_value = {
-        "results": [],
-        "failed_results": [{"url": "https://example.com", "error": "not found"}],
-    }
+def test_parse_url_returns_exa_content(mocker):
+    """parse_url returns Exa's text and does not call Tavily on success."""
     mock_exa = mocker.patch("parsing.exa_client")
     mock_exa.get_contents.return_value = mocker.Mock(
-        results=[mocker.Mock(text="From Exa.")],
+        results=[mocker.Mock(text="Hello world.")],
     )
+    mock_tavily = mocker.patch("parsing.tavily_client")
 
-    with caplog.at_level(logging.WARNING, logger="parsing"):
-        assert parse_url("https://example.com") == "From Exa."
+    assert parse_url("https://example.com") == "Hello world."
     mock_exa.get_contents.assert_called_once_with(
         urls=["https://example.com"],
         text={"max_characters": 20000, "include_html_tags": True},
     )
-    assert "Tavily parsing backend failed, falling back to Exa" in caplog.text
+    mock_tavily.extract.assert_not_called()
 
 
-def test_parse_url_falls_back_to_exa_on_tavily_empty_content(mocker):
-    """parse_url falls back to Exa when Tavily returns empty content."""
+def test_parse_url_falls_back_to_tavily_when_exa_has_no_results(mocker, caplog):
+    """parse_url falls back to Tavily when Exa returns no results."""
+    mocker.patch("time.sleep")
+    mock_exa = mocker.patch("parsing.exa_client")
+    mock_exa.get_contents.return_value = mocker.Mock(results=[])
     mock_tavily = mocker.patch("parsing.tavily_client")
     mock_tavily.extract.return_value = {
-        "results": [{"url": "https://example.com", "raw_content": "   "}],
+        "results": [
+            {"url": "https://example.com", "raw_content": "From Tavily."},
+        ],
         "failed_results": [],
     }
+
+    with caplog.at_level(logging.WARNING, logger="parsing"):
+        assert parse_url("https://example.com") == "From Tavily."
+    mock_tavily.extract.assert_called_once_with(
+        urls=["https://example.com"],
+        format="markdown",
+    )
+    assert "Exa parsing backend failed, falling back to Tavily" in caplog.text
+
+
+def test_parse_url_falls_back_to_tavily_on_exa_empty_content(mocker):
+    """parse_url falls back to Tavily when Exa returns empty content."""
+    mocker.patch("time.sleep")
     mock_exa = mocker.patch("parsing.exa_client")
     mock_exa.get_contents.return_value = mocker.Mock(
-        results=[mocker.Mock(text="From Exa.")],
+        results=[mocker.Mock(text="   ")],
     )
-
-    assert parse_url("https://example.com") == "From Exa."
-
-
-def test_parse_url_falls_back_to_exa_when_tavily_times_out(mocker):
-    """parse_url falls back to Exa when Tavily keeps timing out (RetryError)."""
-    mocker.patch("time.sleep")
     mock_tavily = mocker.patch("parsing.tavily_client")
-    mock_tavily.extract.side_effect = TavilyTimeoutError(
-        "Request timed out after 30 seconds.",
-    )
-    mock_exa = mocker.patch("parsing.exa_client")
-    mock_exa.get_contents.return_value = mocker.Mock(
-        results=[mocker.Mock(text="From Exa.")],
-    )
+    mock_tavily.extract.return_value = {
+        "results": [{"url": "https://example.com", "raw_content": "From Tavily."}],
+        "failed_results": [],
+    }
 
-    assert parse_url("https://example.com") == "From Exa."
-    assert mock_tavily.extract.call_count == 2
-    mock_exa.get_contents.assert_called_once()
+    assert parse_url("https://example.com") == "From Tavily."
 
 
-def test_parse_url_retries_tavily_timeout_then_succeeds(mocker):
-    """parse_url retries a transient Tavily timeout and returns content."""
+def test_parse_url_falls_back_to_tavily_when_exa_retries_exhausted(mocker):
+    """parse_url falls back to Tavily after Exa exhausts its retries."""
     mocker.patch("time.sleep")
+    mock_exa = mocker.patch("parsing.exa_client")
+    mock_exa.get_contents.return_value = mocker.Mock(results=[])
+    mock_tavily = mocker.patch("parsing.tavily_client")
+    mock_tavily.extract.return_value = {
+        "results": [{"url": "https://example.com", "raw_content": "From Tavily."}],
+        "failed_results": [],
+    }
+
+    assert parse_url("https://example.com") == "From Tavily."
+    assert mock_exa.get_contents.call_count == 2
+    mock_tavily.extract.assert_called_once()
+
+
+def test_parse_url_retries_exa_empty_then_succeeds(mocker):
+    """parse_url retries a transient empty Exa result and returns content."""
+    mocker.patch("time.sleep")
+    mock_exa = mocker.patch("parsing.exa_client")
+    mock_exa.get_contents.side_effect = [
+        mocker.Mock(results=[]),
+        mocker.Mock(results=[mocker.Mock(text="Hello world.")]),
+    ]
+    mock_tavily = mocker.patch("parsing.tavily_client")
+
+    assert parse_url("https://example.com") == "Hello world."
+    assert mock_exa.get_contents.call_count == 2
+    mock_tavily.extract.assert_not_called()
+
+
+def test_parse_url_tavily_fallback_retries_timeout_then_succeeds(mocker):
+    """parse_url's Tavily fallback retries a transient timeout then succeeds."""
+    mocker.patch("time.sleep")
+    mock_exa = mocker.patch("parsing.exa_client")
+    mock_exa.get_contents.return_value = mocker.Mock(results=[])
     mock_tavily = mocker.patch("parsing.tavily_client")
     mock_tavily.extract.side_effect = [
         TavilyTimeoutError("Request timed out after 30 seconds."),
         {
             "results": [
-                {"url": "https://example.com", "raw_content": "Hello world."},
+                {"url": "https://example.com", "raw_content": "From Tavily."},
             ],
             "failed_results": [],
         },
     ]
-    mock_exa = mocker.patch("parsing.exa_client")
 
-    assert parse_url("https://example.com") == "Hello world."
+    assert parse_url("https://example.com") == "From Tavily."
     assert mock_tavily.extract.call_count == 2
-    mock_exa.get_contents.assert_not_called()
-
-
-def test_parse_url_exa_retries_empty_then_succeeds(mocker):
-    """parse_url's Exa fallback retries a transient empty result then succeeds."""
-    mocker.patch("time.sleep")
-    mock_tavily = mocker.patch("parsing.tavily_client")
-    mock_tavily.extract.return_value = {"results": [], "failed_results": []}
-    mock_exa = mocker.patch("parsing.exa_client")
-    mock_exa.get_contents.side_effect = [
-        mocker.Mock(results=[]),
-        mocker.Mock(results=[mocker.Mock(text="From Exa.")]),
-    ]
-
-    assert parse_url("https://example.com") == "From Exa."
-    assert mock_exa.get_contents.call_count == 2
 
 
 def test_parse_url_raises_when_both_backends_fail(mocker, caplog):
-    """parse_url raises WebParseError when both Tavily and Exa fail."""
+    """parse_url raises WebParseError when both Exa and Tavily fail."""
     mocker.patch("time.sleep")
-    mock_tavily = mocker.patch("parsing.tavily_client")
-    mock_tavily.extract.return_value = {"results": [], "failed_results": []}
     mock_exa = mocker.patch("parsing.exa_client")
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
+    mock_tavily = mocker.patch("parsing.tavily_client")
+    mock_tavily.extract.return_value = {"results": [], "failed_results": []}
 
     with (
         caplog.at_level(logging.WARNING, logger="parsing"),
         pytest.raises(WebParseError, match="Both parsing backends failed"),
     ):
         parse_url("https://example.com")
-    assert "Tavily parsing backend failed, falling back to Exa" in caplog.text
-    assert "Exa fallback backend also failed" in caplog.text
+    assert "Exa parsing backend failed, falling back to Tavily" in caplog.text
+    assert "Tavily fallback backend also failed" in caplog.text
     assert mock_exa.get_contents.call_count == 2
 
 
-def test_parse_url_raises_when_exa_fallback_returns_empty_text(mocker, caplog):
-    """parse_url raises WebParseError when the Exa fallback returns empty text."""
+def test_parse_url_raises_when_tavily_fallback_returns_empty_content(mocker, caplog):
+    """parse_url raises WebParseError when the Tavily fallback returns empty."""
     mocker.patch("time.sleep")
-    mock_tavily = mocker.patch("parsing.tavily_client")
-    mock_tavily.extract.return_value = {"results": [], "failed_results": []}
     mock_exa = mocker.patch("parsing.exa_client")
-    mock_exa.get_contents.return_value = mocker.Mock(
-        results=[mocker.Mock(text="   ")],
+    mock_exa.get_contents.return_value = mocker.Mock(results=[])
+    mock_tavily = mocker.patch("parsing.tavily_client")
+    mock_tavily.extract.return_value = {
+        "results": [{"url": "https://example.com", "raw_content": "   "}],
+        "failed_results": [],
+    }
+
+    with (
+        caplog.at_level(logging.WARNING, logger="parsing"),
+        pytest.raises(WebParseError, match="Both parsing backends failed"),
+    ):
+        parse_url("https://example.com")
+    assert "Tavily returned empty content for" in caplog.text
+    mock_tavily.extract.assert_called_once()
+
+
+def test_parse_url_falls_back_when_tavily_times_out(mocker, caplog):
+    """parse_url raises combined failure when the Tavily fallback keeps timing out."""
+    mocker.patch("time.sleep")
+    mock_exa = mocker.patch("parsing.exa_client")
+    mock_exa.get_contents.return_value = mocker.Mock(results=[])
+    mock_tavily = mocker.patch("parsing.tavily_client")
+    mock_tavily.extract.side_effect = TavilyTimeoutError(
+        "Request timed out after 30 seconds.",
     )
 
     with (
@@ -147,17 +165,17 @@ def test_parse_url_raises_when_exa_fallback_returns_empty_text(mocker, caplog):
         pytest.raises(WebParseError, match="Both parsing backends failed"),
     ):
         parse_url("https://example.com")
-    assert "Exa returned empty content for" in caplog.text
-    assert mock_exa.get_contents.call_count == 2
+    assert mock_tavily.extract.call_count == 2
+    assert "Tavily fallback backend also failed" in caplog.text
 
 
-def test_parse_url_propagates_non_retryable_tavily_error(mocker):
-    """parse_url lets non-retryable Tavily errors propagate without trying Exa."""
-    mock_tavily = mocker.patch("parsing.tavily_client")
-    mock_tavily.extract.side_effect = RuntimeError("boom")
+def test_parse_url_propagates_non_retryable_exa_error(mocker):
+    """parse_url lets non-retryable Exa errors propagate without trying Tavily."""
     mock_exa = mocker.patch("parsing.exa_client")
+    mock_exa.get_contents.side_effect = RuntimeError("boom")
+    mock_tavily = mocker.patch("parsing.tavily_client")
 
     with pytest.raises(RuntimeError, match="boom"):
         parse_url("https://example.com")
-    mock_tavily.extract.assert_called_once()
-    mock_exa.get_contents.assert_not_called()
+    mock_exa.get_contents.assert_called_once()
+    mock_tavily.extract.assert_not_called()


### PR DESCRIPTION
## **User description**
## Summary

- Reverses the parsing backend order: **Exa.ai is now the primary backend**, Tavily is the automatic fallback.
- `parse_url` now calls `_parse_with_exa` first, catches `WebParseError` (Exa's `reraise=True` never surfaces `RetryError`), logs a warning, and falls back to `_parse_with_tavily`.
- The fallback still catches `(WebParseError, RetryError)` — correct because Tavily's `reraise=False` wraps exhausted timeouts in `RetryError`.
- Non-retryable Exa errors propagate immediately without attempting Tavily (mirrors the old contract with roles swapped).
- Combined failure still raises `WebParseError("Both parsing backends failed")`.

## What changed

| File | Change |
|------|--------|
| `src/parsing.py` | Swapped `_parse_with_exa` / `_parse_with_tavily` call order in `parse_url`; narrowed primary except to `WebParseError`; updated docstring |
| `tests/test_parsing.py` | Reworked all 10 tests to reflect Exa-primary / Tavily-fallback roles |
| `README.md` | Updated "Webpage parsing" description |

## Test plan

- [x] `uv run pytest --cov` — 208 passed, `src/parsing.py` 100%, TOTAL 100%
- [x] `uvx ruff check .` and `uvx ty check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use Exa.ai first for webpage parsing, with Tavily as fallback**

### What Changed
- Webpage parsing now tries Exa.ai first and only uses Tavily if Exa.ai fails.
- If Exa.ai returns no usable text, parsing automatically retries with Tavily and returns that result.
- If both services fail, parsing still raises a single combined error.
- Non-retryable Exa.ai errors stop parsing immediately and do not try Tavily.

### Impact
`✅ More reliable webpage parsing`
`✅ Fewer failed content extractions`
`✅ Clearer fallback behavior when one parser is unavailable`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Reversed the parsing backend priority for webpage parsing: Exa.ai is now the primary service, with fallback to Tavily if Exa.ai fails.
  * Updated error handling to reflect the new backend sequence and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->