### PR TITLE
parsing: add source-indicator prefix to web-page parse results

### DIFF
--- a/src/handlers.py
+++ b/src/handlers.py
@@ -6,7 +6,12 @@ from urllib.parse import urlsplit
 from config import CASTRO_HOST, TG_MAX_FILE_SIZE, YT_HOSTS, bot
 from download import download_tg
 from parsing import parse_url
-from services import check_quota, get_file_with_retry, send_answer
+from services import (
+    check_quota,
+    format_prefixed_summary,
+    get_file_with_retry,
+    send_answer,
+)
 from summary import summarize, summarize_webpage, summarize_with_document
 from utils import clean_up, compress_audio, generate_temporary_name
 
@@ -161,7 +166,10 @@ def handle_url(message: Message, user: UsersOrm, url: str) -> None:
     elif kind == "web":
         check_quota(user_id=user.user_id, daily_limit=user.daily_limit, quantity=0)
         parsed = parse_url(url)
-        answer = summarize_webpage(content=parsed, **_summary_kwargs(user))
+        answer = format_prefixed_summary(
+            parsed.prefix,
+            summarize_webpage(content=parsed.text, **_summary_kwargs(user)),
+        )
         send_answer(message, answer)
     else:
         bot.send_message(message.chat.id, "No data to proceed.")

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -15,6 +15,7 @@ from tenacity import (
 
 from config import exa_client, tavily_client
 from exceptions import WebParseError
+from services import PrefixedText
 
 if TYPE_CHECKING:
     from tenacity import (
@@ -104,7 +105,7 @@ def _parse_with_exa(url: str) -> str:
     return content
 
 
-def parse_url(url: str) -> str:
+def parse_url(url: str) -> PrefixedText:
     """Extract main textual content from a URL.
 
     Parses with Exa.ai first and falls back to Tavily when Exa.ai fails.
@@ -113,7 +114,9 @@ def parse_url(url: str) -> str:
         url (str): The webpage URL to parse.
 
     Returns:
-        str: The extracted page content.
+        PrefixedText: The extracted page content and display prefix. The 🌐
+            prefix means Exa.ai succeeded; 🕸️ means the Tavily fallback
+            succeeded.
 
     Raises:
         WebParseError: If both the Exa.ai and Tavily backends fail to return
@@ -123,14 +126,14 @@ def parse_url(url: str) -> str:
 
     """
     try:
-        return _parse_with_exa(url)
+        return PrefixedText(text=_parse_with_exa(url), prefix="🌐")
     except WebParseError as exa_error:
         logger.warning(
             "Exa parsing backend failed, falling back to Tavily: %s",
             exa_error,
         )
         try:
-            return _parse_with_tavily(url)
+            return PrefixedText(text=_parse_with_tavily(url), prefix="🕸️")
         except (WebParseError, RetryError) as tavily_error:
             logger.warning("Tavily fallback backend also failed: %s", tavily_error)
             msg = "Both parsing backends failed"

--- a/src/services.py
+++ b/src/services.py
@@ -4,6 +4,7 @@ import logging
 import math
 import mimetypes
 import time
+from dataclasses import dataclass
 from functools import lru_cache
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, cast
@@ -249,6 +250,14 @@ def resolve_mime_type(file: str) -> str:
         if file.endswith(ext):
             return mt
     return "application/octet-stream"
+
+
+@dataclass(frozen=True)
+class PrefixedText:
+    """Text paired with the display prefix for the source that produced it."""
+
+    text: str
+    prefix: str
 
 
 def format_prefixed_summary(prefix: str, summary: str) -> str:

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -34,6 +33,7 @@ from exceptions import (
     FetchTranscriptError,
     TranscriptDownloadError,
 )
+from services import PrefixedText
 from utils import (
     clean_up,
     extract_youtube_video_id,
@@ -49,14 +49,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
-
-
-@dataclass(frozen=True)
-class TranscriptResult:
-    """Transcript text with the display prefix for the source that succeeded."""
-
-    text: str
-    prefix: str
 
 
 @retry(
@@ -299,7 +291,7 @@ def fetch_transcript_via_ytdlp(url: str) -> str:  # noqa: C901, PLR0912, PLR0915
             clean_up(file=str(f))
 
 
-def get_yt_transcript(url: str) -> TranscriptResult:
+def get_yt_transcript(url: str) -> PrefixedText:
     """Retrieve and format the transcript from a YouTube video URL.
 
     Downloads subtitles via yt-dlp first and falls back to
@@ -309,7 +301,7 @@ def get_yt_transcript(url: str) -> TranscriptResult:
         url (str): The YouTube video URL.
 
     Returns:
-        TranscriptResult: The transcript text and display prefix. The 📹
+        PrefixedText: The transcript text and display prefix. The 📹
             prefix means yt-dlp succeeded; 📺 means the youtube_transcript_api
             fallback succeeded.
 
@@ -337,5 +329,5 @@ def get_yt_transcript(url: str) -> TranscriptResult:
             logger.warning("API fallback backend also failed: %s", api_error)
             msg = "Both transcript backends failed"
             raise FetchTranscriptError(msg) from api_error
-        return TranscriptResult(text=text, prefix="📺")
-    return TranscriptResult(text=text, prefix="📹")
+        return PrefixedText(text=text, prefix="📺")
+    return PrefixedText(text=text, prefix="📹")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -3,6 +3,7 @@ from tenacity import RetryError
 
 from exceptions import LimitExceededError, WebParseError
 from main import handle_message, process_message_content
+from services import PrefixedText
 
 
 def test_unauthorized_user(message_factory, mocker):
@@ -182,15 +183,21 @@ def test_handle_url_other_http_pattern(message_factory, mocker):
     mocker.patch("handlers.check_quota", return_value=True)
     mock_parse_url = mocker.patch(
         "handlers.parse_url",
-        return_value="Parsed page content.",
+        return_value=PrefixedText(text="Parsed page content.", prefix="🌐"),
     )
-    mock_summarize_webpage = mocker.patch("handlers.summarize_webpage")
-    mocker.patch("handlers.send_answer")
+    mock_summarize_webpage = mocker.patch(
+        "handlers.summarize_webpage",
+        return_value="Summary text.",
+    )
+    mock_send_answer = mocker.patch("handlers.send_answer")
 
     handle_message(msg)
 
     mock_parse_url.assert_called_once_with(url)
     assert mock_summarize_webpage.call_args.kwargs["content"] == "Parsed page content."
+    answer = mock_send_answer.call_args.args[1]
+    assert answer.startswith("🌐")
+    assert "Summary text." in answer
 
 
 def test_handle_url_web_preflight_blocks_before_parse_url(message_factory, mocker):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -16,7 +16,9 @@ def test_parse_url_returns_exa_content(mocker):
     )
     mock_tavily = mocker.patch("parsing.tavily_client")
 
-    assert parse_url("https://example.com") == "Hello world."
+    result = parse_url("https://example.com")
+    assert result.text == "Hello world."
+    assert result.prefix == "🌐"
     mock_exa.get_contents.assert_called_once_with(
         urls=["https://example.com"],
         text={"max_characters": 20000, "include_html_tags": True},
@@ -38,7 +40,9 @@ def test_parse_url_falls_back_to_tavily_when_exa_has_no_results(mocker, caplog):
     }
 
     with caplog.at_level(logging.WARNING, logger="parsing"):
-        assert parse_url("https://example.com") == "From Tavily."
+        result = parse_url("https://example.com")
+    assert result.text == "From Tavily."
+    assert result.prefix == "🕸️"
     mock_tavily.extract.assert_called_once_with(
         urls=["https://example.com"],
         format="markdown",
@@ -59,7 +63,9 @@ def test_parse_url_falls_back_to_tavily_on_exa_empty_content(mocker):
         "failed_results": [],
     }
 
-    assert parse_url("https://example.com") == "From Tavily."
+    result = parse_url("https://example.com")
+    assert result.text == "From Tavily."
+    assert result.prefix == "🕸️"
 
 
 def test_parse_url_falls_back_to_tavily_when_exa_retries_exhausted(mocker):
@@ -73,7 +79,9 @@ def test_parse_url_falls_back_to_tavily_when_exa_retries_exhausted(mocker):
         "failed_results": [],
     }
 
-    assert parse_url("https://example.com") == "From Tavily."
+    result = parse_url("https://example.com")
+    assert result.text == "From Tavily."
+    assert result.prefix == "🕸️"
     assert mock_exa.get_contents.call_count == 2
     mock_tavily.extract.assert_called_once()
 
@@ -88,7 +96,9 @@ def test_parse_url_retries_exa_empty_then_succeeds(mocker):
     ]
     mock_tavily = mocker.patch("parsing.tavily_client")
 
-    assert parse_url("https://example.com") == "Hello world."
+    result = parse_url("https://example.com")
+    assert result.text == "Hello world."
+    assert result.prefix == "🌐"
     assert mock_exa.get_contents.call_count == 2
     mock_tavily.extract.assert_not_called()
 
@@ -109,7 +119,9 @@ def test_parse_url_tavily_fallback_retries_timeout_then_succeeds(mocker):
         },
     ]
 
-    assert parse_url("https://example.com") == "From Tavily."
+    result = parse_url("https://example.com")
+    assert result.text == "From Tavily."
+    assert result.prefix == "🕸️"
     assert mock_tavily.extract.call_count == 2
 
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -17,8 +17,8 @@ from exceptions import (
     FetchTranscriptError,
     TranscriptDownloadError,
 )
+from services import PrefixedText
 from transcription import (
-    TranscriptResult,
     fetch_transcript_via_api,
     fetch_transcript_via_ytdlp,
     get_yt_transcript,
@@ -84,7 +84,7 @@ def test_get_yt_transcript_falls_back_to_api(mocker, url):
 
     result = get_yt_transcript(url)
 
-    assert result == TranscriptResult(text="from fallback", prefix="📺")
+    assert result == PrefixedText(text="from fallback", prefix="📺")
     mock_api.assert_called_once_with("dQw4w9WgXcQ")
 
 


### PR DESCRIPTION
## **User description**
## What changed

- New shared `PrefixedText(text, prefix)` frozen dataclass in `services.py` (placed next to `format_prefixed_summary`)
- `TranscriptResult` in `transcription.py` is replaced by `PrefixedText` — both types are identical 2-field structs; having one canonical definition removes duplication
- `parse_url` return type changes from `str` → `PrefixedText`:
  - **🌐** when Exa.ai is the backend that returned content (default path)
  - **🕸️** when the Tavily fallback returned content
- `handle_url` now calls `format_prefixed_summary(parsed.prefix, summarize_webpage(content=parsed.text, …))`, so the emoji appears in the Telegram message but is **never** inside the LLM prompt

## Why

The media path already tells the user which backend produced a transcript (📹 yt-dlp, 📺 youtube_transcript_api, 📝 transcription fallback). The web path had no such signal. This brings parity.

## Reviewer notes

- The key constraint: `parse_url`'s output is the LLM input for `summarize_webpage`. Attaching the prefix to the final summary (in the handler, not in the parsed content) mirrors how `summarize()` handles transcript prefixes.
- No circular imports: `services.py` only imports `config`/`exceptions`/`prompts`; both `parsing.py` and `transcription.py` importing it is safe.
- 208 tests pass, 100% coverage unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show the source of webpage summaries in the final message**

### What Changed
- Webpage summaries now include a source label in the message: 🌐 for the main parser and 🕸️ for the fallback parser
- The page text sent to the summarizer stays unchanged, so the label appears only in the user-facing result
- The same source-label format is now shared with transcript results instead of using a separate text container

### Impact
`✅ Clearer web summary source labels`
`✅ Easier fallback detection`
`✅ Consistent transcript and webpage output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content from different sources now displays with visual source indicators—🌐 for web pages, 🕸️ for fallback searches, and video symbols for transcripts—helping you quickly identify where results originated.

* **Improvements**
  * Enhanced content handling to consistently preserve and display source attribution across web pages, fallback searches, and video transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->