### PR TITLE
services: move _EXT_MIME_FALLBACK into GeminiHelper

### DIFF
--- a/src/services.py
+++ b/src/services.py
@@ -5,7 +5,7 @@ import mimetypes
 import time
 from functools import lru_cache
 from textwrap import dedent
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from google.genai import types
 from limits import parse as _parse_rate_limit
@@ -123,17 +123,16 @@ class QuotaManager:
         return max(0, stats.remaining)
 
 
-_EXT_MIME_FALLBACK = {
-    ".ogg": "audio/ogg",
-    ".opus": "audio/ogg",
-    ".mp3": "audio/mpeg",
-    ".wav": "audio/wav",
-    ".mp4": "video/mp4",
-}
-
-
 class GeminiHelper:
     """Utilities for Gemini model configuration and file management."""
+
+    _EXT_MIME_FALLBACK: ClassVar[dict[str, str]] = {
+        ".ogg": "audio/ogg",
+        ".opus": "audio/ogg",
+        ".mp3": "audio/mpeg",
+        ".wav": "audio/wav",
+        ".mp4": "video/mp4",
+    }
 
     def get_gemini_config(
         self,
@@ -158,7 +157,7 @@ class GeminiHelper:
         mime_type = mimetypes.guess_type(file)[0]
         if mime_type is not None:
             return mime_type
-        for ext, mt in _EXT_MIME_FALLBACK.items():
+        for ext, mt in self._EXT_MIME_FALLBACK.items():
             if file.endswith(ext):
                 return mt
         return "application/octet-stream"


### PR DESCRIPTION
## **User description**
## Summary

- `_EXT_MIME_FALLBACK` was a module-level private constant used exclusively by `GeminiHelper.resolve_mime_type`
- Moved it inside `GeminiHelper` as a `ClassVar[dict[str, str]]` attribute to tighten scope and co-locate the fallback table with its only consumer
- Added `ClassVar` to the `typing` import; no public API, aliases, or `__all__` changed

## Test plan

- [x] `uvx ruff format .` — no changes
- [x] `uvx ruff check .` — all checks passed (no `RUF012`)
- [x] `uvx ty check .` — all checks passed
- [x] `uv run pytest --cov` — 210 passed, `src/services.py` 100% coverage

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


___

## **CodeAnt-AI Description**
**Keep Gemini file type fallbacks grouped with file upload handling**

### What Changed
- Common audio and video file extensions still resolve to the expected MIME types when the file type cannot be detected automatically
- The fallback list now lives with the Gemini file-handling code instead of at the module level
- No user-facing upload behavior changed

### Impact
`✅ Fewer file upload type mismatches`
`✅ More consistent audio and video uploads`
`✅ Same upload results with cleaner file handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements for better maintainability and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->