### PR TITLE
download/transcription/utils: move single-caller helpers to their owning class

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -33,36 +33,36 @@ logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 
-def choose_yt_audio_format(info: dict[str, Any]) -> str:
-    """Return the most suitable audio format id for a YouTube video.
-
-    Prefer audio-only formats when yt-dlp exposes them. Fall back to the
-    combined format selector when the extractor does not provide a concrete
-    audio-only id.
-
-    """
-    formats = info.get("formats") or []
-    audio_only_formats = [
-        fmt
-        for fmt in formats
-        if fmt.get("acodec") not in (None, "none") and fmt.get("vcodec") == "none"
-    ]
-    if not audio_only_formats:
-        return "bestaudio/worst[acodec!=none]"
-
-    def sort_key(fmt: dict[str, Any]) -> tuple[float, float]:
-        abr = fmt.get("abr")
-        tbr = fmt.get("tbr")
-        return (
-            float(abr) if abr is not None else math.inf,
-            float(tbr) if tbr is not None else math.inf,
-        )
-
-    return str(min(audio_only_formats, key=sort_key)["format_id"])
-
-
 class Downloader:
     """Downloads media from YouTube, Castro, and Telegram."""
+
+    @staticmethod
+    def _choose_yt_audio_format(info: dict[str, Any]) -> str:
+        """Return the most suitable audio format id for a YouTube video.
+
+        Prefer audio-only formats when yt-dlp exposes them. Fall back to the
+        combined format selector when the extractor does not provide a concrete
+        audio-only id.
+
+        """
+        formats = info.get("formats") or []
+        audio_only_formats = [
+            fmt
+            for fmt in formats
+            if fmt.get("acodec") not in (None, "none") and fmt.get("vcodec") == "none"
+        ]
+        if not audio_only_formats:
+            return "bestaudio/worst[acodec!=none]"
+
+        def sort_key(fmt: dict[str, Any]) -> tuple[float, float]:
+            abr = fmt.get("abr")
+            tbr = fmt.get("tbr")
+            return (
+                float(abr) if abr is not None else math.inf,
+                float(tbr) if tbr is not None else math.inf,
+            )
+
+        return str(min(audio_only_formats, key=sort_key)["format_id"])
 
     @staticmethod
     def _stream_to_file(
@@ -118,7 +118,7 @@ class Downloader:
         if info is None:
             msg = "Failed to extract info from YouTube URL."
             raise DownloadError(msg)
-        audio_format = choose_yt_audio_format(cast("dict[str, Any]", info))
+        audio_format = self._choose_yt_audio_format(cast("dict[str, Any]", info))
         ydl_opts = {
             "format": audio_format,
             "outtmpl": temporary_file_name.split(".", maxsplit=1)[0],

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import parse_qs, urlsplit
 
 from defusedxml.ElementTree import ParseError
 from replicate.exceptions import ModelError, ReplicateError
@@ -28,7 +30,7 @@ from youtube_transcript_api.proxies import GenericProxyConfig
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
-from config import replicate_client
+from config import YT_HOSTS, replicate_client
 from domain import PrefixedText
 from exceptions import (
     FetchTranscriptError,
@@ -36,10 +38,8 @@ from exceptions import (
 )
 from utils import (
     clean_up,
-    extract_youtube_video_id,
     generate_temporary_name,
     get_proxy,
-    vtt_to_text,
 )
 
 if TYPE_CHECKING:
@@ -107,6 +107,71 @@ class AudioTranscriber:
 
 class YouTubeTranscriber:
     """Retrieves YouTube transcripts via yt-dlp (primary) or the API (fallback)."""
+
+    @staticmethod
+    def _extract_video_id(url: str) -> str | None:
+        """Extract the video id from any supported YouTube URL form.
+
+        Returns None when the host is not a known YouTube host or the id cannot
+        be located in the path/query.
+
+        """
+        parts = urlsplit(url)
+        hostname = (parts.hostname or "").lower()
+        hostname = hostname.removeprefix("www.")
+        if hostname not in YT_HOSTS:
+            return None
+        if hostname == "youtu.be":
+            video_id = parts.path.lstrip("/").split("/", 1)[0]
+            return video_id or None
+        path_parts = [p for p in parts.path.split("/") if p]
+        prefixed_paths = ("live", "shorts", "embed")
+        if len(path_parts) >= 2 and path_parts[0] in prefixed_paths:  # noqa: PLR2004
+            return path_parts[1]
+        if path_parts and path_parts[0] == "watch":
+            return parse_qs(parts.query).get("v", [None])[0]
+        return None
+
+    @staticmethod
+    def _vtt_to_text(vtt_path: Path) -> str:
+        """Convert a VTT subtitle file to deduplicated plain text.
+
+        Args:
+            vtt_path (Path): Path to the .vtt file.
+
+        Returns:
+            str: Clean transcript text with duplicate lines removed.
+
+        """
+        lines = vtt_path.read_text(encoding="utf-8").splitlines()
+        out: list[str] = []
+        prev = ""
+        in_note = False
+        for i, raw in enumerate(lines):
+            line = raw.strip()
+            if not line:
+                in_note = False
+                continue
+            if in_note:
+                continue
+            if "-->" in line:
+                continue
+            if line.startswith(("WEBVTT", "Kind:", "Language:")):
+                continue
+            if line.startswith("NOTE"):
+                in_note = True
+                continue
+            next_line = lines[i + 1].strip() if i + 1 < len(lines) else ""
+            if "-->" in next_line:
+                continue
+            clean = re.sub(r"<[^>]*>", "", line)
+            clean = (
+                clean.replace("&amp;", "&").replace("&gt;", ">").replace("&lt;", "<")
+            )
+            if clean and clean != prev:
+                out.append(clean)
+                prev = clean
+        return "\n".join(out)
 
     @retry(
         stop=stop_after_attempt(2),
@@ -291,7 +356,7 @@ class YouTubeTranscriber:
                 raise DownloadError(msg)
 
             try:
-                return vtt_to_text(sorted(vtt_files)[0])
+                return self._vtt_to_text(sorted(vtt_files)[0])
             except Exception as e:
                 msg = "Failed to read downloaded VTT file"
                 raise DownloadError(msg) from e
@@ -316,7 +381,7 @@ class YouTubeTranscriber:
             FetchTranscriptError: If both backends fail.
 
         """
-        video_id = extract_youtube_video_id(url)
+        video_id = self._extract_video_id(url)
         if video_id is None:
             msg = "Unknown URL"
             raise ValueError(msg)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,40 +1,14 @@
 import random
-import re
 import subprocess
 from pathlib import Path
-from urllib.parse import parse_qs, urlsplit
 from uuid import uuid4
 
-from config import PROTECTED_FILES, PROXIES, YT_HOSTS
+from config import PROTECTED_FILES, PROXIES
 
 
 def get_proxy() -> str:
     """Return a random proxy URL from PROXIES, or '' if none configured."""
     return random.choice(PROXIES) if PROXIES else ""  # noqa: S311
-
-
-def extract_youtube_video_id(url: str) -> str | None:
-    """Extract the video id from any supported YouTube URL form.
-
-    Returns None when the host is not a known YouTube host or the id cannot
-    be located in the path/query.
-
-    """
-    parts = urlsplit(url)
-    hostname = (parts.hostname or "").lower()
-    hostname = hostname.removeprefix("www.")
-    if hostname not in YT_HOSTS:
-        return None
-    if hostname == "youtu.be":
-        video_id = parts.path.lstrip("/").split("/", 1)[0]
-        return video_id or None
-    path_parts = [p for p in parts.path.split("/") if p]
-    prefixed_paths = ("live", "shorts", "embed")
-    if len(path_parts) >= 2 and path_parts[0] in prefixed_paths:  # noqa: PLR2004
-        return path_parts[1]
-    if path_parts and path_parts[0] == "watch":
-        return parse_qs(parts.query).get("v", [None])[0]
-    return None
 
 
 def generate_temporary_name(ext: str = "") -> str:
@@ -98,45 +72,6 @@ def compress_audio(input_file: str, output_file: str) -> None:
         capture_output=False,
         text=True,
     )
-
-
-def vtt_to_text(vtt_path: Path) -> str:
-    """Convert a VTT subtitle file to deduplicated plain text.
-
-    Args:
-        vtt_path (Path): Path to the .vtt file.
-
-    Returns:
-        str: Clean transcript text with duplicate lines removed.
-
-    """
-    lines = vtt_path.read_text(encoding="utf-8").splitlines()
-    out: list[str] = []
-    prev = ""
-    in_note = False
-    for i, raw in enumerate(lines):
-        line = raw.strip()
-        if not line:
-            in_note = False
-            continue
-        if in_note:
-            continue
-        if "-->" in line:
-            continue
-        if line.startswith(("WEBVTT", "Kind:", "Language:")):
-            continue
-        if line.startswith("NOTE"):
-            in_note = True
-            continue
-        next_line = lines[i + 1].strip() if i + 1 < len(lines) else ""
-        if "-->" in next_line:
-            continue
-        clean = re.sub(r"<[^>]*>", "", line)
-        clean = clean.replace("&amp;", "&").replace("&gt;", ">").replace("&lt;", "<")
-        if clean and clean != prev:
-            out.append(clean)
-            prev = clean
-    return "\n".join(out)
 
 
 def clean_up(file: str | None = None, all_downloads: bool = False) -> None:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from curl_cffi.requests.exceptions import HTTPError
 
-from download import choose_yt_audio_format, download_castro, download_tg, download_yt
+from download import Downloader, download_castro, download_tg, download_yt
 
 
 def test_download_tg_happy_path(mocker):
@@ -139,7 +139,7 @@ def test_choose_yt_audio_format_falls_back_when_no_audio_only_formats():
         ],
     }
 
-    result = choose_yt_audio_format(info)
+    result = Downloader._choose_yt_audio_format(info)
 
     assert result == "bestaudio/worst[acodec!=none]"
 
@@ -154,7 +154,7 @@ def test_choose_yt_audio_format_ranks_missing_bitrates_last():
         ],
     }
 
-    result = choose_yt_audio_format(info)
+    result = Downloader._choose_yt_audio_format(info)
 
     assert result == "zero"
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -21,11 +21,11 @@ from exceptions import (
 )
 from transcription import (
     AudioTranscriber,
+    YouTubeTranscriber,
     fetch_transcript_via_api,
     fetch_transcript_via_ytdlp,
     get_yt_transcript,
 )
-from utils import vtt_to_text
 
 
 def test_get_yt_transcript_uses_ytdlp_primary(mocker, tmp_path):
@@ -166,7 +166,7 @@ def test_vtt_to_text_dedupes_and_strips_tags(tmp_path):
     vtt_path = tmp_path / "test.vtt"
     vtt_path.write_text(vtt_content, encoding="utf-8")
 
-    result = vtt_to_text(vtt_path)
+    result = YouTubeTranscriber._vtt_to_text(vtt_path)
 
     assert result == "Hello & world\nSecond line"
 
@@ -187,7 +187,7 @@ def test_vtt_to_text_skips_cue_identifiers(tmp_path):
     vtt_path = tmp_path / "test.vtt"
     vtt_path.write_text(vtt_content, encoding="utf-8")
 
-    result = vtt_to_text(vtt_path)
+    result = YouTubeTranscriber._vtt_to_text(vtt_path)
 
     assert result == "Hello\nWorld"
 
@@ -212,7 +212,7 @@ def test_vtt_to_text_skips_multiline_note_block(tmp_path):
     vtt_path = tmp_path / "test.vtt"
     vtt_path.write_text(vtt_content, encoding="utf-8")
 
-    result = vtt_to_text(vtt_path)
+    result = YouTubeTranscriber._vtt_to_text(vtt_path)
 
     assert result == "Hello\nWorld"
     assert "comment" not in result
@@ -236,7 +236,7 @@ def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
     vtt_path = tmp_path / "test.vtt"
     vtt_path.write_text(vtt_content, encoding="utf-8")
 
-    result = vtt_to_text(vtt_path)
+    result = YouTubeTranscriber._vtt_to_text(vtt_path)
 
     assert result == "Hello\nWorld\nHello"
 
@@ -812,7 +812,7 @@ def test_fetch_transcript_via_ytdlp_vtt_read_error_raises_download_error(mocker,
     ctx.extract_info.return_value = {"subtitles": {"en": [{}]}, "automatic_captions": {}}
     # create the vtt file so the glob finds it, but vtt_to_text raises OSError
     (tmp_path / "fake-uuid.en.vtt").write_text("WEBVTT\n", encoding="utf-8")
-    mocker.patch("transcription.vtt_to_text", side_effect=OSError("disk full"))
+    mocker.patch.object(YouTubeTranscriber, "_vtt_to_text", side_effect=OSError("disk full"))
 
     with pytest.raises(DownloadError, match="Failed to read downloaded VTT file"):
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
@@ -946,3 +946,30 @@ def test_transcribe_invalid_segments_raises_model_error(mocker):
 
     with pytest.raises(ModelError):
         AudioTranscriber(mock_replicate).transcribe("test.ogg")
+
+
+def test_extract_video_id_uppercase_host():
+    """_extract_video_id handles uppercase and mixed-case hostnames."""
+    assert YouTubeTranscriber._extract_video_id("https://YOUTU.BE/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+    assert (
+        YouTubeTranscriber._extract_video_id("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ")
+        == "dQw4w9WgXcQ"
+    )
+
+
+def test_extract_video_id_malformed_url():
+    """_extract_video_id returns None for malformed URLs with no hostname."""
+    assert YouTubeTranscriber._extract_video_id("not-a-url") is None
+    assert YouTubeTranscriber._extract_video_id("https://") is None
+
+
+def test_extract_video_id_empty_path():
+    """_extract_video_id returns None for youtu.be with no video ID and watch with no v param."""
+    assert YouTubeTranscriber._extract_video_id("https://youtu.be/") is None
+    assert YouTubeTranscriber._extract_video_id("https://www.youtube.com/watch") is None
+
+
+def test_extract_video_id_unrecognized_path():
+    """_extract_video_id returns None for youtube.com URLs with unrecognized paths."""
+    assert YouTubeTranscriber._extract_video_id("https://youtube.com/playlist?list=PLxxx") is None
+    assert YouTubeTranscriber._extract_video_id("https://youtube.com/") is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from config import PROTECTED_FILES
-from utils import clean_up, compress_audio, extract_youtube_video_id, generate_temporary_name
+from utils import clean_up, compress_audio, generate_temporary_name
 
 
 def test_generate_temporary_name_no_ext():
@@ -118,27 +118,3 @@ def test_clean_up_all_downloads(mocker):
 
     # Only file1 should have been unlinked
     mock_unlink.assert_called_once_with(file1)
-
-
-def test_extract_youtube_video_id_uppercase_host():
-    """extract_youtube_video_id handles uppercase and mixed-case hostnames."""
-    assert extract_youtube_video_id("https://YOUTU.BE/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
-    assert extract_youtube_video_id("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
-
-
-def test_extract_youtube_video_id_malformed_url():
-    """extract_youtube_video_id returns None for malformed URLs with no hostname."""
-    assert extract_youtube_video_id("not-a-url") is None
-    assert extract_youtube_video_id("https://") is None
-
-
-def test_extract_youtube_video_id_empty_path():
-    """extract_youtube_video_id returns None for youtu.be with no video ID and watch with no v param."""
-    assert extract_youtube_video_id("https://youtu.be/") is None
-    assert extract_youtube_video_id("https://www.youtube.com/watch") is None
-
-
-def test_extract_youtube_video_id_unrecognized_path():
-    """extract_youtube_video_id returns None for youtube.com URLs with unrecognized paths."""
-    assert extract_youtube_video_id("https://youtube.com/playlist?list=PLxxx") is None
-    assert extract_youtube_video_id("https://youtube.com/") is None


### PR DESCRIPTION
## **User description**
## What changed

Three module-level helpers that had exactly one caller were moved into their owning class as private `@staticmethod`s, with no public alias left behind. `utils.py` now holds only genuinely cross-cutting helpers.

| Old location | New location | Only caller |
|---|---|---|
| `utils.choose_yt_audio_format` | `Downloader._choose_yt_audio_format` | `Downloader.download_yt` |
| `utils.extract_youtube_video_id` | `YouTubeTranscriber._extract_video_id` | `YouTubeTranscriber.get_transcript` |
| `utils.vtt_to_text` | `YouTubeTranscriber._vtt_to_text` | `YouTubeTranscriber.fetch_via_ytdlp` |

The placement of `Messenger._reply_with_retry` (private) and `get_file_with_retry` (public) was reviewed and is correct — visibility mirrors who calls them (`send_answer` vs `handlers.py`), so no change was made there.

## Why

The pattern for private stateless single-caller helpers was already established in the prior OOP refactor (`_stream_to_file`, `_reply_with_retry`, `_generate_text`), but these three were left in `utils.py`. This makes placement consistent: module functions in `utils.py` are for shared, domain-neutral helpers; class-internal helpers belong on the class.

## Tests

- `test_download.py`: calls `Downloader._choose_yt_audio_format(info)` directly.
- `test_transcription.py`: calls `YouTubeTranscriber._vtt_to_text(path)` directly; `_vtt_to_text` OSError patch now uses `mocker.patch.object(YouTubeTranscriber, "_vtt_to_text", ...)`; four `_extract_video_id` tests relocated from `test_utils.py`.
- `test_utils.py`: removed `extract_youtube_video_id` import and its four tests.
- 210 tests pass, 100% statement coverage (975 stmts, 0 missed).


___

## **CodeAnt-AI Description**
**Move YouTube helper logic closer to the code that uses it**

### What Changed
- Moved YouTube audio selection, video ID parsing, and VTT-to-text conversion into the classes that use them
- Kept the transcript and download results the same; this change only reorganizes where the helper logic lives
- Updated tests to call the helpers through their owning classes, with video ID tests moved into the transcription test file

### Impact
`✅ No change in download or transcript results`
`✅ Clearer helper ownership`
`✅ Easier maintenance for YouTube-related code`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for audio download functionality to enhance maintainability and organization standards.
  * Reorganized YouTube transcription utilities and processing logic to promote better modularity and clearer separation of concerns.
  * Consolidated and simplified internal helpers by removing obsolete utility functions, reducing overall code complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->