### PR TITLE
refactor: group module functions into classes (OOP pass)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -19,201 +19,152 @@ engine = create_engine(DSN, echo=False, pool_pre_ping=True)
 Session = sessionmaker(engine)
 
 
-def register_user(
-    user_id: int,
-    first_name: str,
-    last_name: str,
-    username: str,
-    approved: bool = False,
-    target_language: str = DEFAULT_LANG,
-    summarizing_model: str = DEFAULT_MODEL_ID_FOR_SUMMARY,
-    prompt_key_for_summary: (str) = DEFAULT_PROMPT_KEY,
-    thinking_level: str = DEFAULT_THINKING_LEVEL,
-) -> bool:
-    """Register a new user in the database.
+class UserRepository:
+    """Data-access object for the users table."""
 
-    Args:
-        user_id (int): Unique Telegram user ID
-        first_name (str): User's first name
-        last_name (str): User's last name
-        username (str): Telegram username
-        approved (bool, optional): Whether the user is approved.
-        target_language (str, optional): Target language for translations.
-        summarizing_model (str, optional): Model for summary.
-        prompt_key_for_summary (str): Prompt key for summarization strategy.
-        thinking_level (str, optional): AI thinking level.
+    def register_user(
+        self,
+        user_id: int,
+        first_name: str,
+        last_name: str,
+        username: str,
+        approved: bool = False,
+        target_language: str = DEFAULT_LANG,
+        summarizing_model: str = DEFAULT_MODEL_ID_FOR_SUMMARY,
+        prompt_key_for_summary: str = DEFAULT_PROMPT_KEY,
+        thinking_level: str = DEFAULT_THINKING_LEVEL,
+    ) -> bool:
+        """Register a new user in the database.
 
-    Returns:
-        bool: True if registration is successful, False if the user already exists.
+        Returns:
+            bool: True if registration is successful, False if already registered.
 
-    Raises:
-        IntegrityError: Handled internally when the user already exists.
+        """
+        with Session() as session:
+            try:
+                stmt = UsersOrm(
+                    user_id=user_id,
+                    first_name=first_name,
+                    last_name=last_name,
+                    username=username,
+                    approved=approved,
+                    target_language=target_language,
+                    summarizing_model=summarizing_model,
+                    prompt_key_for_summary=prompt_key_for_summary,
+                    thinking_level=thinking_level,
+                )
+                session.add(stmt)
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                return False
+            else:
+                return True
 
-    """
-    with Session() as session:
-        try:
-            stmt = UsersOrm(
-                user_id=user_id,
-                first_name=first_name,
-                last_name=last_name,
-                username=username,
-                approved=approved,
-                target_language=target_language,
-                summarizing_model=summarizing_model,
-                prompt_key_for_summary=prompt_key_for_summary,
-                thinking_level=thinking_level,
-            )
-            session.add(stmt)
-            session.commit()
-        except IntegrityError:
-            session.rollback()
-            return False  # already registered user
-        else:
-            return True
+    def select_user(self, user_id: int) -> UsersOrm:
+        """Retrieve a user from the database by their ID.
 
+        Raises:
+            ValueError: If the user is not found.
 
-def select_user(user_id: int) -> UsersOrm:
-    """Retrieve a user from the database by their ID.
+        """
+        with Session() as session:
+            user = session.get(UsersOrm, user_id)
+            if user is None:
+                msg = "User not found"
+                raise ValueError(msg)
+            return user
 
-    Args:
-        user_id (int): Unique Telegram user ID
+    def check_auth(self, user_id: int) -> bool:
+        """Return True if the user exists and is approved."""
+        user = self.select_user(user_id)
+        return user.approved
 
-    Returns:
-        UsersOrm: User object from the database.
+    def set_target_language(self, user_id: int, target_language: str) -> bool:
+        """Set the target language for a user.
 
-    Raises:
-        ValueError: If the user with the given ID is not found in the database.
+        Returns:
+            bool: True on success, False if language unsupported or user not found.
 
-    """
-    with Session() as session:
-        user = session.get(UsersOrm, user_id)
-        if user is None:
-            msg = "User not found"
-            raise ValueError(msg)
-        return user
+        """
+        if target_language.title() not in SUPPORTED_LANGUAGES:
+            return False
+        with Session() as session:
+            user = session.get(UsersOrm, user_id)
+            if user is not None:
+                user.target_language = target_language
+                session.commit()
+                return True
+            return False
 
+    def set_summarizing_model(self, user_id: int, summarizing_model: str) -> bool:
+        """Set the summarizing model for a user.
 
-def check_auth(user_id: int) -> bool:
-    """Check if a user is approved in the database.
+        Returns:
+            bool: True on success, False if model unsupported or user not found.
 
-    Args:
-        user_id (int): Unique Telegram user ID
+        """
+        if summarizing_model.lower() not in ALLOWED_MODELS_FOR_SUMMARY:
+            return False
+        with Session() as session:
+            user = session.get(UsersOrm, user_id)
+            if user is not None:
+                user.summarizing_model = summarizing_model
+                session.commit()
+                return True
+            return False
 
-    Returns:
-        bool: True if the user is approved, False otherwise.
+    def set_thinking_level(self, user_id: int, thinking_level: str) -> bool:
+        """Set the AI thinking level for a user.
 
-    Raises:
-        ValueError: If the user with the given ID is not found in the database.
+        Returns:
+            bool: True on success, False if level unsupported or user not found.
 
-    """
-    user = select_user(user_id)
-    return user.approved
+        """
+        normalized = thinking_level.upper()
+        if normalized not in ALLOWED_THINKING_LEVELS:
+            return False
+        with Session() as session:
+            user = session.get(UsersOrm, user_id)
+            if user is not None:
+                user.thinking_level = normalized
+                session.commit()
+                return True
+            return False
 
+    def set_prompt_strategy(self, user_id: int, prompt_key_for_summary: str) -> bool:
+        """Set the prompt strategy for a user.
 
-def set_target_language(user_id: int, target_language: str) -> bool:
-    """Set the target language for translations for a user.
+        Returns:
+            bool: True on success, False if key unsupported or user not found.
 
-    Args:
-        user_id (int): Unique Telegram user ID
-        target_language (str): The language to set as target for translations
-
-    Returns:
-        bool: True if language was set successfully, False if the language is not
-        supported or the user is not found.
-
-    Note:
-        The target_language string is checked against SUPPORTED_LANGUAGES
-        (case-insensitive)
-
-    """
-    if target_language.title() not in SUPPORTED_LANGUAGES:
-        return False  # language not supported
-    with Session() as session:
-        user = session.get(UsersOrm, user_id)
-        if user is not None:
-            user.target_language = target_language
-            session.commit()
-            return True
-        return False  # User not found
-
-
-def set_summarizing_model(user_id: int, summarizing_model: str) -> bool:
-    """Set the summarizing model for a user.
-
-    Args:
-        user_id (int): Unique Telegram user ID
-        summarizing_model (str): The model to use for summarization
-
-    Returns:
-        bool: True if model was set successfully, False if the model is not
-        supported or the user is not found.
-
-    Note:
-        The summarizing_model string is checked against ALLOWED_MODELS_FOR_SUMMARY
-        (case-insensitive)
-
-    """
-    if summarizing_model.lower() not in ALLOWED_MODELS_FOR_SUMMARY:
-        return False  # model not supported
-    with Session() as session:
-        user = session.get(UsersOrm, user_id)
-        if user is not None:
-            user.summarizing_model = summarizing_model
-            session.commit()
-            return True
-        return False  # User not found
+        """
+        if prompt_key_for_summary.lower() not in ALLOWED_PROMPT_KEYS:
+            return False
+        with Session() as session:
+            user = session.get(UsersOrm, user_id)
+            if user is not None:
+                user.prompt_key_for_summary = prompt_key_for_summary
+                session.commit()
+                return True
+            return False
 
 
-def set_thinking_level(user_id: int, thinking_level: str) -> bool:
-    """Set the AI thinking level for a user.
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
 
-    Args:
-        user_id (int): Unique Telegram user ID
-        thinking_level (str): AI thinking level
-
-    Returns:
-        bool: True if the level was set successfully, False if the value is not
-        supported or the user is not found.
-
-    Note:
-        The thinking_level string is upper-cased and checked against
-        ALLOWED_THINKING_LEVELS.
-
-    """
-    normalized = thinking_level.upper()
-    if normalized not in ALLOWED_THINKING_LEVELS:
-        return False  # level not supported
-    with Session() as session:
-        user = session.get(UsersOrm, user_id)
-        if user is not None:
-            user.thinking_level = normalized
-            session.commit()
-            return True
-        return False  # User not found
+user_repo = UserRepository()
 
 
-def set_prompt_strategy(user_id: int, prompt_key_for_summary: str) -> bool:
-    """Set the prompt strategy for summarization for a user.
+# ---------------------------------------------------------------------------
+# Module-level aliases — preserve the existing public API
+# ---------------------------------------------------------------------------
 
-    Args:
-        user_id (int): Unique Telegram user ID
-        prompt_key_for_summary (str): The prompt key to use for summarization strategy
-
-    Returns:
-        bool: True if prompt strategy was set successfully, False if the prompt key
-        is not supported or the user is not found.
-
-    Note:
-        The prompt_key_for_summary string is checked against ALLOWED_PROMPT_KEYS
-        (case-insensitive)
-
-    """
-    if prompt_key_for_summary.lower() not in ALLOWED_PROMPT_KEYS:
-        return False  # prompt key not supported
-    with Session() as session:
-        user = session.get(UsersOrm, user_id)
-        if user is not None:
-            user.prompt_key_for_summary = prompt_key_for_summary
-            session.commit()
-            return True
-        return False  # User not found
+register_user = user_repo.register_user
+select_user = user_repo.select_user
+check_auth = user_repo.check_auth
+set_target_language = user_repo.set_target_language
+set_summarizing_model = user_repo.set_summarizing_model
+set_thinking_level = user_repo.set_thinking_level
+set_prompt_strategy = user_repo.set_prompt_strategy

--- a/src/domain.py
+++ b/src/domain.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PrefixedText:
+    """Text paired with the display prefix for the source that produced it."""
+
+    text: str
+    prefix: str
+
+
+def format_prefixed_summary(prefix: str, summary: str) -> str:
+    """Format a prefixed summary with a stable blank line separator."""
+    return f"{prefix}\n\n{summary.strip()}"

--- a/src/download.py
+++ b/src/download.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -20,182 +21,207 @@ from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
 from config import TG_API_TOKEN
-from services import choose_yt_audio_format
 from utils import generate_temporary_name, get_proxy
 
 if TYPE_CHECKING:
     from typing import Any
 
     from telebot.types import File
-    from tenacity import (
-        _utils as tenacity_utils,
-    )
+    from tenacity import _utils as tenacity_utils
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 
-@retry(
-    stop=stop_after_attempt(2),
-    wait=wait_fixed(10),
-    retry=retry_if_exception_type(DownloadError),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def download_yt(url: str) -> str:
-    """Download audio from a YouTube video and convert it to MP3 format.
+def choose_yt_audio_format(info: dict[str, Any]) -> str:
+    """Return the most suitable audio format id for a YouTube video.
 
-    Args:
-        url (str): The YouTube video URL to download from.
-
-    Returns:
-        str: Path to the downloaded temporary MP3 file.
-
-    Raises:
-        RetryError: If the download fails after 2 retry attempts.
-            Each retry attempt waits 10 seconds before retrying.
-
-    Notes:
-        - Downloads the lowest quality audio stream to minimize bandwidth
-        - Uses FFmpeg to extract and convert the audio to MP3
-        - The output file is given a temporary name with .mp3 extension
+    Prefer audio-only formats when yt-dlp exposes them. Fall back to the
+    combined format selector when the extractor does not provide a concrete
+    audio-only id.
 
     """
-    temporary_file_name = generate_temporary_name(ext=".mp3")
-    proxy = get_proxy()
-    # Resolve a real format id first because the abstract `worstaudio` selector
-    # can fail on videos whose available formats do not satisfy yt-dlp's alias.
-    with YoutubeDL({"proxy": proxy, "nocheckcertificate": False}) as ydl:
-        info = ydl.extract_info(url, download=False)
-    if info is None:
-        msg = "Failed to extract info from YouTube URL."
-        raise DownloadError(msg)
-    audio_format = choose_yt_audio_format(cast("dict[str, Any]", info))
-    ydl_opts = {
-        "format": audio_format,
-        "outtmpl": temporary_file_name.split(".", maxsplit=1)[0],
-        "nocheckcertificate": False,
-        "proxy": proxy,
-        "postprocessors": [
-            {  # Extract audio using ffmpeg
-                "key": "FFmpegExtractAudio",
-                "preferredcodec": "mp3",
-            },
-        ],
-    }
-    with YoutubeDL(ydl_opts) as ydl:
-        ydl.download(url)
-    return temporary_file_name
+    formats = info.get("formats") or []
+    audio_only_formats = [
+        fmt
+        for fmt in formats
+        if fmt.get("acodec") not in (None, "none") and fmt.get("vcodec") == "none"
+    ]
+    if not audio_only_formats:
+        return "bestaudio/worst[acodec!=none]"
+
+    def sort_key(fmt: dict[str, Any]) -> tuple[float, float]:
+        abr = fmt.get("abr")
+        tbr = fmt.get("tbr")
+        return (
+            float(abr) if abr is not None else math.inf,
+            float(tbr) if tbr is not None else math.inf,
+        )
+
+    return str(min(audio_only_formats, key=sort_key)["format_id"])
 
 
-def _stream_to_file(
-    url: str,
-    dest: str,
-    timeout: int = 120,
-) -> None:
-    """GET `url` and stream the body to `dest` in 8KB chunks."""
-    r = requests.get(
-        url,
-        stream=True,
-        impersonate="chrome",
-        verify=True,
-        timeout=timeout,
-    )
-    try:
+class Downloader:
+    """Downloads media from YouTube, Castro, and Telegram."""
+
+    @staticmethod
+    def _stream_to_file(
+        url: str,
+        dest: str,
+        timeout: int = 120,
+    ) -> None:
+        """GET `url` and stream the body to `dest` in 8 KB chunks."""
+        r = requests.get(
+            url,
+            stream=True,
+            impersonate="chrome",
+            verify=True,
+            timeout=timeout,
+        )
         try:
-            r.raise_for_status()
-        except HTTPError:
-            logger.exception("%s: status code", r.status_code)
-            raise
-        with Path(dest).open("wb") as f:
-            for chunk in r.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
-    finally:
-        r.close()
+            try:
+                r.raise_for_status()
+            except HTTPError:
+                logger.exception("%s: status code", r.status_code)
+                raise
+            with Path(dest).open("wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+        finally:
+            r.close()
 
-
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(10),
-    retry=retry_if_exception_type((SSLError, RequestsConnectionError)),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def download_castro(url: str) -> str:
-    """Download audio from a Castro podcast URL and save it as an MP3 file.
-
-    Args:
-        url (str): The Castro podcast URL to download from.
-
-    Returns:
-        str: Path to the downloaded temporary MP3 file.
-
-    Raises:
-        ValueError: If the audio source tag or URL is missing on the page.
-        HTTPError: If the HTTP request fails or returns an error status code.
-        Timeout: If the request exceeds the timeout limits
-            (30s for parsing, 120s for download).
-        RetryError: If SSL/connection failures persist after retries.
-
-    Notes:
-        - First parses the URL to extract the actual audio source URL
-        - Downloads the audio file in chunks to manage memory usage
-        - Uses a chunk size of 8192 bytes for streaming
-        - The output file is given a temporary name with .mp3 extension
-
-    """
-    temporary_file_name = generate_temporary_name(ext=".mp3")
-    logger.debug("Parsing URL...")
-    response = requests.get(
-        requote_uri(url),
-        impersonate="chrome",
-        verify=True,
-        timeout=30,
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(10),
+        retry=retry_if_exception_type(DownloadError),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
     )
-    try:
-        response.raise_for_status()
-        soup = BeautifulSoup(response.content, "html.parser")
-    finally:
-        response.close()
-    source_tag = soup.source
-    if source_tag is None:
-        msg = "Audio source tag not found in Castro page."
-        raise ValueError(msg)
-    audio_url = source_tag.get("src")
-    if not audio_url:
-        msg = "Audio URL not found in Castro page."
-        raise ValueError(msg)
-    if not isinstance(audio_url, str):
-        msg = "Audio URL is not a string."
-        raise TypeError(msg)
-    logger.debug("URL parsed! Starting download...")
-    _stream_to_file(requote_uri(audio_url), temporary_file_name)
-    logger.debug("File downloaded...")
-    return temporary_file_name
+    def download_yt(self, url: str) -> str:
+        """Download audio from a YouTube video and convert it to MP3 format.
+
+        Args:
+            url (str): The YouTube video URL to download from.
+
+        Returns:
+            str: Path to the downloaded temporary MP3 file.
+
+        Raises:
+            RetryError: If the download fails after 2 retry attempts.
+
+        """
+        temporary_file_name = generate_temporary_name(ext=".mp3")
+        proxy = get_proxy()
+        with YoutubeDL({"proxy": proxy, "nocheckcertificate": False}) as ydl:
+            info = ydl.extract_info(url, download=False)
+        if info is None:
+            msg = "Failed to extract info from YouTube URL."
+            raise DownloadError(msg)
+        audio_format = choose_yt_audio_format(cast("dict[str, Any]", info))
+        ydl_opts = {
+            "format": audio_format,
+            "outtmpl": temporary_file_name.split(".", maxsplit=1)[0],
+            "nocheckcertificate": False,
+            "proxy": proxy,
+            "postprocessors": [
+                {
+                    "key": "FFmpegExtractAudio",
+                    "preferredcodec": "mp3",
+                },
+            ],
+        }
+        with YoutubeDL(ydl_opts) as ydl:
+            ydl.download(url)
+        return temporary_file_name
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(10),
+        retry=retry_if_exception_type((SSLError, RequestsConnectionError)),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
+    )
+    def download_castro(self, url: str) -> str:
+        """Download audio from a Castro podcast URL and save it as an MP3 file.
+
+        Args:
+            url (str): The Castro podcast URL to download from.
+
+        Returns:
+            str: Path to the downloaded temporary MP3 file.
+
+        Raises:
+            ValueError: If the audio source tag or URL is missing on the page.
+            HTTPError: If the HTTP request fails.
+            RetryError: If SSL/connection failures persist after retries.
+
+        """
+        temporary_file_name = generate_temporary_name(ext=".mp3")
+        logger.debug("Parsing URL...")
+        response = requests.get(
+            requote_uri(url),
+            impersonate="chrome",
+            verify=True,
+            timeout=30,
+        )
+        try:
+            response.raise_for_status()
+            soup = BeautifulSoup(response.content, "html.parser")
+        finally:
+            response.close()
+        source_tag = soup.source
+        if source_tag is None:
+            msg = "Audio source tag not found in Castro page."
+            raise ValueError(msg)
+        audio_url = source_tag.get("src")
+        if not audio_url:
+            msg = "Audio URL not found in Castro page."
+            raise ValueError(msg)
+        if not isinstance(audio_url, str):
+            msg = "Audio URL is not a string."
+            raise TypeError(msg)
+        logger.debug("URL parsed! Starting download...")
+        self._stream_to_file(requote_uri(audio_url), temporary_file_name)
+        logger.debug("File downloaded...")
+        return temporary_file_name
+
+    def download_tg(self, file_id: File, ext: str = "") -> str:
+        """Download a file from Telegram and save it locally.
+
+        Args:
+            file_id (File): The Telegram File object containing file information.
+            ext (str, optional): File extension for the output file.
+
+        Returns:
+            str: Path to the downloaded temporary file.
+
+        Raises:
+            ValueError: If the Telegram file path is missing.
+
+        """
+        temporary_file_name = generate_temporary_name(ext=ext)
+        if file_id.file_path is None:
+            msg = "Telegram file path is missing."
+            raise ValueError(msg)
+        file_url = (
+            f"https://api.telegram.org/file/bot{TG_API_TOKEN}/{file_id.file_path}"
+        )
+        self._stream_to_file(file_url, temporary_file_name)
+        return temporary_file_name
 
 
-def download_tg(file_id: File, ext: str = "") -> str:
-    """Download a file from Telegram and save it locally.
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
 
-    Args:
-        file_id (File): The Telegram File object containing file information.
-        ext (str, optional): File extension for the output file.
-                             Defaults to empty string.
+downloader = Downloader()
 
-    Returns:
-        str: Path to the downloaded temporary file.
 
-    Notes:
-        - Uses the Telegram bot API to download the file
-        - The output file is given a temporary name with the specified extension
-        - File is written in binary mode
+# ---------------------------------------------------------------------------
+# Module-level aliases — preserve the existing public API
+# ---------------------------------------------------------------------------
 
-    """
-    temporary_file_name = generate_temporary_name(ext=ext)
-    if file_id.file_path is None:
-        msg = "Telegram file path is missing."
-        raise ValueError(msg)
-    file_url = f"https://api.telegram.org/file/bot{TG_API_TOKEN}/{file_id.file_path}"
-    _stream_to_file(file_url, temporary_file_name)
-    return temporary_file_name
+download_yt = downloader.download_yt
+download_castro = downloader.download_castro
+download_tg = downloader.download_tg

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -103,6 +103,7 @@ def _handle_video_like(message: Message, user: UsersOrm, data: File) -> None:
         send_answer(message, answer)
     finally:
         clean_up(file=downloaded_file)
+        clean_up(file=compressed_file)
 
 
 def handle_video_note(message: Message, user: UsersOrm) -> None:

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -4,11 +4,11 @@ from typing import TYPE_CHECKING, TypedDict
 from urllib.parse import urlsplit
 
 from config import CASTRO_HOST, TG_MAX_FILE_SIZE, YT_HOSTS, bot
+from domain import format_prefixed_summary
 from download import download_tg
 from parsing import parse_url
 from services import (
     check_quota,
-    format_prefixed_summary,
     get_file_with_retry,
     send_answer,
 )

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, cast
 
 from tavily.errors import TimeoutError as TavilyTimeoutError
@@ -14,127 +15,158 @@ from tenacity import (
 )
 
 from config import exa_client, tavily_client
+from domain import PrefixedText
 from exceptions import WebParseError
-from services import PrefixedText
 
 if TYPE_CHECKING:
-    from tenacity import (
-        _utils as tenacity_utils,
-    )
+    from exa_py import Exa
+    from tavily import TavilyClient
+    from tenacity import _utils as tenacity_utils
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 
-@retry(
-    stop=stop_after_attempt(2),
-    wait=wait_fixed(5),
-    retry=retry_if_exception_type(TavilyTimeoutError),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def _parse_with_tavily(url: str) -> str:
-    """Extract main textual content from a URL using Tavily.
+class ParserBackend(ABC):
+    """Abstract base for URL content-extraction backends."""
 
-    Args:
-        url (str): The webpage URL to parse.
+    prefix: str
 
-    Returns:
-        str: The extracted page content as markdown text.
-
-    Raises:
-        WebParseError: If Tavily returns no successful results or empty content.
-        RetryError: If Tavily keeps timing out after all retry attempts. The
-            function is decorated with @retry and makes 2 total attempts (1
-            retry with a 5-second wait) before raising RetryError.
-
-    """
-    response = tavily_client.extract(urls=[url], format="markdown")
-    results = response.get("results") or []
-    if not results:
-        failed = response.get("failed_results") or []
-        msg = f"Tavily could not extract content from {url}: {failed}"
-        logger.warning(msg)
-        raise WebParseError(msg)
-    content = (results[0].get("raw_content") or "").strip()
-    if not content:
-        msg = f"Tavily returned empty content for {url}"
-        logger.warning(msg)
-        raise WebParseError(msg)
-    return content
+    @abstractmethod
+    def parse(self, url: str) -> str:
+        """Extract main textual content from a URL."""
 
 
-@retry(
-    stop=stop_after_attempt(2),
-    wait=wait_fixed(5),
-    retry=retry_if_exception_type(WebParseError),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=True,
-)
-def _parse_with_exa(url: str) -> str:
-    """Extract main textual content from a URL using Exa.ai.
+class ExaBackend(ParserBackend):
+    """Exa.ai URL extraction backend."""
 
-    Args:
-        url (str): The webpage URL to parse.
+    prefix = "🌐"
 
-    Returns:
-        str: The extracted page content as text (HTML tags included).
+    def __init__(self, client: Exa) -> None:
+        """Store the injected Exa client."""
+        self._client = client
 
-    Raises:
-        WebParseError: If Exa returns no results or empty content. Exa's
-            get_contents is intermittent and may return an empty result for a
-            URL it can normally extract, so the function is decorated with
-            @retry and makes 2 total attempts (1 retry with a 5-second wait)
-            before re-raising WebParseError.
-
-    """
-    response = exa_client.get_contents(
-        urls=[url],
-        text={"max_characters": 20000, "include_html_tags": True},
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(5),
+        retry=retry_if_exception_type(WebParseError),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=True,
     )
-    results = response.results or []
-    if not results:
-        msg = f"Exa could not extract content from {url}"
-        logger.warning(msg)
-        raise WebParseError(msg)
-    content = (results[0].text or "").strip()
-    if not content:
-        msg = f"Exa returned empty content for {url}"
-        logger.warning(msg)
-        raise WebParseError(msg)
-    return content
+    def parse(self, url: str) -> str:
+        """Extract main textual content from a URL using Exa.ai.
+
+        Raises:
+            WebParseError: If Exa returns no results or empty content. Retried
+                once (2 total attempts) before re-raising.
+
+        """
+        response = self._client.get_contents(
+            urls=[url],
+            text={"max_characters": 20000, "include_html_tags": True},
+        )
+        results = response.results or []
+        if not results:
+            msg = f"Exa could not extract content from {url}"
+            logger.warning(msg)
+            raise WebParseError(msg)
+        content = (results[0].text or "").strip()
+        if not content:
+            msg = f"Exa returned empty content for {url}"
+            logger.warning(msg)
+            raise WebParseError(msg)
+        return content
+
+
+class TavilyBackend(ParserBackend):
+    """Tavily URL extraction backend."""
+
+    prefix = "🕸️"
+
+    def __init__(self, client: TavilyClient) -> None:
+        """Store the injected Tavily client."""
+        self._client = client
+
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(5),
+        retry=retry_if_exception_type(TavilyTimeoutError),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
+    )
+    def parse(self, url: str) -> str:
+        """Extract main textual content from a URL using Tavily.
+
+        Raises:
+            WebParseError: If Tavily returns no results or empty content.
+            RetryError: If Tavily keeps timing out after all retry attempts.
+
+        """
+        response = self._client.extract(urls=[url], format="markdown")
+        results = response.get("results") or []
+        if not results:
+            failed = response.get("failed_results") or []
+            msg = f"Tavily could not extract content from {url}: {failed}"
+            logger.warning(msg)
+            raise WebParseError(msg)
+        content = (results[0].get("raw_content") or "").strip()
+        if not content:
+            msg = f"Tavily returned empty content for {url}"
+            logger.warning(msg)
+            raise WebParseError(msg)
+        return content
+
+
+class WebParser:
+    """Orchestrates URL parsing with a primary→fallback backend strategy."""
+
+    def __init__(self, primary: ParserBackend, fallback: ParserBackend) -> None:
+        """Store the primary and fallback backends."""
+        self._primary = primary
+        self._fallback = fallback
+
+    def parse(self, url: str) -> PrefixedText:
+        """Extract main textual content from a URL.
+
+        Parses with the primary backend first, falls back to the secondary on
+        failure.
+
+        Returns:
+            PrefixedText: The extracted content and source display prefix.
+
+        Raises:
+            WebParseError: If both backends fail.
+            Exception: Any non-retryable primary error propagates immediately
+                without attempting the fallback.
+
+        """
+        try:
+            return PrefixedText(
+                text=self._primary.parse(url),
+                prefix=self._primary.prefix,
+            )
+        except WebParseError as primary_error:
+            logger.warning(
+                "Exa parsing backend failed, falling back to Tavily: %s",
+                primary_error,
+            )
+            try:
+                return PrefixedText(
+                    text=self._fallback.parse(url),
+                    prefix=self._fallback.prefix,
+                )
+            except (WebParseError, RetryError) as fallback_error:
+                logger.warning(
+                    "Tavily fallback backend also failed: %s",
+                    fallback_error,
+                )
+                msg = "Both parsing backends failed"
+                raise WebParseError(msg) from fallback_error
+
+
+web_parser = WebParser(ExaBackend(exa_client), TavilyBackend(tavily_client))
 
 
 def parse_url(url: str) -> PrefixedText:
-    """Extract main textual content from a URL.
-
-    Parses with Exa.ai first and falls back to Tavily when Exa.ai fails.
-
-    Args:
-        url (str): The webpage URL to parse.
-
-    Returns:
-        PrefixedText: The extracted page content and display prefix. The 🌐
-            prefix means Exa.ai succeeded; 🕸️ means the Tavily fallback
-            succeeded.
-
-    Raises:
-        WebParseError: If both the Exa.ai and Tavily backends fail to return
-            usable content.
-        Exception: Any non-retryable error raised by the Exa.ai backend
-            propagates immediately without attempting the Tavily fallback.
-
-    """
-    try:
-        return PrefixedText(text=_parse_with_exa(url), prefix="🌐")
-    except WebParseError as exa_error:
-        logger.warning(
-            "Exa parsing backend failed, falling back to Tavily: %s",
-            exa_error,
-        )
-        try:
-            return PrefixedText(text=_parse_with_tavily(url), prefix="🕸️")
-        except (WebParseError, RetryError) as tavily_error:
-            logger.warning("Tavily fallback backend also failed: %s", tavily_error)
-            msg = "Both parsing backends failed"
-            raise WebParseError(msg) from tavily_error
+    """Extract main textual content from a URL via the default WebParser."""
+    return web_parser.parse(url)

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -30,6 +30,7 @@ tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 class ParserBackend(ABC):
     """Abstract base for URL content-extraction backends."""
 
+    name: str
     prefix: str
 
     @abstractmethod
@@ -40,6 +41,7 @@ class ParserBackend(ABC):
 class ExaBackend(ParserBackend):
     """Exa.ai URL extraction backend."""
 
+    name = "Exa"
     prefix = "🌐"
 
     def __init__(self, client: Exa) -> None:
@@ -81,6 +83,7 @@ class ExaBackend(ParserBackend):
 class TavilyBackend(ParserBackend):
     """Tavily URL extraction backend."""
 
+    name = "Tavily"
     prefix = "🕸️"
 
     def __init__(self, client: TavilyClient) -> None:
@@ -147,7 +150,9 @@ class WebParser:
             )
         except WebParseError as primary_error:
             logger.warning(
-                "Exa parsing backend failed, falling back to Tavily: %s",
+                "%s parsing backend failed, falling back to %s: %s",
+                self._primary.name,
+                self._fallback.name,
                 primary_error,
             )
             try:
@@ -157,7 +162,8 @@ class WebParser:
                 )
             except (WebParseError, RetryError) as fallback_error:
                 logger.warning(
-                    "Tavily fallback backend also failed: %s",
+                    "%s fallback backend also failed: %s",
+                    self._fallback.name,
                     fallback_error,
                 )
                 msg = "Both parsing backends failed"

--- a/src/services.py
+++ b/src/services.py
@@ -29,7 +29,7 @@ from config import (
     per_minute_rate,
     rate_limiter,
 )
-from domain import PrefixedText, format_prefixed_summary
+from domain import PrefixedText
 from exceptions import LimitExceededError
 from prompts import SYSTEM_INSTRUCTION
 
@@ -201,7 +201,6 @@ gemini_helper = GeminiHelper()
 # all importers and mocker.patch("services.*") calls continue to work.
 # ---------------------------------------------------------------------------
 
-_reply_with_retry = messenger._reply_with_retry  # noqa: SLF001
 get_file_with_retry = messenger.get_file_with_retry
 send_answer = messenger.send_answer
 
@@ -213,12 +212,10 @@ resolve_mime_type = gemini_helper.resolve_mime_type
 upload_and_wait_for_file = gemini_helper.upload_and_wait_for_file
 
 
-# Re-export domain types so existing `from services import PrefixedText` imports work.
+# Re-export PrefixedText so existing `from services import PrefixedText` imports work.
 __all__ = [
     "PrefixedText",
-    "_reply_with_retry",
     "check_quota",
-    "format_prefixed_summary",
     "gemini_helper",
     "get_file_with_retry",
     "get_gemini_config",

--- a/src/services.py
+++ b/src/services.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import logging
-import math
 import mimetypes
 import time
-from dataclasses import dataclass
 from functools import lru_cache
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from google.genai import types
 from limits import parse as _parse_rate_limit
@@ -31,205 +29,98 @@ from config import (
     per_minute_rate,
     rate_limiter,
 )
+from domain import PrefixedText, format_prefixed_summary
 from exceptions import LimitExceededError
 from prompts import SYSTEM_INSTRUCTION
 
 if TYPE_CHECKING:
     from telebot.types import File, Message
-    from tenacity import (
-        _utils as tenacity_utils,
-    )
+    from tenacity import _utils as tenacity_utils
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 parse_rate_limit = lru_cache(maxsize=64)(_parse_rate_limit)
 
 
-def choose_yt_audio_format(info: dict[str, Any]) -> str:
-    """Return the most suitable audio format id for a YouTube video.
+class Messenger:
+    """Handles all Telegram bot messaging with retry logic."""
 
-    Prefer audio-only formats when yt-dlp exposes them. Fall back to the
-    combined format selector when the extractor does not provide a concrete
-    audio-only id.
-
-    """
-    formats = info.get("formats") or []
-    audio_only_formats = [
-        fmt
-        for fmt in formats
-        if fmt.get("acodec") not in (None, "none") and fmt.get("vcodec") == "none"
-    ]
-    if not audio_only_formats:
-        return "bestaudio/worst[acodec!=none]"
-
-    def sort_key(fmt: dict[str, Any]) -> tuple[float, float]:
-        abr = fmt.get("abr")
-        tbr = fmt.get("tbr")
-        return (
-            float(abr) if abr is not None else math.inf,
-            float(tbr) if tbr is not None else math.inf,
-        )
-
-    return str(min(audio_only_formats, key=sort_key)["format_id"])
-
-
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(1),
-    retry=retry_if_exception_type((ApiTelegramException, ReadTimeout)),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=True,
-)
-def _reply_with_retry(
-    message: Message,
-    text: str,
-    entities: list[dict[str, object]] | None = None,
-) -> None:
-    """Send a reply to a Telegram message with retry logic.
-
-    This function attempts to reply to a Telegram message using the bot's
-    reply_to method. If an ApiTelegramException occurs, it retries up to 3
-    times with a 1-second wait between attempts.
-
-    Args:
-        message (Message): The Telegram message to reply to.
-        text (str): The text content of the reply.
-        entities (list[dict[str, object]] | None): Optional list of message
-            entities for formatting.
-
-    Returns:
-        None
-
-    """
-    if entities is None:
-        bot.reply_to(message, text)
-    else:
-        bot.reply_to(message, text, entities=entities)
-
-
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(30),
-    retry=retry_if_exception_type(ReadTimeout),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=True,
-)
-def get_file_with_retry(file_id: str) -> File:
-    """Get file information from Telegram, with retries on timeout.
-
-    Args:
-        file_id (str): The Telegram file ID to retrieve.
-
-    Returns:
-        File: The downloaded file information.
-
-    """
-    return bot.get_file(file_id)
-
-
-def send_answer(message: Message, answer: str) -> None:
-    """Send a response message to the user.
-
-    This function handles sending messages through the Telegram bot, including:
-    - Converting Markdown to Telegram entities
-    - Splitting long messages into chunks if they exceed Telegram's UTF-16 limit
-    - Retrying Telegram API failures up to 3 times with a 1-second wait
-
-    Args:
-        message (Message): The original Telegram message to reply to
-        answer (str): The text content to send as a response
-
-    Returns:
-        None
-
-    Note:
-        - Messages longer than 4096 UTF-16 code units are automatically split
-        - There is a 1-second delay between sending chunks of split messages
-
-    """
-    text, entities = convert(answer)
-    chunks_iter = iter(split_entities(text, entities, max_utf16_len=4096))
-    current = next(chunks_iter, None)
-    while current is not None:
-        chunk_text, chunk_entities = current
-        serialized_entities = [entity.to_dict() for entity in chunk_entities]
-        _reply_with_retry(message, chunk_text, entities=serialized_entities)
-        next_chunk = next(chunks_iter, None)
-        if next_chunk is not None:
-            time.sleep(1)
-        current = next_chunk
-
-
-def check_quota(user_id: int, daily_limit: int, quantity: int = 1) -> bool:
-    """Check if the request is within rate limits and handle any delays.
-
-    This function checks both daily (per-user) and per-minute (global) rate limits.
-    If the daily limit is exceeded, it raises an exception. If the per-minute limit
-    is exceeded, it waits until the limit resets.
-
-    Args:
-        user_id (int): Telegram user ID whose daily cap to enforce.
-        daily_limit (int): The user's configured daily request cap.
-        quantity (int, optional): Number of quota units to check. Defaults to 1.
-
-    Returns:
-        bool: True if the request is allowed to proceed.
-
-    Raises:
-        LimitExceededError: If the daily request limit has been exceeded.
-
-    Note:
-        - The function will automatically sleep if the per-minute limit is reached
-        - Daily limits cannot be bypassed and will raise an exception
-
-    """
-    if daily_limit <= 0:
-        msg = "The daily limit for requests has been exceeded"
-        raise LimitExceededError(msg)
-    daily_rate = parse_rate_limit(f"{daily_limit} per day")
-    if not rate_limiter.hit(daily_rate, f"{DAILY_LIMIT_KEY}:{user_id}", cost=quantity):
-        msg = "The daily limit for requests has been exceeded"
-        raise LimitExceededError(msg)
-    while not rate_limiter.hit(per_minute_rate, MINUTE_LIMIT_KEY, cost=quantity):
-        stats = rate_limiter.get_window_stats(per_minute_rate, MINUTE_LIMIT_KEY)
-        time.sleep(max(0.0, stats.reset_time - time.time()))
-    return True
-
-
-def get_remaining_quota(user_id: int, daily_limit: int) -> int:
-    """Return remaining daily requests for a user without consuming quota.
-
-    Args:
-        user_id (int): Telegram user ID.
-        daily_limit (int): The user's configured daily request cap.
-
-    Returns:
-        int: Number of requests still available today.
-
-    """
-    if daily_limit <= 0:
-        return 0
-    daily_rate = parse_rate_limit(f"{daily_limit} per day")
-    stats = rate_limiter.get_window_stats(daily_rate, f"{DAILY_LIMIT_KEY}:{user_id}")
-    return max(0, stats.remaining)
-
-
-def get_gemini_config(
-    target_language: str,
-    thinking_level: str,
-) -> types.GenerateContentConfig:
-    """Get Gemini config with system instruction and thinking enabled."""
-    system_instruction = dedent(
-        SYSTEM_INSTRUCTION.format(language=target_language),
-    ).strip()
-    return GEMINI_CONFIG.model_copy(
-        update={
-            "system_instruction": system_instruction,
-            "thinking_config": types.ThinkingConfig(
-                thinking_level=types.ThinkingLevel(thinking_level),
-            ),
-        },
+    @staticmethod
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1),
+        retry=retry_if_exception_type((ApiTelegramException, ReadTimeout)),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=True,
     )
+    def _reply_with_retry(
+        message: Message,
+        text: str,
+        entities: list[dict[str, object]] | None = None,
+    ) -> None:
+        """Send a reply with retry logic on Telegram API errors."""
+        if entities is None:
+            bot.reply_to(message, text)
+        else:
+            bot.reply_to(message, text, entities=entities)
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(30),
+        retry=retry_if_exception_type(ReadTimeout),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=True,
+    )
+    def get_file_with_retry(self, file_id: str) -> File:
+        """Get file information from Telegram, with retries on timeout."""
+        return bot.get_file(file_id)
+
+    def send_answer(self, message: Message, answer: str) -> None:
+        """Send a response message, splitting at Telegram's 4 096-code-unit limit."""
+        text, entities = convert(answer)
+        chunks_iter = iter(split_entities(text, entities, max_utf16_len=4096))
+        current = next(chunks_iter, None)
+        while current is not None:
+            chunk_text, chunk_entities = current
+            serialized_entities = [entity.to_dict() for entity in chunk_entities]
+            self._reply_with_retry(message, chunk_text, entities=serialized_entities)
+            next_chunk = next(chunks_iter, None)
+            if next_chunk is not None:
+                time.sleep(1)
+            current = next_chunk
+
+
+class QuotaManager:
+    """Enforces per-user daily and global per-minute rate limits."""
+
+    def check_quota(self, user_id: int, daily_limit: int, quantity: int = 1) -> bool:
+        """Enforce rate limits; raise if daily exceeded; sleep on per-minute."""
+        if daily_limit <= 0:
+            msg = "The daily limit for requests has been exceeded"
+            raise LimitExceededError(msg)
+        daily_rate = parse_rate_limit(f"{daily_limit} per day")
+        if not rate_limiter.hit(
+            daily_rate,
+            f"{DAILY_LIMIT_KEY}:{user_id}",
+            cost=quantity,
+        ):
+            msg = "The daily limit for requests has been exceeded"
+            raise LimitExceededError(msg)
+        while not rate_limiter.hit(per_minute_rate, MINUTE_LIMIT_KEY, cost=quantity):
+            stats = rate_limiter.get_window_stats(per_minute_rate, MINUTE_LIMIT_KEY)
+            time.sleep(max(0.0, stats.reset_time - time.time()))
+        return True
+
+    def get_remaining_quota(self, user_id: int, daily_limit: int) -> int:
+        """Return remaining daily requests for a user without consuming quota."""
+        if daily_limit <= 0:
+            return 0
+        daily_rate = parse_rate_limit(f"{daily_limit} per day")
+        stats = rate_limiter.get_window_stats(
+            daily_rate,
+            f"{DAILY_LIMIT_KEY}:{user_id}",
+        )
+        return max(0, stats.remaining)
 
 
 _EXT_MIME_FALLBACK = {
@@ -241,45 +132,100 @@ _EXT_MIME_FALLBACK = {
 }
 
 
-def resolve_mime_type(file: str) -> str:
-    """Resolve the MIME type for a file path, with fallbacks."""
-    mime_type = mimetypes.guess_type(file)[0]
-    if mime_type is not None:
-        return mime_type
-    for ext, mt in _EXT_MIME_FALLBACK.items():
-        if file.endswith(ext):
-            return mt
-    return "application/octet-stream"
+class GeminiHelper:
+    """Utilities for Gemini model configuration and file management."""
+
+    def get_gemini_config(
+        self,
+        target_language: str,
+        thinking_level: str,
+    ) -> types.GenerateContentConfig:
+        """Get Gemini config with system instruction and thinking enabled."""
+        system_instruction = dedent(
+            SYSTEM_INSTRUCTION.format(language=target_language),
+        ).strip()
+        return GEMINI_CONFIG.model_copy(
+            update={
+                "system_instruction": system_instruction,
+                "thinking_config": types.ThinkingConfig(
+                    thinking_level=types.ThinkingLevel(thinking_level),
+                ),
+            },
+        )
+
+    def resolve_mime_type(self, file: str) -> str:
+        """Resolve the MIME type for a file path, with fallbacks."""
+        mime_type = mimetypes.guess_type(file)[0]
+        if mime_type is not None:
+            return mime_type
+        for ext, mt in _EXT_MIME_FALLBACK.items():
+            if file.endswith(ext):
+                return mt
+        return "application/octet-stream"
+
+    def upload_and_wait_for_file(
+        self,
+        file: str,
+        mime_type: str,
+        sleep_time: int,
+    ) -> types.File:
+        """Upload a file to Gemini and wait for processing to finish."""
+        uploaded = gemini_client.files.upload(
+            file=file,
+            config={"mime_type": mime_type},
+        )
+        if uploaded.name is None:
+            raise AttributeError
+        file_name = uploaded.name
+        while uploaded.state == "PROCESSING":
+            time.sleep(sleep_time)
+            uploaded = gemini_client.files.get(name=file_name)
+        if uploaded.state == "FAILED":
+            raise ValueError(uploaded.state)
+        if uploaded.uri is None or uploaded.mime_type is None:
+            raise AttributeError
+        return uploaded
 
 
-@dataclass(frozen=True)
-class PrefixedText:
-    """Text paired with the display prefix for the source that produced it."""
+# ---------------------------------------------------------------------------
+# Module-level singletons
+# ---------------------------------------------------------------------------
 
-    text: str
-    prefix: str
-
-
-def format_prefixed_summary(prefix: str, summary: str) -> str:
-    """Format a prefixed summary with a stable blank line separator."""
-    return f"{prefix}\n\n{summary.strip()}"
+messenger = Messenger()
+quota_manager = QuotaManager()
+gemini_helper = GeminiHelper()
 
 
-def upload_and_wait_for_file(
-    file: str,
-    mime_type: str,
-    sleep_time: int,
-) -> types.File:
-    """Upload a file to Gemini and wait for processing to finish."""
-    uploaded = gemini_client.files.upload(file=file, config={"mime_type": mime_type})
-    if uploaded.name is None:
-        raise AttributeError
-    file_name = uploaded.name
-    while uploaded.state == "PROCESSING":
-        time.sleep(sleep_time)
-        uploaded = gemini_client.files.get(name=file_name)
-    if uploaded.state == "FAILED":
-        raise ValueError(uploaded.state)
-    if uploaded.uri is None or uploaded.mime_type is None:
-        raise AttributeError
-    return uploaded
+# ---------------------------------------------------------------------------
+# Module-level aliases — keep the existing public API intact so that
+# all importers and mocker.patch("services.*") calls continue to work.
+# ---------------------------------------------------------------------------
+
+_reply_with_retry = messenger._reply_with_retry  # noqa: SLF001
+get_file_with_retry = messenger.get_file_with_retry
+send_answer = messenger.send_answer
+
+check_quota = quota_manager.check_quota
+get_remaining_quota = quota_manager.get_remaining_quota
+
+get_gemini_config = gemini_helper.get_gemini_config
+resolve_mime_type = gemini_helper.resolve_mime_type
+upload_and_wait_for_file = gemini_helper.upload_and_wait_for_file
+
+
+# Re-export domain types so existing `from services import PrefixedText` imports work.
+__all__ = [
+    "PrefixedText",
+    "_reply_with_retry",
+    "check_quota",
+    "format_prefixed_summary",
+    "gemini_helper",
+    "get_file_with_retry",
+    "get_gemini_config",
+    "get_remaining_quota",
+    "messenger",
+    "quota_manager",
+    "resolve_mime_type",
+    "send_answer",
+    "upload_and_wait_for_file",
+]

--- a/src/summary.py
+++ b/src/summary.py
@@ -20,12 +20,12 @@ from tenacity import (
 )
 
 from config import gemini_client
+from domain import format_prefixed_summary
 from download import download_castro, download_tg, download_yt
 from exceptions import FetchTranscriptError
 from prompts import PROMPTS
 from services import (
     check_quota,
-    format_prefixed_summary,
     get_gemini_config,
     resolve_mime_type,
     upload_and_wait_for_file,
@@ -34,389 +34,388 @@ from transcription import get_yt_transcript, transcribe
 from utils import clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
-    from tenacity import (
-        _utils as tenacity_utils,
-    )
+    from tenacity import _utils as tenacity_utils
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 
-@retry(
-    stop=stop_after_attempt(2),
-    wait=wait_fixed(30),
-    retry=retry_if_exception_type(
-        (ServerError, AttributeError, ClientError, SSLError),
-    ),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def summarize_with_file(
-    file: str,
-    model: str,
-    prompt_key: str,
-    target_language: str,
-    user_id: int,
-    daily_limit: int,
-    thinking_level: str,
-    sleep_time: int = 10,
-) -> str:
-    """Summarize audio content using Gemini API with file upload.
+class Summarizer:
+    """Generates Gemini-powered summaries from audio, video, documents, and URLs."""
 
-    This function uploads an audio file to Gemini, waits for processing,
-    and generates a summary using the specified model and prompt.
-
-    Args:
-        file (str): Path to the audio file to be summarized
-        model (str): The Gemini model identifier to use for generation
-        prompt_key (str): Key to retrieve the prompt template from PROMPTS
-        target_language (str): The language to translate the text into.
-        user_id (int): Telegram user ID for per-user quota enforcement.
-        daily_limit (int): The user's configured daily request cap.
-        thinking_level (str): AI thinking level
-        sleep_time (int, optional): Time between processing checks. Defaults to 10.
-
-    Returns:
-        str: Generated summary text from the audio content
-
-    Raises:
-        AttributeError: If Gemini returns incomplete file or response metadata.
-        ValueError: If Gemini reports a failed processing state.
-        RetryError: If transient Gemini or network errors persist after retries.
-
-    Note:
-        This function is decorated with @retry and will attempt the operation
-        up to 2 times with a 30-second wait between attempts.
-
-    """
-    check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
-    prompt = dedent(PROMPTS[prompt_key]).strip()
-    mime_type = resolve_mime_type(file)
-    audio_file = upload_and_wait_for_file(
-        file=file,
-        mime_type=mime_type,
-        sleep_time=sleep_time,
-    )
-    audio_file_name = audio_file.name
-    try:
-        if audio_file.uri is None or audio_file.mime_type is None:
-            raise AttributeError
-        check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
+    @staticmethod
+    def _generate_text(
+        prompt: str,
+        model: str,
+        target_language: str,
+        thinking_level: str,
+    ) -> str:
+        """Run a single Gemini text-prompt generation with the standard config."""
+        config = get_gemini_config(target_language, thinking_level=thinking_level)
         response = gemini_client.models.generate_content(
             model=model,
-            contents=[
-                types.Content(
-                    role="user",
-                    parts=[
-                        types.Part.from_text(text=prompt),
-                        types.Part.from_uri(
-                            file_uri=audio_file.uri,
-                            mime_type=audio_file.mime_type,
-                        ),
-                    ],
-                ),
-            ],
-            config=get_gemini_config(
-                target_language,
-                thinking_level=thinking_level,
-            ),
+            contents=prompt,
+            config=config,
         )
         if response.text is None:
             raise AttributeError
         return response.text
-    finally:
-        if audio_file_name is not None:
-            try:
-                gemini_client.files.delete(name=audio_file_name)
-            except Exception as e:
-                logger.warning(
-                    "Failed to delete Gemini file %s: %s",
-                    audio_file_name,
-                    e,
-                )
 
-
-def _generate_text(
-    prompt: str,
-    model: str,
-    target_language: str,
-    thinking_level: str,
-) -> str:
-    """Run a single Gemini text-prompt generation with the standard config."""
-    config = get_gemini_config(target_language, thinking_level=thinking_level)
-    response = gemini_client.models.generate_content(
-        model=model,
-        contents=prompt,
-        config=config,
-    )
-    if response.text is None:
-        raise AttributeError
-    return response.text
-
-
-@retry(
-    stop=stop_after_attempt(2),
-    wait=wait_fixed(30),
-    retry=retry_if_exception_type(
-        (ServerError, AttributeError, ClientError),
-    ),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def summarize_with_transcript(
-    transcript: str,
-    model: str,
-    prompt_key: str,
-    target_language: str,
-    user_id: int,
-    daily_limit: int,
-    thinking_level: str,
-) -> str:
-    """Generate a summary from a transcript using Gemini API.
-
-    This function takes a transcript text, combines it with a predefined prompt
-    template, and uses the Gemini API to generate a summary.
-
-    Args:
-        transcript (str): The text transcript to be summarized
-        model (str): The Gemini model identifier to use for generation
-        prompt_key (str): Key to retrieve the prompt template from PROMPTS
-        target_language (str): The language to translate the text into.
-        user_id (int): Telegram user ID for per-user quota enforcement.
-        daily_limit (int): The user's configured daily request cap.
-        thinking_level (str): AI thinking level
-
-    Returns:
-        str: Generated summary text from the transcript
-
-    Raises:
-        AttributeError: If Gemini returns an empty response.
-        RetryError: If transient Gemini or network errors persist after retries.
-
-    Note:
-        The function checks quota usage before making the API call and uses
-        get_gemini_config for model configuration.
-
-    """
-    prompt = (f"{dedent(PROMPTS[prompt_key])} {transcript}").strip()
-    check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-    return _generate_text(prompt, model, target_language, thinking_level)
-
-
-@retry(
-    stop=stop_after_attempt(2),
-    wait=wait_fixed(30),
-    retry=retry_if_exception_type(
-        (ServerError, AttributeError, ClientError),
-    ),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def summarize_webpage(
-    content: str,
-    model: str,
-    prompt_key: str,
-    target_language: str,
-    user_id: int,
-    daily_limit: int,
-    thinking_level: str,
-) -> str:
-    """Generate a summary from pre-parsed webpage content using Gemini API.
-
-    Args:
-        content (str): Pre-parsed webpage content (markdown text from Tavily).
-        model (str): The Gemini model identifier to use for generation
-        prompt_key (str): Key to retrieve the prompt template from PROMPTS
-        target_language (str): The language to translate the text into.
-        user_id (int): Telegram user ID for per-user quota enforcement.
-        daily_limit (int): The user's configured daily request cap.
-        thinking_level (str): AI thinking level
-
-    Returns:
-        str: Generated summary text from the webpage content
-
-    Raises:
-        AttributeError: If Gemini returns an empty response.
-        RetryError: If transient Gemini or network errors persist after retries.
-
-    """
-    prompt = (f"{dedent(PROMPTS[prompt_key])} {content}").strip()
-    check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-    return _generate_text(prompt, model, target_language, thinking_level)
-
-
-@retry(
-    stop=stop_after_attempt(2),
-    wait=wait_fixed(30),
-    retry=retry_if_exception_type(
-        (
-            ServerError,
-            AttributeError,
-            ClientError,
-            SSLError,
-            CurlSSLError,
-            CurlConnectionError,
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(30),
+        retry=retry_if_exception_type(
+            (ServerError, AttributeError, ClientError, SSLError),
         ),
-    ),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def summarize_with_document(
-    file: File,
-    model: str,
-    prompt_key: str,
-    target_language: str,
-    mime_type: str,
-    user_id: int,
-    daily_limit: int,
-    thinking_level: str,
-    sleep_time: int = 10,
-) -> str:
-    """Summarize document content using Gemini API with file upload.
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
+    )
+    def summarize_with_file(
+        self,
+        file: str,
+        model: str,
+        prompt_key: str,
+        target_language: str,
+        user_id: int,
+        daily_limit: int,
+        thinking_level: str,
+        sleep_time: int = 10,
+    ) -> str:
+        """Summarize audio content using Gemini API with file upload.
 
-    This function downloads a document from Telegram, uploads it to Gemini,
-    waits for processing, and generates a summary using the specified model
-    and prompt.
+        Args:
+            file (str): Path to the audio file to be summarized.
+            model (str): The Gemini model identifier.
+            prompt_key (str): Key to retrieve the prompt template from PROMPTS.
+            target_language (str): The language to translate the summary into.
+            user_id (int): Telegram user ID for per-user quota enforcement.
+            daily_limit (int): The user's configured daily request cap.
+            thinking_level (str): AI thinking level.
+            sleep_time (int, optional): Time between processing checks. Defaults to 10.
 
-    Args:
-        file (File): Telegram File object for the document to be summarized
-        model (str): The Gemini model identifier to use for generation
-        prompt_key (str): Key to retrieve the prompt template from PROMPTS
-        target_language (str): The language to translate the text into.
-        mime_type (str): MIME type of the document being uploaded
-        user_id (int): Telegram user ID for per-user quota enforcement.
-        daily_limit (int): The user's configured daily request cap.
-        thinking_level (str): AI thinking level
-        sleep_time (int, optional): Time between processing checks. Defaults to 10.
+        Returns:
+            str: Generated summary text from the audio content.
 
-    Returns:
-        str: Generated summary text from the document content
+        Raises:
+            AttributeError: If Gemini returns incomplete file or response metadata.
+            ValueError: If Gemini reports a failed processing state.
+            RetryError: If transient Gemini or network errors persist after retries.
 
-    Raises:
-        AttributeError: If Gemini returns incomplete file or response metadata.
-        ValueError: If the document processing fails on Gemini's side.
-        RetryError: If the operation fails after all retry attempts.
-
-    Note:
-        - This function is decorated with @retry and will attempt the operation
-          up to 2 times with a 30-second wait between attempts.
-        - Temporary files are automatically cleaned up after processing.
-        - The function checks quota usage before making the API call.
-
-    """
-    data: str | None = None
-    document_file_name: str | None = None
-    try:
+        """
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
-        data = download_tg(file)
         prompt = dedent(PROMPTS[prompt_key]).strip()
-        document_file = upload_and_wait_for_file(
-            file=data,
+        mime_type = resolve_mime_type(file)
+        audio_file = upload_and_wait_for_file(
+            file=file,
             mime_type=mime_type,
             sleep_time=sleep_time,
         )
-        document_file_name = document_file.name
-        check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-        response = gemini_client.models.generate_content(
-            model=model,
-            contents=[
-                types.Content(
-                    role="user",
-                    parts=[
-                        types.Part.from_text(text=prompt),
-                        types.Part.from_uri(
-                            file_uri=cast("str", document_file.uri),
-                            mime_type=cast("str", document_file.mime_type),
-                        ),
-                    ],
+        audio_file_name = audio_file.name
+        try:
+            if audio_file.uri is None or audio_file.mime_type is None:
+                raise AttributeError
+            check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
+            response = gemini_client.models.generate_content(
+                model=model,
+                contents=[
+                    types.Content(
+                        role="user",
+                        parts=[
+                            types.Part.from_text(text=prompt),
+                            types.Part.from_uri(
+                                file_uri=audio_file.uri,
+                                mime_type=audio_file.mime_type,
+                            ),
+                        ],
+                    ),
+                ],
+                config=get_gemini_config(
+                    target_language,
+                    thinking_level=thinking_level,
                 ),
-            ],
-            config=get_gemini_config(
-                target_language,
-                thinking_level=thinking_level,
+            )
+            if response.text is None:
+                raise AttributeError
+            return response.text
+        finally:
+            if audio_file_name is not None:
+                try:
+                    gemini_client.files.delete(name=audio_file_name)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to delete Gemini file %s: %s",
+                        audio_file_name,
+                        e,
+                    )
+
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(30),
+        retry=retry_if_exception_type(
+            (ServerError, AttributeError, ClientError),
+        ),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
+    )
+    def summarize_with_transcript(
+        self,
+        transcript: str,
+        model: str,
+        prompt_key: str,
+        target_language: str,
+        user_id: int,
+        daily_limit: int,
+        thinking_level: str,
+    ) -> str:
+        """Generate a summary from a transcript using Gemini API.
+
+        Args:
+            transcript (str): The text transcript to be summarized.
+            model (str): The Gemini model identifier.
+            prompt_key (str): Key to retrieve the prompt template from PROMPTS.
+            target_language (str): The language to translate the summary into.
+            user_id (int): Telegram user ID for per-user quota enforcement.
+            daily_limit (int): The user's configured daily request cap.
+            thinking_level (str): AI thinking level.
+
+        Returns:
+            str: Generated summary text from the transcript.
+
+        Raises:
+            AttributeError: If Gemini returns an empty response.
+            RetryError: If transient Gemini or network errors persist after retries.
+
+        """
+        prompt = (f"{dedent(PROMPTS[prompt_key])} {transcript}").strip()
+        check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
+        return self._generate_text(prompt, model, target_language, thinking_level)
+
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(30),
+        retry=retry_if_exception_type(
+            (ServerError, AttributeError, ClientError),
+        ),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
+    )
+    def summarize_webpage(
+        self,
+        content: str,
+        model: str,
+        prompt_key: str,
+        target_language: str,
+        user_id: int,
+        daily_limit: int,
+        thinking_level: str,
+    ) -> str:
+        """Generate a summary from pre-parsed webpage content using Gemini API.
+
+        Args:
+            content (str): Pre-parsed webpage content (markdown text).
+            model (str): The Gemini model identifier.
+            prompt_key (str): Key to retrieve the prompt template from PROMPTS.
+            target_language (str): The language to translate the summary into.
+            user_id (int): Telegram user ID for per-user quota enforcement.
+            daily_limit (int): The user's configured daily request cap.
+            thinking_level (str): AI thinking level.
+
+        Returns:
+            str: Generated summary text from the webpage content.
+
+        Raises:
+            AttributeError: If Gemini returns an empty response.
+            RetryError: If transient Gemini or network errors persist after retries.
+
+        """
+        prompt = (f"{dedent(PROMPTS[prompt_key])} {content}").strip()
+        check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
+        return self._generate_text(prompt, model, target_language, thinking_level)
+
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(30),
+        retry=retry_if_exception_type(
+            (
+                ServerError,
+                AttributeError,
+                ClientError,
+                SSLError,
+                CurlSSLError,
+                CurlConnectionError,
             ),
-        )
-        if response.text is None:
-            raise AttributeError
-    finally:
-        if document_file_name is not None:
+        ),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
+    )
+    def summarize_with_document(
+        self,
+        file: File,
+        model: str,
+        prompt_key: str,
+        target_language: str,
+        mime_type: str,
+        user_id: int,
+        daily_limit: int,
+        thinking_level: str,
+        sleep_time: int = 10,
+    ) -> str:
+        """Summarize document content using Gemini API with file upload.
+
+        Args:
+            file (File): Telegram File object for the document to be summarized.
+            model (str): The Gemini model identifier.
+            prompt_key (str): Key to retrieve the prompt template from PROMPTS.
+            target_language (str): The language to translate the summary into.
+            mime_type (str): MIME type of the document being uploaded.
+            user_id (int): Telegram user ID for per-user quota enforcement.
+            daily_limit (int): The user's configured daily request cap.
+            thinking_level (str): AI thinking level.
+            sleep_time (int, optional): Time between processing checks. Defaults to 10.
+
+        Returns:
+            str: Generated summary text from the document content.
+
+        Raises:
+            AttributeError: If Gemini returns incomplete file or response metadata.
+            ValueError: If the document processing fails on Gemini's side.
+            RetryError: If the operation fails after all retry attempts.
+
+        """
+        data: str | None = None
+        document_file_name: str | None = None
+        try:
+            check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
+            data = download_tg(file)
+            prompt = dedent(PROMPTS[prompt_key]).strip()
+            document_file = upload_and_wait_for_file(
+                file=data,
+                mime_type=mime_type,
+                sleep_time=sleep_time,
+            )
+            document_file_name = document_file.name
+            check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
+            response = gemini_client.models.generate_content(
+                model=model,
+                contents=[
+                    types.Content(
+                        role="user",
+                        parts=[
+                            types.Part.from_text(text=prompt),
+                            types.Part.from_uri(
+                                file_uri=cast("str", document_file.uri),
+                                mime_type=cast("str", document_file.mime_type),
+                            ),
+                        ],
+                    ),
+                ],
+                config=get_gemini_config(
+                    target_language,
+                    thinking_level=thinking_level,
+                ),
+            )
+            if response.text is None:
+                raise AttributeError
+        finally:
+            if document_file_name is not None:
+                try:
+                    gemini_client.files.delete(name=document_file_name)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to delete Gemini file %s: %s",
+                        document_file_name,
+                        e,
+                    )
+            if data is not None:
+                clean_up(file=data)
+        return response.text
+
+    def summarize(
+        self,
+        data: str | File,
+        model: str,
+        prompt_key: str,
+        target_language: str,
+        user_id: int,
+        daily_limit: int,
+        thinking_level: str,
+    ) -> str:
+        """Generate a summary from various input sources using Gemini API.
+
+        Args:
+            data (str | File): Input data to summarize. Can be:
+                - YouTube URL
+                - Castro.fm episode URL
+                - Telegram File object
+            model (str): The Gemini model identifier.
+            prompt_key (str): Key to retrieve the prompt template from PROMPTS.
+            target_language (str): The language to translate the summary into.
+            user_id (int): Telegram user ID for per-user quota enforcement.
+            daily_limit (int): The user's configured daily request cap.
+            thinking_level (str): AI thinking level.
+
+        Returns:
+            str: Generated summary of the content, prefixed with the source emoji.
+
+        Raises:
+            RetryError: If all summarization attempts fail after retries.
+
+        """
+        check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
+        if isinstance(data, str):
+            if data.startswith("https://castro.fm/episode/"):
+                data = download_castro(data)
+            if data.startswith(
+                (
+                    "https://youtu.be/",
+                    "https://www.youtube.com/",
+                    "https://youtube.com/",
+                ),
+            ):
+                try:
+                    transcript_result = get_yt_transcript(data)
+                except (FetchTranscriptError, ValueError) as e:
+                    logger.warning(
+                        "get_yt_transcript failed, falling back to download: %s",
+                        e,
+                    )
+                else:
+                    return format_prefixed_summary(
+                        transcript_result.prefix,
+                        self.summarize_with_transcript(
+                            transcript=transcript_result.text,
+                            model=model,
+                            prompt_key=prompt_key,
+                            target_language=target_language,
+                            user_id=user_id,
+                            daily_limit=daily_limit,
+                            thinking_level=thinking_level,
+                        ),
+                    )
+                data = download_yt(data)
+        if isinstance(data, File):
+            data = download_tg(data, ext=".ogg")
+
+        try:
+            return self.summarize_with_file(
+                file=data,
+                model=model,
+                prompt_key=prompt_key,
+                target_language=target_language,
+                user_id=user_id,
+                daily_limit=daily_limit,
+                thinking_level=thinking_level,
+            )
+        except RetryError as e:
+            logger.warning("Error occurred while summarizing with file: %s", e)
+            new_file = generate_temporary_name(ext=".ogg")
             try:
-                gemini_client.files.delete(name=document_file_name)
-            except Exception as e:
-                logger.warning(
-                    "Failed to delete Gemini file %s: %s",
-                    document_file_name,
-                    e,
-                )
-        if data is not None:
-            clean_up(file=data)
-    return response.text
-
-
-def summarize(
-    data: str | File,
-    model: str,
-    prompt_key: str,
-    target_language: str,
-    user_id: int,
-    daily_limit: int,
-    thinking_level: str,
-) -> str:
-    """Generate a summary from various input sources using Gemini API.
-
-    This function handles multiple input types (URLs, files, etc.) and attempts
-    different summarization strategies based on the input and configuration.
-
-    Args:
-        data (str | File): Input data to summarize. Can be:
-            - YouTube URL
-            - Castro.fm episode URL
-            - Telegram File object
-        model (str): The Gemini model identifier to use for generation
-        prompt_key (str): Key to retrieve the prompt template from PROMPTS
-        target_language (str): The language to translate the text into.
-        user_id (int): Telegram user ID for per-user quota enforcement.
-        daily_limit (int): The user's configured daily request cap.
-        thinking_level (str): AI thinking level
-
-    Returns:
-        str: Generated summary of the content, prefixed with:
-            - 📹 for default-backend YouTube transcript summaries
-            - 📺 for fallback-backend YouTube transcript summaries
-            - 📝 for fallback transcription summaries
-            - No prefix for direct file summaries
-
-    Raises:
-        RetryError: If all summarization attempts fail after retries
-
-    Note:
-        The function follows this process:
-        1. For URLs: Downloads content from YouTube or Castro.fm
-        2. For YouTube: Attempts to use built-in transcripts
-        3. For files: Attempts direct summarization
-        4. On failure: Falls back to transcription
-        5. Cleans up temporary files after processing
-
-    """
-    check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
-    if isinstance(data, str):
-        if data.startswith("https://castro.fm/episode/"):
-            data = download_castro(data)
-        if data.startswith(
-            ("https://youtu.be/", "https://www.youtube.com/", "https://youtube.com/"),
-        ):
-            try:
-                transcript_result = get_yt_transcript(data)
-            except (FetchTranscriptError, ValueError) as e:
-                logger.warning(
-                    "get_yt_transcript failed, falling back to download: %s",
-                    e,
-                )
-            else:
+                compress_audio(input_file=data, output_file=new_file)
+                transcription = transcribe(new_file)
                 return format_prefixed_summary(
-                    transcript_result.prefix,
-                    summarize_with_transcript(
-                        transcript=transcript_result.text,
+                    "📝",
+                    self.summarize_with_transcript(
+                        transcript=transcription,
                         model=model,
                         prompt_key=prompt_key,
                         target_language=target_language,
@@ -425,40 +424,25 @@ def summarize(
                         thinking_level=thinking_level,
                     ),
                 )
-            data = download_yt(data)
-    if isinstance(data, File):
-        data = download_tg(data, ext=".ogg")
-
-    try:
-        return summarize_with_file(
-            file=data,
-            model=model,
-            prompt_key=prompt_key,
-            target_language=target_language,
-            user_id=user_id,
-            daily_limit=daily_limit,
-            thinking_level=thinking_level,
-        )
-    except RetryError as e:
-        logger.warning("Error occurred while summarizing with file: %s", e)
-        new_file = generate_temporary_name(ext=".ogg")
-        try:
-            compress_audio(input_file=data, output_file=new_file)
-            transcription = transcribe(new_file)
-            # If it fails, a RetryError will raise
-            return format_prefixed_summary(
-                "📝",
-                summarize_with_transcript(
-                    transcript=transcription,
-                    model=model,
-                    prompt_key=prompt_key,
-                    target_language=target_language,
-                    user_id=user_id,
-                    daily_limit=daily_limit,
-                    thinking_level=thinking_level,
-                ),
-            )
+            finally:
+                clean_up(file=new_file)
         finally:
-            clean_up(file=new_file)
-    finally:
-        clean_up(file=data)
+            clean_up(file=data)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+summarizer = Summarizer()
+
+
+# ---------------------------------------------------------------------------
+# Module-level aliases — preserve the existing public API
+# ---------------------------------------------------------------------------
+
+summarize_with_file = summarizer.summarize_with_file
+summarize_with_transcript = summarizer.summarize_with_transcript
+summarize_webpage = summarizer.summarize_webpage
+summarize_with_document = summarizer.summarize_with_document
+summarize = summarizer.summarize

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -350,22 +350,7 @@ yt_transcriber = YouTubeTranscriber()
 # Module-level aliases — preserve the existing public API
 # ---------------------------------------------------------------------------
 
-
-def transcribe(file: str, sleep_time: int = 10) -> str:
-    """Transcribe an audio file using WhisperX via Replicate."""
-    return audio_transcriber.transcribe(file, sleep_time=sleep_time)
-
-
-def fetch_transcript_via_api(video_id: str) -> str:
-    """Retrieve and format a YouTube transcript via youtube_transcript_api."""
-    return yt_transcriber.fetch_via_api(video_id)
-
-
-def fetch_transcript_via_ytdlp(url: str) -> str:
-    """Retrieve a YouTube transcript by downloading subtitles via yt-dlp."""
-    return yt_transcriber.fetch_via_ytdlp(url)
-
-
-def get_yt_transcript(url: str) -> PrefixedText:
-    """Retrieve the transcript from a YouTube video URL."""
-    return yt_transcriber.get_transcript(url)
+transcribe = audio_transcriber.transcribe
+fetch_transcript_via_api = yt_transcriber.fetch_via_api
+fetch_transcript_via_ytdlp = yt_transcriber.fetch_via_ytdlp
+get_yt_transcript = yt_transcriber.get_transcript

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -29,11 +29,11 @@ from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
 from config import replicate_client
+from domain import PrefixedText
 from exceptions import (
     FetchTranscriptError,
     TranscriptDownloadError,
 )
-from services import PrefixedText
 from utils import (
     clean_up,
     extract_youtube_video_id,
@@ -43,291 +43,329 @@ from utils import (
 )
 
 if TYPE_CHECKING:
-    from tenacity import (
-        _utils as tenacity_utils,
-    )
+    import replicate as replicate_lib
+    from tenacity import _utils as tenacity_utils
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(10),
-    retry=retry_if_exception_type(ReplicateError),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def transcribe(file: str, sleep_time: int = 10) -> str:
-    """Transcribe an audio file using WhisperX model.
+class AudioTranscriber:
+    """Transcribes audio files via the Replicate WhisperX model."""
 
-    Args:
-        file (str): Path to the audio file to transcribe.
-        sleep_time (int, optional): Time in seconds to wait between status checks.
+    def __init__(self, client: replicate_lib.Client) -> None:
+        """Store the injected Replicate client."""
+        self._client = client
 
-    Returns:
-        str: The transcribed text from the audio file.
-
-    Raises:
-        ModelError: If the transcription fails, is canceled, or output is invalid.
-        RetryError: If Replicate errors persist after all retry attempts.
-
-    """
-    model = replicate_client.models.get("victor-upmeet/whisperx")
-    version = model.versions.list()[0]
-    with Path(file).open("rb") as audio:
-        prediction = replicate_client.predictions.create(
-            version=version,
-            input={"audio_file": audio},
-        )
-    while prediction.status != "succeeded":
-        if prediction.status in ("failed", "canceled"):
-            raise ModelError(prediction)
-        prediction.reload()
-        time.sleep(sleep_time)
-    if prediction.output is None:
-        raise ModelError(prediction)
-    segments = prediction.output.get("segments")
-    if not isinstance(segments, list):
-        raise ModelError(prediction)
-    return "".join(
-        [segment.get("text", "") for segment in segments if isinstance(segment, dict)],
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(10),
+        retry=retry_if_exception_type(ReplicateError),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
     )
+    def transcribe(self, file: str, sleep_time: int = 10) -> str:
+        """Transcribe an audio file using WhisperX model.
 
+        Args:
+            file (str): Path to the audio file to transcribe.
+            sleep_time (int, optional): Time in seconds to wait between status checks.
 
-@retry(
-    stop=stop_after_attempt(2),
-    wait=wait_fixed(10),
-    retry=retry_if_exception_type(
-        (
-            ParseError,
-            IpBlocked,
-            RequestBlocked,
-            ProxyError,
-            SSLError,
-            ChunkedEncodingError,
-        ),
-    ),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def fetch_transcript_via_api(video_id: str) -> str:
-    """Retrieve and format a YouTube transcript via youtube_transcript_api.
+        Returns:
+            str: The transcribed text from the audio file.
 
-    Args:
-        video_id (str): The YouTube video ID.
+        Raises:
+            ModelError: If the transcription fails, is canceled, or output is invalid.
+            RetryError: If Replicate errors persist after all retry attempts.
 
-    Returns:
-        str: The formatted transcript text.
-
-    Raises:
-        NoTranscriptFound: If no transcript is found in any language.
-        CouldNotRetrieveTranscript: Subclasses (TranscriptsDisabled, VideoUnavailable,
-            AgeRestricted, etc.) propagate to the caller.
-        RetryError: If IpBlocked, RequestBlocked, ParseError, ProxyError, SSLError,
-            or ChunkedEncodingError persist after retries.
-
-    """
-    proxy = get_proxy()
-    if proxy:
-        ytt_api = YouTubeTranscriptApi(proxy_config=GenericProxyConfig(https_url=proxy))
-    else:
-        ytt_api = YouTubeTranscriptApi()
-
-    try:
-        transcript = ytt_api.fetch(video_id)
-    except NoTranscriptFound:
-        transcript_list = ytt_api.list(video_id)
-        language_codes = [transcript.language_code for transcript in transcript_list]
-        time.sleep(60)
-        transcript = ytt_api.fetch(video_id, languages=language_codes)
-    return TextFormatter().format_transcript(transcript)
-
-
-@retry(
-    stop=stop_after_attempt(2),
-    wait=wait_fixed(10),
-    retry=retry_if_exception_type(TranscriptDownloadError),
-    before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-    reraise=False,
-)
-def fetch_transcript_via_ytdlp(url: str) -> str:  # noqa: C901, PLR0912, PLR0915
-    """Retrieve a YouTube transcript by downloading subtitles via yt-dlp.
-
-    Probes available tracks first, preferring genuine manual subtitles (English
-    when present) and otherwise the video's original-language automatic captions,
-    then converts to vtt via ffmpeg.
-
-    Args:
-        url (str): The YouTube video URL.
-
-    Returns:
-        str: The transcript as plain text.
-
-    Raises:
-        DownloadError: If no subtitles are available for the video (sentinel
-            paths: extract_info returned no data, no subtitle languages
-            offered, or no vtt file appeared after download), or if vtt
-            conversion/reading fails unexpectedly after a successful download.
-        TranscriptDownloadError: Wraps transient yt-dlp failures from
-            extract_info / download. Up to 2 total attempts (1 retry); on
-            exhaustion tenacity raises RetryError to the caller.
-        RetryError: If TranscriptDownloadError persists after all retries.
-
-    """
-    temp_basename = generate_temporary_name()
-    proxy = get_proxy()
-    probe_opts: dict[str, Any] = {
-        "proxy": proxy,
-        "noplaylist": True,
-        "skip_download": True,
-        "quiet": True,
-        "nocheckcertificate": False,
-    }
-
-    # Phase 1: probe available subtitle tracks (no download, no temp files written).
-    try:
-        with YoutubeDL(probe_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
-            info = ydl.extract_info(url, download=False)
-    except DownloadError as e:
-        logger.warning("yt-dlp probe failed: %s: %s", type(e).__name__, e)
-        raise TranscriptDownloadError(str(e)) from e
-    except Exception as e:
-        logger.warning("yt-dlp probe failed unexpectedly: %s: %s", type(e).__name__, e)
-        msg = "yt-dlp probe failed"
-        raise TranscriptDownloadError(msg) from e
-
-    if info is None:
-        msg = "No subtitles available via yt-dlp"
-        raise DownloadError(msg)
-
-    manual = info.get("subtitles") or {}
-    auto = info.get("automatic_captions") or {}
-
-    # yt-dlp lists "live_chat" under subtitles for live-stream replays; it is not a
-    # real subtitle track and cannot be converted to vtt, so drop it.
-    manual_langs = [lang for lang in manual if lang != "live_chat"]
-
-    if manual_langs:
-        # Human-uploaded tracks are genuine: prefer English, then the video's original
-        # language, then the first offered key.
-        en_manual = next((lang for lang in manual_langs if lang.startswith("en")), None)
-        orig = info.get("language")
-        chosen_langs = [
-            en_manual or (orig if orig in manual_langs else manual_langs[0]),
-        ]
-    elif auto:
-        # automatic_captions include machine translations for ~every language, so an
-        # "en" key here is usually a translation, not a real track — request the
-        # video's original language and let the summarizer translate.
-        orig = info.get("language")
-        if orig and orig in auto:
-            chosen_langs = [orig]
-        else:
-            chosen_langs = [
-                next(
-                    (lang for lang in auto if lang.endswith("-orig")),
-                    next(iter(auto)),
-                ),
-            ]
-    else:
-        msg = "No subtitles available via yt-dlp"
-        raise DownloadError(msg)
-
-    ydl_opts: dict[str, Any] = {
-        "proxy": proxy,
-        "noplaylist": True,
-        "skip_download": True,
-        "writesubtitles": True,
-        "writeautomaticsub": True,
-        "subtitleslangs": chosen_langs,
-        "subtitlesformat": "vtt/best",
-        "postprocessors": [
-            {
-                "key": "FFmpegSubtitlesConvertor",
-                "format": "vtt",
-                "when": "before_dl",
-            },
-        ],
-        "outtmpl": temp_basename,
-        "quiet": True,
-        "nocheckcertificate": False,
-    }
-
-    # Phase 2: download and convert subtitles.
-    try:
-        try:
-            with YoutubeDL(ydl_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
-                ydl.download([url])
-        except DownloadError as e:
-            logger.warning(
-                "yt-dlp subtitle fetch failed: %s: %s",
-                type(e).__name__,
-                e,
+        """
+        model = self._client.models.get("victor-upmeet/whisperx")
+        version = model.versions.list()[0]
+        with Path(file).open("rb") as audio:
+            prediction = self._client.predictions.create(
+                version=version,
+                input={"audio_file": audio},
             )
+        while prediction.status != "succeeded":
+            if prediction.status in ("failed", "canceled"):
+                raise ModelError(prediction)
+            prediction.reload()
+            time.sleep(sleep_time)
+        if prediction.output is None:
+            raise ModelError(prediction)
+        segments = prediction.output.get("segments")
+        if not isinstance(segments, list):
+            raise ModelError(prediction)
+        return "".join(
+            [
+                segment.get("text", "")
+                for segment in segments
+                if isinstance(segment, dict)
+            ],
+        )
+
+
+class YouTubeTranscriber:
+    """Retrieves YouTube transcripts via yt-dlp (primary) or the API (fallback)."""
+
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(10),
+        retry=retry_if_exception_type(
+            (
+                ParseError,
+                IpBlocked,
+                RequestBlocked,
+                ProxyError,
+                SSLError,
+                ChunkedEncodingError,
+            ),
+        ),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
+    )
+    def fetch_via_api(self, video_id: str) -> str:
+        """Retrieve and format a YouTube transcript via youtube_transcript_api.
+
+        Args:
+            video_id (str): The YouTube video ID.
+
+        Returns:
+            str: The formatted transcript text.
+
+        Raises:
+            NoTranscriptFound: If no transcript is found in any language.
+            CouldNotRetrieveTranscript: Subclasses propagate to the caller.
+            RetryError: If transient errors persist after retries.
+
+        """
+        proxy = get_proxy()
+        if proxy:
+            ytt_api = YouTubeTranscriptApi(
+                proxy_config=GenericProxyConfig(https_url=proxy),
+            )
+        else:
+            ytt_api = YouTubeTranscriptApi()
+
+        try:
+            transcript = ytt_api.fetch(video_id)
+        except NoTranscriptFound:
+            transcript_list = ytt_api.list(video_id)
+            language_codes = [t.language_code for t in transcript_list]
+            time.sleep(60)
+            transcript = ytt_api.fetch(video_id, languages=language_codes)
+        return TextFormatter().format_transcript(transcript)
+
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(10),
+        retry=retry_if_exception_type(TranscriptDownloadError),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
+    )
+    def fetch_via_ytdlp(self, url: str) -> str:  # noqa: C901, PLR0912, PLR0915
+        """Retrieve a YouTube transcript by downloading subtitles via yt-dlp.
+
+        Probes available tracks first, preferring genuine manual subtitles (English
+        when present) and otherwise the video's original-language automatic captions,
+        then converts to vtt via ffmpeg.
+
+        Args:
+            url (str): The YouTube video URL.
+
+        Returns:
+            str: The transcript as plain text.
+
+        Raises:
+            DownloadError: If no subtitles are available or vtt conversion fails.
+            TranscriptDownloadError: Wraps transient yt-dlp failures; retried once.
+            RetryError: If TranscriptDownloadError persists after all retries.
+
+        """
+        temp_basename = generate_temporary_name()
+        proxy = get_proxy()
+        probe_opts: dict[str, Any] = {
+            "proxy": proxy,
+            "noplaylist": True,
+            "skip_download": True,
+            "quiet": True,
+            "nocheckcertificate": False,
+        }
+
+        # Phase 1: probe available subtitle tracks (no download, no temp files).
+        try:
+            with YoutubeDL(probe_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
+                info = ydl.extract_info(url, download=False)
+        except DownloadError as e:
+            logger.warning("yt-dlp probe failed: %s: %s", type(e).__name__, e)
             raise TranscriptDownloadError(str(e)) from e
         except Exception as e:
             logger.warning(
-                "yt-dlp subtitle fetch failed unexpectedly: %s: %s",
+                "yt-dlp probe failed unexpectedly: %s: %s",
                 type(e).__name__,
                 e,
             )
-            msg = "yt-dlp subtitle fetch failed"
+            msg = "yt-dlp probe failed"
             raise TranscriptDownloadError(msg) from e
 
-        vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
-
-        if not vtt_files:
+        if info is None:
             msg = "No subtitles available via yt-dlp"
             raise DownloadError(msg)
 
+        manual = info.get("subtitles") or {}
+        auto = info.get("automatic_captions") or {}
+
+        # yt-dlp lists "live_chat" under subtitles for live-stream replays; it is not
+        # a real subtitle track and cannot be converted to vtt, so drop it.
+        manual_langs = [lang for lang in manual if lang != "live_chat"]
+
+        if manual_langs:
+            en_manual = next(
+                (lang for lang in manual_langs if lang.startswith("en")),
+                None,
+            )
+            orig = info.get("language")
+            chosen_langs = [
+                en_manual or (orig if orig in manual_langs else manual_langs[0]),
+            ]
+        elif auto:
+            orig = info.get("language")
+            if orig and orig in auto:
+                chosen_langs = [orig]
+            else:
+                chosen_langs = [
+                    next(
+                        (lang for lang in auto if lang.endswith("-orig")),
+                        next(iter(auto)),
+                    ),
+                ]
+        else:
+            msg = "No subtitles available via yt-dlp"
+            raise DownloadError(msg)
+
+        ydl_opts: dict[str, Any] = {
+            "proxy": proxy,
+            "noplaylist": True,
+            "skip_download": True,
+            "writesubtitles": True,
+            "writeautomaticsub": True,
+            "subtitleslangs": chosen_langs,
+            "subtitlesformat": "vtt/best",
+            "postprocessors": [
+                {
+                    "key": "FFmpegSubtitlesConvertor",
+                    "format": "vtt",
+                    "when": "before_dl",
+                },
+            ],
+            "outtmpl": temp_basename,
+            "quiet": True,
+            "nocheckcertificate": False,
+        }
+
+        # Phase 2: download and convert subtitles.
         try:
-            return vtt_to_text(sorted(vtt_files)[0])
-        except Exception as e:
-            msg = "Failed to read downloaded VTT file"
-            raise DownloadError(msg) from e
-    finally:
-        for f in Path.cwd().glob(f"{temp_basename}.*"):
-            clean_up(file=str(f))
+            try:
+                with YoutubeDL(ydl_opts) as ydl:  # pyrefly: ignore[bad-argument-type]
+                    ydl.download([url])
+            except DownloadError as e:
+                logger.warning(
+                    "yt-dlp subtitle fetch failed: %s: %s",
+                    type(e).__name__,
+                    e,
+                )
+                raise TranscriptDownloadError(str(e)) from e
+            except Exception as e:
+                logger.warning(
+                    "yt-dlp subtitle fetch failed unexpectedly: %s: %s",
+                    type(e).__name__,
+                    e,
+                )
+                msg = "yt-dlp subtitle fetch failed"
+                raise TranscriptDownloadError(msg) from e
+
+            vtt_files = list(Path.cwd().glob(f"{temp_basename}.*.vtt"))
+
+            if not vtt_files:
+                msg = "No subtitles available via yt-dlp"
+                raise DownloadError(msg)
+
+            try:
+                return vtt_to_text(sorted(vtt_files)[0])
+            except Exception as e:
+                msg = "Failed to read downloaded VTT file"
+                raise DownloadError(msg) from e
+        finally:
+            for f in Path.cwd().glob(f"{temp_basename}.*"):
+                clean_up(file=str(f))
+
+    def get_transcript(self, url: str) -> PrefixedText:
+        """Retrieve the transcript from a YouTube video URL.
+
+        Tries yt-dlp first; falls back to youtube_transcript_api.
+
+        Args:
+            url (str): The YouTube video URL.
+
+        Returns:
+            PrefixedText: The transcript text and display prefix. 📹 = yt-dlp;
+                📺 = youtube_transcript_api fallback.
+
+        Raises:
+            ValueError: If the URL format is not recognized.
+            FetchTranscriptError: If both backends fail.
+
+        """
+        video_id = extract_youtube_video_id(url)
+        if video_id is None:
+            msg = "Unknown URL"
+            raise ValueError(msg)
+
+        try:
+            text = self.fetch_via_ytdlp(url)
+        except (DownloadError, RetryError) as ytdlp_error:
+            logger.warning(
+                "yt-dlp transcript backend failed, falling back to API: %s",
+                ytdlp_error,
+            )
+            try:
+                text = self.fetch_via_api(video_id)
+            except (CouldNotRetrieveTranscript, RetryError) as api_error:
+                logger.warning("API fallback backend also failed: %s", api_error)
+                msg = "Both transcript backends failed"
+                raise FetchTranscriptError(msg) from api_error
+            return PrefixedText(text=text, prefix="📺")
+        return PrefixedText(text=text, prefix="📹")
+
+
+# ---------------------------------------------------------------------------
+# Module-level singletons
+# ---------------------------------------------------------------------------
+
+audio_transcriber = AudioTranscriber(replicate_client)
+yt_transcriber = YouTubeTranscriber()
+
+
+# ---------------------------------------------------------------------------
+# Module-level aliases — preserve the existing public API
+# ---------------------------------------------------------------------------
+
+
+def transcribe(file: str, sleep_time: int = 10) -> str:
+    """Transcribe an audio file using WhisperX via Replicate."""
+    return audio_transcriber.transcribe(file, sleep_time=sleep_time)
+
+
+def fetch_transcript_via_api(video_id: str) -> str:
+    """Retrieve and format a YouTube transcript via youtube_transcript_api."""
+    return yt_transcriber.fetch_via_api(video_id)
+
+
+def fetch_transcript_via_ytdlp(url: str) -> str:
+    """Retrieve a YouTube transcript by downloading subtitles via yt-dlp."""
+    return yt_transcriber.fetch_via_ytdlp(url)
 
 
 def get_yt_transcript(url: str) -> PrefixedText:
-    """Retrieve and format the transcript from a YouTube video URL.
-
-    Downloads subtitles via yt-dlp first and falls back to
-    youtube_transcript_api when yt-dlp retrieval fails.
-
-    Args:
-        url (str): The YouTube video URL.
-
-    Returns:
-        PrefixedText: The transcript text and display prefix. The 📹
-            prefix means yt-dlp succeeded; 📺 means the youtube_transcript_api
-            fallback succeeded.
-
-    Raises:
-        ValueError: If the URL format is not recognized.
-        FetchTranscriptError: If both the yt-dlp and youtube_transcript_api
-            backends fail.
-
-    """
-    video_id = extract_youtube_video_id(url)
-    if video_id is None:
-        msg = "Unknown URL"
-        raise ValueError(msg)
-
-    try:
-        text = fetch_transcript_via_ytdlp(url)
-    except (DownloadError, RetryError) as ytdlp_error:
-        logger.warning(
-            "yt-dlp transcript backend failed, falling back to API: %s",
-            ytdlp_error,
-        )
-        try:
-            text = fetch_transcript_via_api(video_id)
-        except (CouldNotRetrieveTranscript, RetryError) as api_error:
-            logger.warning("API fallback backend also failed: %s", api_error)
-            msg = "Both transcript backends failed"
-            raise FetchTranscriptError(msg) from api_error
-        return PrefixedText(text=text, prefix="📺")
-    return PrefixedText(text=text, prefix="📹")
+    """Retrieve the transcript from a YouTube video URL."""
+    return yt_transcriber.get_transcript(url)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,8 +3,7 @@ from pathlib import Path
 import pytest
 from curl_cffi.requests.exceptions import HTTPError
 
-from download import download_castro, download_tg, download_yt
-from services import choose_yt_audio_format
+from download import choose_yt_audio_format, download_castro, download_tg, download_yt
 
 
 def test_download_tg_happy_path(mocker):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -307,7 +307,10 @@ def test_handle_video_happy_path_cleans_up_download(message_factory, mocker):
 
     handle_message(msg)
 
-    mock_clean_up.assert_called_once_with(file="downloaded.mp4")
+    assert mock_clean_up.call_args_list == [
+        mocker.call(file="downloaded.mp4"),
+        mocker.call(file="compressed.ogg"),
+    ]
 
 
 def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker):
@@ -333,7 +336,47 @@ def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker
 
     handle_message(msg)
 
-    mock_clean_up.assert_called_once_with(file="downloaded.mp4")
+    assert mock_clean_up.call_args_list == [
+        mocker.call(file="downloaded.mp4"),
+        mocker.call(file="compressed.ogg"),
+    ]
+
+
+def test_handle_video_cleans_up_compressed_file_when_summarize_raises(
+    message_factory, mocker
+):
+    """Test the compressed temp file is removed even if summarize() raises early.
+
+    summarize()'s preflight quota check can raise LimitExceededError before its
+    own cleanup runs, so _handle_video_like must clean up the file it created.
+    """
+    msg = message_factory(content_type="video")
+    mocker.patch(
+        "main.select_user",
+        return_value=mocker.MagicMock(
+            approved=True,
+            summarizing_model="model",
+            prompt_key_for_summary="prompt",
+            target_language="English",
+        ),
+    )
+    mock_file = mocker.MagicMock(spec=types.File)
+    mocker.patch("handlers.get_file_with_retry", return_value=mock_file)
+    mocker.patch("handlers.download_tg", return_value="downloaded.mp4")
+    mocker.patch("handlers.generate_temporary_name", return_value="compressed.ogg")
+    mocker.patch("handlers.compress_audio")
+    mocker.patch("handlers.summarize", side_effect=LimitExceededError("blocked"))
+    mocker.patch("handlers.send_answer")
+    mocker.patch("main.bot.reply_to")
+    mocker.patch("main.capture_exception")
+    mock_clean_up = mocker.patch("handlers.clean_up")
+
+    handle_message(msg)
+
+    assert mock_clean_up.call_args_list == [
+        mocker.call(file="downloaded.mp4"),
+        mocker.call(file="compressed.ogg"),
+    ]
 
 
 def test_handle_video_note_file_too_large(message_factory, mocker):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -4,19 +4,36 @@ import pytest
 from tavily.errors import TimeoutError as TavilyTimeoutError
 from tenacity import RetryError
 
+import parsing
 from exceptions import WebParseError
-from parsing import parse_url
+from parsing import ExaBackend, TavilyBackend, WebParser, parse_url
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_parser(mocker):
+    """Return (parser, mock_exa_client, mock_tavily_client)."""
+    mock_exa = mocker.MagicMock()
+    mock_tavily = mocker.MagicMock()
+    parser = WebParser(ExaBackend(mock_exa), TavilyBackend(mock_tavily))
+    return parser, mock_exa, mock_tavily
+
+
+# ---------------------------------------------------------------------------
+# WebParser orchestration tests
+# ---------------------------------------------------------------------------
 
 def test_parse_url_returns_exa_content(mocker):
-    """parse_url returns Exa's text and does not call Tavily on success."""
-    mock_exa = mocker.patch("parsing.exa_client")
+    """parse returns Exa's text and does not call Tavily on success."""
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(
         results=[mocker.Mock(text="Hello world.")],
     )
-    mock_tavily = mocker.patch("parsing.tavily_client")
 
-    result = parse_url("https://example.com")
+    result = parser.parse("https://example.com")
+
     assert result.text == "Hello world."
     assert result.prefix == "🌐"
     mock_exa.get_contents.assert_called_once_with(
@@ -27,20 +44,18 @@ def test_parse_url_returns_exa_content(mocker):
 
 
 def test_parse_url_falls_back_to_tavily_when_exa_has_no_results(mocker, caplog):
-    """parse_url falls back to Tavily when Exa returns no results."""
+    """parse falls back to Tavily when Exa returns no results."""
     mocker.patch("time.sleep")
-    mock_exa = mocker.patch("parsing.exa_client")
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
-    mock_tavily = mocker.patch("parsing.tavily_client")
     mock_tavily.extract.return_value = {
-        "results": [
-            {"url": "https://example.com", "raw_content": "From Tavily."},
-        ],
+        "results": [{"url": "https://example.com", "raw_content": "From Tavily."}],
         "failed_results": [],
     }
 
     with caplog.at_level(logging.WARNING, logger="parsing"):
-        result = parse_url("https://example.com")
+        result = parser.parse("https://example.com")
+
     assert result.text == "From Tavily."
     assert result.prefix == "🕸️"
     mock_tavily.extract.assert_called_once_with(
@@ -51,35 +66,35 @@ def test_parse_url_falls_back_to_tavily_when_exa_has_no_results(mocker, caplog):
 
 
 def test_parse_url_falls_back_to_tavily_on_exa_empty_content(mocker):
-    """parse_url falls back to Tavily when Exa returns empty content."""
+    """parse falls back to Tavily when Exa returns empty content."""
     mocker.patch("time.sleep")
-    mock_exa = mocker.patch("parsing.exa_client")
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(
         results=[mocker.Mock(text="   ")],
     )
-    mock_tavily = mocker.patch("parsing.tavily_client")
     mock_tavily.extract.return_value = {
         "results": [{"url": "https://example.com", "raw_content": "From Tavily."}],
         "failed_results": [],
     }
 
-    result = parse_url("https://example.com")
+    result = parser.parse("https://example.com")
+
     assert result.text == "From Tavily."
     assert result.prefix == "🕸️"
 
 
 def test_parse_url_falls_back_to_tavily_when_exa_retries_exhausted(mocker):
-    """parse_url falls back to Tavily after Exa exhausts its retries."""
+    """parse falls back to Tavily after Exa exhausts its retries."""
     mocker.patch("time.sleep")
-    mock_exa = mocker.patch("parsing.exa_client")
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
-    mock_tavily = mocker.patch("parsing.tavily_client")
     mock_tavily.extract.return_value = {
         "results": [{"url": "https://example.com", "raw_content": "From Tavily."}],
         "failed_results": [],
     }
 
-    result = parse_url("https://example.com")
+    result = parser.parse("https://example.com")
+
     assert result.text == "From Tavily."
     assert result.prefix == "🕸️"
     assert mock_exa.get_contents.call_count == 2
@@ -87,16 +102,16 @@ def test_parse_url_falls_back_to_tavily_when_exa_retries_exhausted(mocker):
 
 
 def test_parse_url_retries_exa_empty_then_succeeds(mocker):
-    """parse_url retries a transient empty Exa result and returns content."""
+    """parse retries a transient empty Exa result and returns content."""
     mocker.patch("time.sleep")
-    mock_exa = mocker.patch("parsing.exa_client")
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.side_effect = [
         mocker.Mock(results=[]),
         mocker.Mock(results=[mocker.Mock(text="Hello world.")]),
     ]
-    mock_tavily = mocker.patch("parsing.tavily_client")
 
-    result = parse_url("https://example.com")
+    result = parser.parse("https://example.com")
+
     assert result.text == "Hello world."
     assert result.prefix == "🌐"
     assert mock_exa.get_contents.call_count == 2
@@ -104,40 +119,38 @@ def test_parse_url_retries_exa_empty_then_succeeds(mocker):
 
 
 def test_parse_url_tavily_fallback_retries_timeout_then_succeeds(mocker):
-    """parse_url's Tavily fallback retries a transient timeout then succeeds."""
+    """parse's Tavily fallback retries a transient timeout then succeeds."""
     mocker.patch("time.sleep")
-    mock_exa = mocker.patch("parsing.exa_client")
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
-    mock_tavily = mocker.patch("parsing.tavily_client")
     mock_tavily.extract.side_effect = [
         TavilyTimeoutError("Request timed out after 30 seconds."),
         {
-            "results": [
-                {"url": "https://example.com", "raw_content": "From Tavily."},
-            ],
+            "results": [{"url": "https://example.com", "raw_content": "From Tavily."}],
             "failed_results": [],
         },
     ]
 
-    result = parse_url("https://example.com")
+    result = parser.parse("https://example.com")
+
     assert result.text == "From Tavily."
     assert result.prefix == "🕸️"
     assert mock_tavily.extract.call_count == 2
 
 
 def test_parse_url_raises_when_both_backends_fail(mocker, caplog):
-    """parse_url raises WebParseError when both Exa and Tavily fail."""
+    """parse raises WebParseError when both Exa and Tavily fail."""
     mocker.patch("time.sleep")
-    mock_exa = mocker.patch("parsing.exa_client")
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
-    mock_tavily = mocker.patch("parsing.tavily_client")
     mock_tavily.extract.return_value = {"results": [], "failed_results": []}
 
     with (
         caplog.at_level(logging.WARNING, logger="parsing"),
         pytest.raises(WebParseError, match="Both parsing backends failed") as exc_info,
     ):
-        parse_url("https://example.com")
+        parser.parse("https://example.com")
+
     assert "Exa parsing backend failed, falling back to Tavily" in caplog.text
     assert "Tavily fallback backend also failed" in caplog.text
     assert mock_exa.get_contents.call_count == 2
@@ -145,11 +158,10 @@ def test_parse_url_raises_when_both_backends_fail(mocker, caplog):
 
 
 def test_parse_url_raises_when_tavily_fallback_returns_empty_content(mocker, caplog):
-    """parse_url raises WebParseError when the Tavily fallback returns empty."""
+    """parse raises WebParseError when the Tavily fallback returns empty content."""
     mocker.patch("time.sleep")
-    mock_exa = mocker.patch("parsing.exa_client")
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
-    mock_tavily = mocker.patch("parsing.tavily_client")
     mock_tavily.extract.return_value = {
         "results": [{"url": "https://example.com", "raw_content": "   "}],
         "failed_results": [],
@@ -159,18 +171,18 @@ def test_parse_url_raises_when_tavily_fallback_returns_empty_content(mocker, cap
         caplog.at_level(logging.WARNING, logger="parsing"),
         pytest.raises(WebParseError, match="Both parsing backends failed") as exc_info,
     ):
-        parse_url("https://example.com")
+        parser.parse("https://example.com")
+
     assert "Tavily returned empty content for" in caplog.text
     mock_tavily.extract.assert_called_once()
     assert isinstance(exc_info.value.__cause__, WebParseError)
 
 
 def test_parse_url_falls_back_when_tavily_times_out(mocker, caplog):
-    """parse_url raises combined failure when the Tavily fallback keeps timing out."""
+    """parse raises combined failure when the Tavily fallback keeps timing out."""
     mocker.patch("time.sleep")
-    mock_exa = mocker.patch("parsing.exa_client")
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
-    mock_tavily = mocker.patch("parsing.tavily_client")
     mock_tavily.extract.side_effect = TavilyTimeoutError(
         "Request timed out after 30 seconds.",
     )
@@ -179,19 +191,33 @@ def test_parse_url_falls_back_when_tavily_times_out(mocker, caplog):
         caplog.at_level(logging.WARNING, logger="parsing"),
         pytest.raises(WebParseError, match="Both parsing backends failed") as exc_info,
     ):
-        parse_url("https://example.com")
+        parser.parse("https://example.com")
+
     assert mock_tavily.extract.call_count == 2
     assert "Tavily fallback backend also failed" in caplog.text
     assert isinstance(exc_info.value.__cause__, RetryError)
 
 
 def test_parse_url_propagates_non_retryable_exa_error(mocker):
-    """parse_url lets non-retryable Exa errors propagate without trying Tavily."""
-    mock_exa = mocker.patch("parsing.exa_client")
+    """parse lets non-retryable Exa errors propagate without trying Tavily."""
+    parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.side_effect = RuntimeError("boom")
-    mock_tavily = mocker.patch("parsing.tavily_client")
 
     with pytest.raises(RuntimeError, match="boom"):
-        parse_url("https://example.com")
+        parser.parse("https://example.com")
+
     mock_exa.get_contents.assert_called_once()
     mock_tavily.extract.assert_not_called()
+
+
+def test_parse_url_delegates_to_web_parser(mocker):
+    """parse_url routes to the module-level web_parser singleton."""
+    from domain import PrefixedText
+
+    mock_result = PrefixedText(text="hello", prefix="🌐")
+    mock_parse = mocker.patch.object(parsing.web_parser, "parse", return_value=mock_result)
+
+    result = parse_url("https://example.com")
+
+    assert result is mock_result
+    mock_parse.assert_called_once_with("https://example.com")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,7 +9,6 @@ from services import (
     get_file_with_retry,
     get_gemini_config,
     get_remaining_quota,
-    _reply_with_retry,
     resolve_mime_type,
     send_answer,
     upload_and_wait_for_file,
@@ -21,7 +20,7 @@ def test__reply_with_retry_happy_path(mocker):
     mock_bot = mocker.patch("services.bot")
     mock_msg = mocker.MagicMock()
 
-    _reply_with_retry(mock_msg, "hello")
+    services_module.messenger._reply_with_retry(mock_msg, "hello")
 
     mock_bot.reply_to.assert_called_once_with(mock_msg, "hello")
 
@@ -32,7 +31,7 @@ def test__reply_with_retry_with_entities(mocker):
     mock_msg = mocker.MagicMock()
     entities = [{"type": "bold"}]
 
-    _reply_with_retry(mock_msg, "hello", entities=entities)
+    services_module.messenger._reply_with_retry(mock_msg, "hello", entities=entities)
 
     mock_bot.reply_to.assert_called_once_with(mock_msg, "hello", entities=entities)
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2,6 +2,7 @@ import pytest
 from google.genai import types
 from limits.util import WindowStats
 
+import services as services_module
 from exceptions import LimitExceededError
 from services import (
     check_quota,
@@ -57,7 +58,7 @@ def test_send_answer_single_chunk(mocker):
         "services.split_entities", return_value=[("text", [mock_entity])]
     )
 
-    mock_reply = mocker.patch("services._reply_with_retry")
+    mock_reply = mocker.patch.object(services_module.messenger, "_reply_with_retry")
     mock_msg = mocker.MagicMock()
 
     send_answer(mock_msg, "short answer")
@@ -71,7 +72,7 @@ def test_send_answer_multi_chunk(mocker):
     """Test send_answer with a long message (multiple chunks)."""
     mocker.patch("services.convert", return_value=("text", []))
     mocker.patch("services.split_entities", return_value=[("part1", []), ("part2", [])])
-    mock_reply = mocker.patch("services._reply_with_retry")
+    mock_reply = mocker.patch.object(services_module.messenger, "_reply_with_retry")
     mocker.patch("services.time.sleep")
 
     mock_msg = mocker.MagicMock()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -4,6 +4,7 @@ import pytest
 from google.genai.errors import ClientError
 from tenacity import RetryError
 
+import summary as summary_module
 from exceptions import FetchTranscriptError
 from services import resolve_mime_type
 from summary import (
@@ -275,7 +276,7 @@ def test_summarize_youtube_always_attempts_transcript(mocker):
         "summary.get_yt_transcript",
         return_value=SimpleNamespace(text="YT Transcript", prefix="📹"),
     )
-    mocker.patch("summary.summarize_with_transcript", return_value="Summary")
+    mocker.patch.object(summary_module.summarizer, "summarize_with_transcript", return_value="Summary")
 
     summarize(
         data=url,
@@ -298,8 +299,9 @@ def test_summarize_youtube_direct_transcript(mocker):
         "summary.get_yt_transcript",
         return_value=SimpleNamespace(text="YT Transcript content", prefix="📹"),
     )
-    mock_sum_transcript = mocker.patch(
-        "summary.summarize_with_transcript",
+    mock_sum_transcript = mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_transcript",
         return_value="- first point\n- second point",
     )
 
@@ -334,8 +336,9 @@ def test_summarize_youtube_direct_transcript_uses_blank_line_separator(mocker):
         "summary.get_yt_transcript",
         return_value=SimpleNamespace(text="YT Transcript content", prefix="📹"),
     )
-    mocker.patch(
-        "summary.summarize_with_transcript",
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_transcript",
         return_value="- first point\n- second point",
     )
 
@@ -360,8 +363,9 @@ def test_summarize_youtube_fallback_transcript_uses_fallback_prefix(mocker):
         "summary.get_yt_transcript",
         return_value=SimpleNamespace(text="YT Transcript content", prefix="📺"),
     )
-    mocker.patch(
-        "summary.summarize_with_transcript",
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_transcript",
         return_value="- first point\n- second point",
     )
 
@@ -388,9 +392,9 @@ def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
         return_value=SimpleNamespace(text="YT Transcript content", prefix="📹"),
     )
     mock_download = mocker.patch("summary.download_yt")
-    mock_file_summary = mocker.patch("summary.summarize_with_file")
+    mock_file_summary = mocker.patch.object(summary_module.summarizer, "summarize_with_file")
     mock_transcribe = mocker.patch("summary.transcribe")
-    mocker.patch("summary.summarize_with_transcript", side_effect=retry_error)
+    mocker.patch.object(summary_module.summarizer, "summarize_with_transcript", side_effect=retry_error)
 
     with pytest.raises(RetryError):
         summarize(
@@ -417,7 +421,7 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(mocker):
         side_effect=FetchTranscriptError("transcript failed"),
     )
     mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
-    mocker.patch("summary.summarize_with_file", return_value="File summary")
+    mocker.patch.object(summary_module.summarizer, "summarize_with_file", return_value="File summary")
     mock_clean_up = mocker.patch("summary.clean_up")
     mock_logger = mocker.patch("summary.logger")
 
@@ -446,7 +450,7 @@ def test_summarize_youtube_transcript_value_error_falls_back_to_download(mocker)
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("summary.get_yt_transcript", side_effect=ValueError("no transcript"))
     mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
-    mocker.patch("summary.summarize_with_file", return_value="File summary")
+    mocker.patch.object(summary_module.summarizer, "summarize_with_file", return_value="File summary")
     mock_clean_up = mocker.patch("summary.clean_up")
     mock_logger = mocker.patch("summary.logger")
 
@@ -472,15 +476,17 @@ def test_summarize_youtube_transcript_value_error_falls_back_to_download(mocker)
 def test_summarize_fallback_to_transcription(mocker):
     """Test summarize() fallback to transcription (📝 prefix) when file summary fails."""
     mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch(
-        "summary.summarize_with_file",
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_file",
         side_effect=RetryError(mocker.MagicMock()),
     )
     mocker.patch("summary.generate_temporary_name", return_value="temp.ogg")
     mocker.patch("summary.compress_audio")
     mocker.patch("summary.transcribe", return_value="Transcription text")
-    mocker.patch(
-        "summary.summarize_with_transcript",
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_transcript",
         return_value="- transcript point\n- follow-up point",
     )
     mock_clean_up = mocker.patch("summary.clean_up")
@@ -508,8 +514,9 @@ def test_summarize_fallback_to_transcription(mocker):
 def test_summarize_fallback_cleans_up_temp_file_when_compress_fails(mocker):
     """Test summarize() cleans up the temp file even if compress_audio raises."""
     mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch(
-        "summary.summarize_with_file",
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_file",
         side_effect=RetryError(mocker.MagicMock()),
     )
     mocker.patch("summary.generate_temporary_name", return_value="temp.ogg")
@@ -535,7 +542,7 @@ def test_summarize_castro(mocker):
     url = "https://castro.fm/episode/123"
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("summary.download_castro", return_value="downloaded.mp3")
-    mocker.patch("summary.summarize_with_file", return_value="Castro summary")
+    mocker.patch.object(summary_module.summarizer, "summarize_with_file", return_value="Castro summary")
     mocker.patch("summary.clean_up")
 
     result = summarize(
@@ -849,7 +856,7 @@ def test_summarize_with_telegram_file(mocker):
 
     mocker.patch("summary.check_quota", return_value=True)
     mock_download_tg = mocker.patch("summary.download_tg", return_value="downloaded.ogg")
-    mocker.patch("summary.summarize_with_file", return_value="Telegram file summary")
+    mocker.patch.object(summary_module.summarizer, "summarize_with_file", return_value="Telegram file summary")
     mocker.patch("summary.clean_up")
     mock_tg_file = mocker.MagicMock(spec=File)
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -24,7 +24,6 @@ from transcription import (
     fetch_transcript_via_api,
     fetch_transcript_via_ytdlp,
     get_yt_transcript,
-    transcribe,
 )
 from utils import vtt_to_text
 
@@ -947,11 +946,3 @@ def test_transcribe_invalid_segments_raises_model_error(mocker):
 
     with pytest.raises(ModelError):
         AudioTranscriber(mock_replicate).transcribe("test.ogg")
-
-
-def test_transcribe_module_wrapper_delegates_to_singleton(mocker):
-    """transcribe() delegates to the module-level audio_transcriber singleton."""
-    mock = mocker.patch.object(transcription.audio_transcriber, "transcribe", return_value="ok")
-    result = transcribe("audio.ogg", sleep_time=5)
-    assert result == "ok"
-    mock.assert_called_once_with("audio.ogg", sleep_time=5)

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -13,12 +13,14 @@ from youtube_transcript_api._errors import (
 )
 from yt_dlp.utils import DownloadError
 
+import transcription
+from domain import PrefixedText
 from exceptions import (
     FetchTranscriptError,
     TranscriptDownloadError,
 )
-from services import PrefixedText
 from transcription import (
+    AudioTranscriber,
     fetch_transcript_via_api,
     fetch_transcript_via_ytdlp,
     get_yt_transcript,
@@ -48,7 +50,7 @@ def test_get_yt_transcript_uses_ytdlp_primary(mocker, tmp_path):
         "subtitles": {"en": [{}]},
         "automatic_captions": {},
     }
-    mock_api = mocker.patch("transcription.fetch_transcript_via_api")
+    mock_api = mocker.patch.object(transcription.yt_transcriber, "fetch_via_api")
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     result = get_yt_transcript(url)
@@ -73,12 +75,14 @@ def test_get_yt_transcript_falls_back_to_api(mocker, url):
     Parametrized across URL formats to confirm each resolves to the same
     video_id that is handed to the API backend.
     """
-    mocker.patch(
-        "transcription.fetch_transcript_via_ytdlp",
+    mocker.patch.object(
+        transcription.yt_transcriber,
+        "fetch_via_ytdlp",
         side_effect=DownloadError("no subs"),
     )
-    mock_api = mocker.patch(
-        "transcription.fetch_transcript_via_api",
+    mock_api = mocker.patch.object(
+        transcription.yt_transcriber,
+        "fetch_via_api",
         return_value="from fallback",
     )
 
@@ -92,8 +96,8 @@ def test_get_yt_transcript_both_backends_fail_raises_error(mocker):
     """Test get_yt_transcript raises FetchTranscriptError chained from the API failure."""
     ytdlp_error = DownloadError("no subs")
     api_error = TranscriptsDisabled("dQw4w9WgXcQ")
-    mocker.patch("transcription.fetch_transcript_via_ytdlp", side_effect=ytdlp_error)
-    mocker.patch("transcription.fetch_transcript_via_api", side_effect=api_error)
+    mocker.patch.object(transcription.yt_transcriber, "fetch_via_ytdlp", side_effect=ytdlp_error)
+    mocker.patch.object(transcription.yt_transcriber, "fetch_via_api", side_effect=api_error)
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with pytest.raises(FetchTranscriptError) as exc_info:
@@ -104,8 +108,8 @@ def test_get_yt_transcript_both_backends_fail_raises_error(mocker):
 
 def test_get_yt_transcript_unknown_url(mocker):
     """Test get_yt_transcript raises ValueError for unknown URL formats."""
-    mock_api = mocker.patch("transcription.fetch_transcript_via_api")
-    mock_ytdlp = mocker.patch("transcription.fetch_transcript_via_ytdlp")
+    mock_api = mocker.patch.object(transcription.yt_transcriber, "fetch_via_api")
+    mock_ytdlp = mocker.patch.object(transcription.yt_transcriber, "fetch_via_ytdlp")
 
     with pytest.raises(ValueError, match="Unknown URL"):
         get_yt_transcript("https://example.com/not-youtube")
@@ -870,7 +874,7 @@ def test_fetch_transcript_via_ytdlp_pins_proxy_across_probe_and_download(
 
 def test_transcribe_happy_path(mocker):
     """Test transcribing an audio file successfully via Replicate."""
-    mock_replicate = mocker.patch("transcription.replicate_client")
+    mock_replicate = mocker.MagicMock()
     mocker.patch("transcription.Path.open", mocker.mock_open())
     mocker.patch("transcription.time.sleep")  # Don't actually wait
 
@@ -889,7 +893,7 @@ def test_transcribe_happy_path(mocker):
     ]
     mock_replicate.predictions.create.return_value = mock_prediction
 
-    result = transcribe("test.ogg")
+    result = AudioTranscriber(mock_replicate).transcribe("test.ogg")
 
     assert result == "Hello world!"
     mock_prediction.reload.assert_called_once()
@@ -897,7 +901,7 @@ def test_transcribe_happy_path(mocker):
 
 def test_transcribe_failed_prediction(mocker):
     """Test transcribe raises ModelError when prediction fails."""
-    mock_replicate = mocker.patch("transcription.replicate_client")
+    mock_replicate = mocker.MagicMock()
     mocker.patch("transcription.Path.open", mocker.mock_open())
 
     mock_prediction = mocker.MagicMock()
@@ -908,12 +912,12 @@ def test_transcribe_failed_prediction(mocker):
     ]
 
     with pytest.raises(ModelError):
-        transcribe("test.ogg")
+        AudioTranscriber(mock_replicate).transcribe("test.ogg")
 
 
 def test_transcribe_null_output(mocker):
     """Test transcribe raises ModelError when prediction output is None."""
-    mock_replicate = mocker.patch("transcription.replicate_client")
+    mock_replicate = mocker.MagicMock()
     mocker.patch("transcription.Path.open", mocker.mock_open())
 
     mock_prediction = mocker.MagicMock()
@@ -925,12 +929,12 @@ def test_transcribe_null_output(mocker):
     ]
 
     with pytest.raises(ModelError):
-        transcribe("test.ogg")
+        AudioTranscriber(mock_replicate).transcribe("test.ogg")
 
 
 def test_transcribe_invalid_segments_raises_model_error(mocker):
     """Test transcribe raises ModelError when output segments is not a list."""
-    mock_replicate = mocker.patch("transcription.replicate_client")
+    mock_replicate = mocker.MagicMock()
     mocker.patch("transcription.Path.open", mocker.mock_open())
 
     mock_prediction = mocker.MagicMock()
@@ -942,4 +946,12 @@ def test_transcribe_invalid_segments_raises_model_error(mocker):
     ]
 
     with pytest.raises(ModelError):
-        transcribe("test.ogg")
+        AudioTranscriber(mock_replicate).transcribe("test.ogg")
+
+
+def test_transcribe_module_wrapper_delegates_to_singleton(mocker):
+    """transcribe() delegates to the module-level audio_transcriber singleton."""
+    mock = mocker.patch.object(transcription.audio_transcriber, "transcribe", return_value="ok")
+    result = transcribe("audio.ogg", sleep_time=5)
+    assert result == "ok"
+    mock.assert_called_once_with("audio.ogg", sleep_time=5)


### PR DESCRIPTION
## **User description**
## What

Refactors the flat per-module function collections into classes so private helpers belong to the class they serve, while keeping the existing public API intact via module-level singletons and aliases.

- **parsing** — `ParserBackend` ABC + `ExaBackend`/`TavilyBackend` strategy backends, orchestrated by `WebParser`
- **services** — split into `Messenger`, `QuotaManager`, `GeminiHelper`
- **transcription** — `AudioTranscriber` (constructor-injected client) + `YouTubeTranscriber`
- **download** — `Downloader`; `choose_yt_audio_format` relocated here from `services`
- **summary** — `Summarizer`
- **database** — `UserRepository`
- **domain** — new neutral module for `PrefixedText` + `format_prefixed_summary`, breaking the `services` ↔ `parsing`/`transcription` import cycle

## Why

The codebase grew well past its original size and leaned heavily on module-level private functions sitting as siblings of their callers. Grouping each operation's helpers into the class that owns them makes the modules navigable without changing behavior.

## Design notes for reviewers

- **Public API preserved.** Every old module-level name still exists as a singleton-backed alias, so `handlers.py`/`main.py` and external imports are unchanged.
- **Injection is deliberate but selective.** Only the strategy backends (`ExaBackend`/`TavilyBackend`) and `AudioTranscriber` take constructor-injected clients. The other classes read module-level singletons inside their methods — an intentional trade-off to keep existing `mocker.patch("module.name")` targets valid. Tests use `patch.object` on the singleton where a call dispatches through `self`.
- **Private stateless helpers became `@staticmethod`** (`_stream_to_file`, `_reply_with_retry`, `_generate_text`).
- **Second commit** addresses self-review findings: `WebParser` logs are now backend-agnostic (via a `name` attr) instead of hardcoding "Exa"/"Tavily"; dead `format_prefixed_summary` re-export dropped; transcription aliases normalized to bare assignments.

## Verification

`uvx ruff format` / `ruff check` / `ty check` clean; `uv run pytest --cov` → **209 passed, 100% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep bot behavior intact while reorganizing shared helpers**

### What Changed
- Moved parsing, downloading, transcription, summarization, quota, messaging, and user data handling behind named classes while keeping the existing module-level entry points
- Added a shared home for prefixed text formatting so summaries keep the same source labels and spacing
- Kept YouTube transcript and fallback summary flows working the same, including the existing prefix markers for each path
- Updated tests to call the preserved public entry points through the new class-backed singletons

### Impact
`✅ Same summary and transcript output for existing users`
`✅ Fewer import-related breakages in existing integrations`
`✅ Safer future changes to shared bot behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization for improved reliability, clearer backend fallback behavior, and safer resource cleanup; existing user-facing commands and behavior preserved.
  * Downloading, parsing, transcription and summarization flows made more modular and resilient (better format selection, retry/fallback handling, and temp-file cleanup).

* **Tests**
  * Test suite updated to match internal reorganizations and to assert stronger cleanup and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->