### PR TITLE
docs: drop summary-* session artifact, unify to single handoff per session

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -2,7 +2,7 @@ Write a session handoff file for the current session.
 
 Steps:
 
-1. Use the Session Summary/Handoff template in `AGENTS.md`. For a handoff, fill the optional forward-looking tail (What the Next Session Should Do / Files to Load / What NOT to Re-Read) in addition to the core sections.
+1. Use the Handoff template in `AGENTS.md`. Fill the optional forward-looking tail (What the Next Session Should Do / Files to Load / What NOT to Re-Read) in addition to the core sections.
 2. Fill in every field based on what was accomplished in this session. Be specific — include exact file paths for every output, exact numbers discovered, and conditional logic established.
 3. Write the handoff to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`.
 4. If a previous handoff file exists in `docs/summaries/`, move it to `docs/archive/handoffs/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,4 +75,4 @@ If context degrades or auto-compact fires unexpectedly: write current state to `
 
 ## Before Delivering Output
 
-Verify: exact numbers preserved, open questions marked OPEN, output matches what was requested (not assumed), claims backed by specific data, output consistent with stored decisions in `docs/context/`, handoff written/updated to disk for this session's work.
+Verify: exact numbers preserved, open questions marked OPEN, output matches what was requested (not assumed), claims backed by specific data, output consistent with decision records in `docs/summaries/`, handoff written/updated to disk for this session's work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,9 @@ Before starting work, state: what you understand the project state to be, what y
 ## Rules
 
 1. Do not mix unrelated project contexts in one session.
-2. Write state to disk, not conversation. After completing meaningful work, write a summary to `docs/summaries/` using the Session Summary/Handoff template below. Include: decisions with rationale, exact numbers, file paths, open items.
+2. Write state to disk, not conversation. After completing meaningful work, record it in the session handoff at `docs/summaries/handoff-[date]-[topic].md` using the Handoff template below — create it on first write, update it as work progresses. Include: decisions with rationale, exact numbers, file paths, open items.
 3. Before compaction or session end, write to disk: every number, every decision with rationale, every open question, every file path, exact next action.
-4. When switching work types (research → writing → review), write a handoff to `docs/summaries/handoff-[date]-[topic].md` using the Session Summary/Handoff template below (fill the optional tail) and suggest a new session.
+4. When switching work types (research → writing → review) or ending the session, finalize the handoff at `docs/summaries/handoff-[date]-[topic].md` using the Handoff template below (fill the optional tail) and suggest a new session.
 5. Do not silently resolve open questions. Mark them OPEN or ASSUMED.
 6. Do not bulk-read documents. Process one at a time: read, summarize to disk, release from context before reading next. For the detailed protocol, read `docs/context/processing-protocol.md`.
 7. Sub-agent returns must be structured (numbers, file paths, decisions, open items), not free-form prose. See `docs/context/subagent-rules.md`.
@@ -19,12 +19,12 @@ Before starting work, state: what you understand the project state to be, what y
 9. Before every commit, pass: `uvx ruff format .`, `uvx ruff check .`, `uvx ty check .`, `uv run pytest --cov`. Review the coverage report and do not introduce new uncovered lines. See `docs/context/git-guide.md` for the full sequence.
 10. When changing code, update or add tests in the same PR. Treat test maintenance as mandatory — skipping it is equivalent to skipping the pre-commit checks in Rule 9.
 
-## Session Summary / Handoff Template
+## Handoff Template
 
-Write to `docs/summaries/summary-[YYYY-MM-DD]-[topic].md` after meaningful work, or `handoff-[YYYY-MM-DD]-[topic].md` when ending/switching the session — then fill the optional tail and move the previous handoff to `docs/archive/handoffs/`.
+Write to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`. Create it after the first meaningful work and update it as the session proceeds; when ending or switching the session, fill the optional tail and move the previous handoff to `docs/archive/handoffs/`.
 
 ```markdown
-# [Summary | Handoff]: [Topic]
+# Handoff: [Topic]
 **Date:** [YYYY-MM-DD]  **Branch:** [branch]  **Focus:** [one sentence]
 
 ## What Was Accomplished
@@ -59,7 +59,7 @@ Write to `docs/summaries/summary-[YYYY-MM-DD]-[topic].md` after meaningful work,
 
 - `docs/summaries/` — active session state (latest handoff + project-digest + decision records + source summaries)
 - `docs/context/` — reusable domain knowledge, loaded only when relevant to the current task
-  - `agent-templates.md` — decision, analysis, and source-summary templates (read on demand). The session summary/handoff template lives inline in `AGENTS.md` above.
+  - `agent-templates.md` — decision, analysis, and source-summary templates (read on demand). The session handoff template lives inline in `AGENTS.md` above.
   - `processing-protocol.md` — full document processing steps
   - `archive-rules.md` — summary lifecycle and file archival rules
   - `style-guide.md` — writing or coding conventions
@@ -75,4 +75,4 @@ If context degrades or auto-compact fires unexpectedly: write current state to `
 
 ## Before Delivering Output
 
-Verify: exact numbers preserved, open questions marked OPEN, output matches what was requested (not assumed), claims backed by specific data, output consistent with stored decisions in `docs/context/`, summary written to disk for this session's work.
+Verify: exact numbers preserved, open questions marked OPEN, output matches what was requested (not assumed), claims backed by specific data, output consistent with stored decisions in `docs/context/`, handoff written/updated to disk for this session's work.

--- a/docs/context/agent-templates.md
+++ b/docs/context/agent-templates.md
@@ -1,6 +1,6 @@
 # Agent Templates — On-Demand Reference
 
-> **Do NOT read this file at session start.** Read it only when you need to write a decision record, analysis summary, or source-document summary. The session summary/handoff template lives inline in AGENTS.md — not here.
+> **Do NOT read this file at session start.** Read it only when you need to write a decision record, analysis summary, or source-document summary. The session handoff template lives inline in AGENTS.md — not here.
 
 ---
 


### PR DESCRIPTION
## **User description**
## Summary

- Removes the `summary-*` session artifact from the agent workflow (`AGENTS.md`, `agent-templates.md`, `.claude/commands/handoff.md`)
- There is now a single per-session artifact — the **handoff** — created on first meaningful work and updated as the session proceeds, then finalized at end/switch

## Why

The `summary-*` / `handoff-*` split was redundant:

1. **Nothing ever reads `summary-*` back.** The Session Start rule reads only the latest handoff; summaries were write-only relative to any future session.
2. **Latent gap closed.** A session that wrote a `summary-*` but no `handoff-*` left its most recent work invisible to the next session's resume path.
3. **Durability preserved.** Mid-session crash protection is covered by the continuously-updated handoff plus the existing Rule 3 ("before compaction, write to disk").

Rationale recorded in `docs/summaries/decision-11-drop-session-summary-artifact.md` (gitignored, local state).

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | Rule 2 → record in handoff (create on first write, update as work progresses); Rule 4 → "finalize the handoff", added "or ending the session"; section header, template intro and title unified to single handoff path; "Before Delivering Output" wording updated |
| `docs/context/agent-templates.md` | "session summary/handoff template" → "session handoff template" |
| `.claude/commands/handoff.md` | "Session Summary/Handoff template" → "Handoff template" |

## Test plan

- [x] Docs-only change — no code or tests modified
- [x] Pre-commit hooks passed (ruff, ty, pytest all skipped as no Python files changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use a single session handoff instead of separate summary files**

### What Changed
- Session notes now go into one handoff file per session, created after the first meaningful work and updated as the session continues.
- Ending or switching work now finalizes that same handoff instead of writing a separate summary.
- The session handoff template, instructions, and command help text were updated to use the new handoff-only flow and naming.

### Impact
`✅ Clearer session handoffs`
`✅ Fewer missing work logs`
`✅ Easier session resumption`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified session handoff guidance and pointed to the correct, current “Handoff template” referenced in the main agent guidelines.
  * Tightened requirements for writing meaningful progress to disk during session handoff.
  * Updated wording around finalizing handoffs when switching or ending sessions, and reinforced the expectation to verify the handoff is saved/updated before delivering output.
  * Aligned the related handoff workflow references across the documentation set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->