### PR TITLE
docs: make architecture.md agent-agnostic — inline memory-only facts

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -11,7 +11,7 @@ line-by-line, dependencies, or env vars — read the source for that.
 - *Why* the core infra was chosen (sync polling, Valkey, Gemini+Replicate,
   Postgres+Valkey split, Modal cron) → `docs/summaries/decision-10-architecture-rationale.md`
 - Per-feature decisions → `docs/summaries/decision-*.md`
-- External-service gotchas → "Cross-cutting patterns" below
+- External-service gotchas → `docs/summaries/decision-*.md` and source comments
 
 ---
 
@@ -108,9 +108,6 @@ to Gemini — return the raw model text with **no** prefix.
   surfaces as `RetryError`, which `handle_message` maps to a user-facing
   "try again later" message. Other mapped errors: `LimitExceededError`,
   `WebParseError`. All exceptions are sent to Sentry via `capture_exception`.
-- **Gemini API constraints.** The Interactions API rejects `safety_settings` —
-  the live API returns HTTP 400 even when the parameter is passed via
-  `extra_body`, so it is intentionally omitted. Do not re-add it.
 - **Temp-file hygiene.** Downloads/compression write UUID-named temp files in the
   CWD; `clean_up` removes them, guarded by a `PROTECTED_FILES` snapshot taken at
   startup. On shutdown `clean_up(all_downloads=True)` sweeps the rest.

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -11,7 +11,7 @@ line-by-line, dependencies, or env vars — read the source for that.
 - *Why* the core infra was chosen (sync polling, Valkey, Gemini+Replicate,
   Postgres+Valkey split, Modal cron) → `docs/summaries/decision-10-architecture-rationale.md`
 - Per-feature decisions → `docs/summaries/decision-*.md`
-- External-service gotchas → memory files
+- External-service gotchas → "Cross-cutting patterns" below
 
 ---
 
@@ -91,18 +91,26 @@ to Gemini — return the raw model text with **no** prefix.
 
 - **OOP + singleton + alias.** Each service module defines a (mostly stateless)
   class, instantiates one module-level singleton, then exports module-level
-  aliases to its methods to preserve the original functional public API. Keep
-  this surface — importers and `mocker.patch("module.func")` calls depend on it.
-  (See the "keep OOP" memory; the unwind was cancelled.)
+  aliases to its methods so the original functional public API (`module.func`)
+  still works — importers and `mocker.patch("module.func")` calls depend on
+  those aliases today. OOP is the intended direction: a proposal to *unwind* it
+  — remove the classes and revert to plain module-level functions — was reviewed
+  and rejected, so don't go back that way. A future refactor toward stricter OOP
+  is welcome; note the alias layer is a backward-compatibility shim, not an OOP
+  goal, so such a refactor may drop it, but must migrate importers and the
+  `mocker.patch("module.func")` test calls in the same change.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one
   unit. A global per-minute limit throttles by sleeping. Counters live in Valkey;
   user data lives in Postgres. Gemini bills failed calls, so quota is counted
-  per attempt by design — not a double-charge bug (see memory).
+  per attempt by design — not a double-charge bug.
 - **Retries.** Network/model calls use `tenacity` `@retry`; persistent failure
   surfaces as `RetryError`, which `handle_message` maps to a user-facing
   "try again later" message. Other mapped errors: `LimitExceededError`,
   `WebParseError`. All exceptions are sent to Sentry via `capture_exception`.
+- **Gemini API constraints.** The Interactions API rejects `safety_settings` —
+  the live API returns HTTP 400 even when the parameter is passed via
+  `extra_body`, so it is intentionally omitted. Do not re-add it.
 - **Temp-file hygiene.** Downloads/compression write UUID-named temp files in the
   CWD; `clean_up` removes them, guarded by a `PROTECTED_FILES` snapshot taken at
   startup. On shutdown `clean_up(all_downloads=True)` sweeps the rest.


### PR DESCRIPTION
## **User description**
## Summary

- Removed all three references to Claude-only memory files from `docs/context/architecture.md` so the doc is usable by any AI agent, not only Claude.
- Inlined the substance that was previously only reachable via memory:
  - OOP bullet: clarifies that the rejected "Part C" unwind proposed removing the classes and reverting to plain functions (not the intended direction); explicitly notes that a future stricter-OOP refactor *is* welcome, and flags the alias layer as a back-compat shim that such a refactor may drop (with a note to migrate importers + `mocker.patch` calls together).
  - Quota bullet: dropped the trailing `(see memory)` — fact was already fully stated inline.
  - New **Gemini API constraints** bullet: the Interactions API rejects `safety_settings` (HTTP 400 even via `extra_body`); do not re-add it.
- Top pointer updated from `External-service gotchas → memory files` to point at the "Cross-cutting patterns" section where they now live.

## Why

`docs/context/architecture.md` is intended as an orientation file for any AI agent at session start (per `AGENTS.md`). Memory files are Claude-only; a non-Claude agent (or a fresh Claude session without the right memory loaded) would silently miss the constraints. Inlining them makes the doc self-contained.

## Reviewer notes

- Docs-only change; no source, test, or config files touched.
- The OOP bullet is intentionally longer than before — it needed to capture both "don't unwind back to functions" and "future OOP improvement is welcome," which are opposite directions and easy to confuse.


___

## **CodeAnt-AI Description**
**Make the architecture guide self-contained for any AI agent**

### What Changed
- Repoints the external-service notes to the in-document “Cross-cutting patterns” section instead of memory files
- Expands the service design note to clearly say the current class-and-alias surface should stay, while also explaining that a future stricter OOP refactor is allowed if importers and tests move with it
- Removes the leftover memory reference from the quota note
- Adds a new note that Gemini’s Interactions API rejects `safety_settings`, so it should not be added back

### Impact
`✅ Clearer agent onboarding`
`✅ Fewer missing architecture rules`
`✅ Lower risk of reintroducing unsupported Gemini settings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to improve navigation to relevant decision notes and clarify guidance on cross-cutting patterns, including backward-compatibility behavior.
  * Refined quota-model documentation to remove outdated references while expanding how quota is counted per attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->