### PR TITLE
docs: add architecture.md — component map and data flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 Read the latest handoff in `docs/summaries/` if one exists. Load only the files that handoff references — not all summaries. If no handoff exists, ask: what is the project, what type of work, what is the target deliverable.
 
+For a quick orientation to the codebase (component map and data flow), read `docs/context/architecture.md` if present.
+
 Before starting work, state: what you understand the project state to be, what you plan to do this session, and any open questions.
 
 ## Rules
@@ -59,6 +61,7 @@ Write to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`. Create it after the f
 
 - `docs/summaries/` — active session state (latest handoff + project-digest + decision records + source summaries)
 - `docs/context/` — reusable domain knowledge, loaded only when relevant to the current task
+  - `architecture.md` — high-level component map and data flow. Stable; update only on architectural change, not every handoff.
   - `agent-templates.md` — decision, analysis, and source-summary templates (read on demand). The session handoff template lives inline in `AGENTS.md` above.
   - `processing-protocol.md` — full document processing steps
   - `archive-rules.md` — summary lifecycle and file archival rules

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -58,6 +58,7 @@ Telegram update
 ```
 
 ### Summarizer input branching (`summary.py:summarize`)
+
 - **YouTube URL** → try transcript (`get_yt_transcript`); on success summarize
   the transcript. On failure → `download_yt` audio, then the file path below.
 - **Castro URL** → `download_castro` audio → file path.

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -1,0 +1,109 @@
+# Architecture
+
+High-level component map and data flow for orientation at session start.
+**Stable** — update only when the architecture actually changes (a new component,
+a new flow, a routing/fallback rewrite), not every handoff.
+
+This file is deliberately **not** a source mirror. It does not list functions
+line-by-line, dependencies, or env vars — read the source for that.
+
+- Stack list → `pyproject.toml` + `README.md`
+- *Why* the core infra was chosen (sync polling, Valkey, Gemini+Replicate,
+  Postgres+Valkey split, Modal cron) → `docs/summaries/decision-10-architecture-rationale.md`
+- Per-feature decisions → `docs/summaries/decision-*.md`
+- External-service gotchas → memory files
+
+---
+
+## What it is
+
+A private Telegram bot that summarizes content — webpages, YouTube/Castro
+links, audio, voice, video, video notes, and documents — with Gemini, and
+replies with the summary in the user's chosen language. Synchronous,
+polling-based (`bot.infinity_polling`); no webhooks, no async framework.
+
+## Component map (`src/`)
+
+| Module | Role |
+|--------|------|
+| `main.py` | Telegram entry point. Command handlers + the unified `handle_message`; routes by `content_type`; top-level error → user-message mapping. |
+| `handlers.py` | Per-content-type handlers. Media validation, builds `SummaryKwargs` from the user record, picks the summarize path. |
+| `summary.py` | `Summarizer` — the core summarization orchestrator. Owns the input-type branching and the Gemini calls. |
+| `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (yt-dlp primary, `youtube_transcript_api` fallback). |
+| `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
+| `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
+| `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (config, MIME, file upload/poll). |
+| `database.py` | `UserRepository` — users table access (SQLAlchemy + Postgres). |
+| `models.py` | `UsersOrm` — the single `users` table (id, approval, per-user settings, `daily_limit`). |
+| `config.py` | All clients/singletons + labels, defaults, limits, constants. Side-effectful import (Sentry, logging, env). |
+| `prompts.py` | `PROMPTS` (strategy templates) + `SYSTEM_INSTRUCTION`. |
+| `domain.py` | `PrefixedText` + `format_prefixed_summary` — source-provenance prefixing. |
+| `utils.py` | Proxy pick, temp-name gen, `compress_audio` (ffmpeg Opus 16k mono), `clean_up`. |
+| `scripts/cron.py` | Modal serverless cron — clears the bot's per-user daily request-limit counters (`RPD`) in Valkey at midnight PT, so daily budgets reset in step with Gemini's free-tier quota. |
+
+## Request flow
+
+```
+Telegram update
+  └─ main.handle_message
+       ├─ select_user (Postgres) ─ reject if not approved
+       └─ process_message_content  ── routes by content_type ──┐
+                                                               │
+  handlers.py:                                                 ▼
+    audio / voice ───────────────► summarize(File)
+    video / video_note ──────────► download_tg(.mp4) → compress_audio(.ogg) → summarize(path)
+    document ────────────────────► summarize_with_document(File, mime)
+    text (treated as URL) ── _classify_url ──┬─ "media" (YT/Castro) ► summarize(url)
+                                             └─ "web"  ► parse_url → summarize_webpage
+```
+
+### Summarizer input branching (`summary.py:summarize`)
+- **YouTube URL** → try transcript (`get_yt_transcript`); on success summarize
+  the transcript. On failure → `download_yt` audio, then the file path below.
+- **Castro URL** → `download_castro` audio → file path.
+- **Telegram File** → `download_tg(.ogg)` → file path.
+- **File path** → `summarize_with_file` (upload to Gemini, generate). If that
+  exhausts retries → fallback: `compress_audio` → `transcribe` (Replicate) →
+  `summarize_with_transcript`.
+
+So there are two layered fallbacks for spoken content: transcript-first for
+YouTube, and Gemini-file-first with a Replicate-transcription rescue for any
+audio that Gemini can't process.
+
+## Source-provenance prefixes
+
+Summaries from the transcript, web-parse, and Replicate-rescue paths are
+prefixed with an emoji marking where the content came from
+(`format_prefixed_summary`). Direct Gemini-file summaries — audio, voice,
+video, video notes, documents, and any URL whose audio is downloaded and sent
+to Gemini — return the raw model text with **no** prefix.
+
+| Prefix | Source |
+|--------|--------|
+| 📹 | YouTube transcript via yt-dlp |
+| 📺 | YouTube transcript via `youtube_transcript_api` (fallback) |
+| 📝 | Audio transcription via Replicate (Gemini-file rescue path) |
+| 🌐 | Webpage via Exa |
+| 🕸️ | Webpage via Tavily (fallback) |
+
+## Cross-cutting patterns
+
+- **OOP + singleton + alias.** Each service module defines a (mostly stateless)
+  class, instantiates one module-level singleton, then exports module-level
+  aliases to its methods to preserve the original functional public API. Keep
+  this surface — importers and `mocker.patch("module.func")` calls depend on it.
+  (See the "keep OOP" memory; the unwind was cancelled.)
+- **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
+  the daily budget is exhausted but consumes nothing; `quantity=1` consumes one
+  unit. A global per-minute limit throttles by sleeping. Counters live in Valkey;
+  user data lives in Postgres. Gemini bills failed calls, so quota is counted
+  per attempt by design — not a double-charge bug (see memory).
+- **Retries.** Network/model calls use `tenacity` `@retry`; persistent failure
+  surfaces as `RetryError`, which `handle_message` maps to a user-facing
+  "try again later" message. Other mapped errors: `LimitExceededError`,
+  `WebParseError`. All exceptions are sent to Sentry via `capture_exception`.
+- **Temp-file hygiene.** Downloads/compression write UUID-named temp files in the
+  CWD; `clean_up` removes them, guarded by a `PROTECTED_FILES` snapshot taken at
+  startup. On shutdown `clean_up(all_downloads=True)` sweeps the rest.
+- **Settings commands** use a one-time reply keyboard + `register_next_step_handler`
+  (`_prompt_choice` → `proceed_*`) and validate against the allow-lists in `config.py`.


### PR DESCRIPTION
## **User description**
## Summary

- Adds `docs/context/architecture.md`: a stable, one-page orientation map for agents starting a new session. Covers component responsibilities, the end-to-end request flow, the `Summarizer` input-branching and fallback chains (YouTube transcript-first, Gemini-file-first with Replicate rescue), source-provenance emoji prefixes, and cross-cutting patterns (quota model, retries, temp-file hygiene, OOP+singleton+alias surface).
- Updates `AGENTS.md` in two places: Session Start now instructs agents to load the file for orientation; Where Things Live lists it with an explicit "update on architectural change only, not every handoff" cadence note to prevent it drifting stale.

## Motivation

Each new session was reconstructing the component map by reading several source files or scanning a 10 KB chronological `project-digest.md`. This single stable doc gives that orientation immediately, while keeping non-derivable rationale/gotchas where they already live (decision records, memory files).

## Reviewer notes

- Docs-only change — no Python touched, pre-commit checks for Python were skipped by the hook.
- The "update on architectural change only" cadence is intentional: the doc deliberately does **not** mirror source line-by-line so it doesn't need per-handoff maintenance.
- Two factual errors caught and fixed during a code-review pass this session before commit: (1) "Every summary is prefixed" was false — direct Gemini-file paths return raw text; (2) `scripts/cron.py` was mislabelled as resetting "Gemini quota keys" — it clears the bot's own per-user RPD counters.

## Test plan

- [x] Read `docs/context/architecture.md` and verify all module descriptions match `src/` source
- [x] Verify the request-flow diagram against `main.py:process_message_content` and `handlers.py`
- [x] Verify prefix table against `transcription.py:get_transcript`, `parsing.py:WebParser.parse`, and `summary.py:summarize`
- [x] Confirm `AGENTS.md` Session Start and Where Things Live sections read naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add a stable architecture map and point sessions to it**

### What Changed
- Added a single-page architecture guide that explains the bot’s main parts, how requests move through the system, and how summaries are produced for links, files, and media
- Documented the main fallback paths, including transcript-first handling for YouTube and audio transcription rescue when direct summarization fails
- Clarified which summary results are prefixed with a source marker and which return plain text
- Updated the session guidance so new work starts with this architecture map, and noted that it should change only when the architecture changes

### Impact
`✅ Faster codebase orientation`
`✅ Less time spent tracing request flow`
`✅ Fewer stale session handoffs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced architecture documentation with comprehensive system overview, including component map, end-to-end request flow, and cross-cutting design patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->