### PR TITLE
feat: pre-resolve URL redirects before web parsing

### DIFF
--- a/src/parsing.py
+++ b/src/parsing.py
@@ -4,6 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, cast
 
+from curl_cffi import requests
 from tavily.errors import TimeoutError as TavilyTimeoutError
 from tenacity import (
     RetryError,
@@ -17,6 +18,7 @@ from tenacity import (
 from config import exa_client, tavily_client
 from domain import PrefixedText
 from exceptions import WebParseError
+from utils import get_proxy
 
 if TYPE_CHECKING:
     from exa_py import Exa
@@ -128,6 +130,37 @@ class WebParser:
         self._primary = primary
         self._fallback = fallback
 
+    @staticmethod
+    def resolve_url(url: str, timeout: int = 10) -> str:
+        """Return the final URL after following redirects; the original on failure.
+
+        Best-effort pre-check: issues a streamed GET (browser-impersonated,
+        routed through the proxy pool, body never read) and follows 301/302
+        redirects so the parser receives the real destination. Any failure
+        (timeout, network error) is logged and the original URL is returned
+        unchanged.
+        """
+        try:
+            response = requests.get(
+                url,
+                stream=True,
+                allow_redirects=True,
+                impersonate="chrome",
+                verify=True,
+                timeout=timeout,
+                proxy=get_proxy() or None,
+            )
+            try:
+                resolved = response.url or url
+            finally:
+                response.close()
+        except Exception:  # best-effort: never let resolution break parsing
+            logger.warning("Could not resolve redirects for %s", url, exc_info=True)
+            return url
+        if resolved != url:
+            logger.info("Resolved %s -> %s", url, resolved)
+        return resolved
+
     def parse(self, url: str) -> PrefixedText:
         """Extract main textual content from a URL.
 
@@ -174,5 +207,5 @@ web_parser = WebParser(ExaBackend(exa_client), TavilyBackend(tavily_client))
 
 
 def parse_url(url: str) -> PrefixedText:
-    """Extract main textual content from a URL via the default WebParser."""
-    return web_parser.parse(url)
+    """Resolve redirects, then extract content via the default WebParser."""
+    return web_parser.parse(WebParser.resolve_url(url))

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -32,24 +32,6 @@ logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 
-def _is_public_url(url: str) -> bool:
-    """Return True only if every resolved IP for the URL hostname is globally routable.
-
-    Rejects localhost, private RFC1918 ranges, link-local (169.254.x.x / ::1),
-    and any other non-global address to block SSRF.
-    """
-    hostname = (urlsplit(url).hostname or "").rstrip(".")
-    if not hostname:
-        return False
-    try:
-        results = socket.getaddrinfo(hostname, None)
-    except OSError:
-        return False
-    return bool(results) and all(
-        ipaddress.ip_address(addr[4][0]).is_global for addr in results
-    )
-
-
 class ParserBackend(ABC):
     """Abstract base for URL content-extraction backends."""
 
@@ -143,16 +125,14 @@ class TavilyBackend(ParserBackend):
         return content
 
 
-class WebParser:
-    """Orchestrates URL parsing with a primary→fallback backend strategy."""
+class UrlResolver:
+    """Resolves a URL to its final post-redirect destination, guarding against SSRF."""
 
-    def __init__(self, primary: ParserBackend, fallback: ParserBackend) -> None:
-        """Store the primary and fallback backends."""
-        self._primary = primary
-        self._fallback = fallback
+    def __init__(self, timeout: int = 10) -> None:
+        """Store the per-request timeout in seconds."""
+        self._timeout = timeout
 
-    @staticmethod
-    def resolve_url(url: str, timeout: int = 10) -> str:
+    def resolve(self, url: str) -> str:
         """Return the final URL after following redirects; the original on failure.
 
         Best-effort pre-check: issues a streamed GET (browser-impersonated,
@@ -162,7 +142,7 @@ class WebParser:
         unchanged. Non-public hosts (private, loopback, link-local) are
         rejected before the request and after redirect to prevent SSRF.
         """
-        if not _is_public_url(url):
+        if not self._is_public(url):
             logger.warning("Blocked non-public URL: %s", url)
             return url
         try:
@@ -172,7 +152,7 @@ class WebParser:
                 allow_redirects=True,
                 impersonate="chrome",
                 verify=True,
-                timeout=timeout,
+                timeout=self._timeout,
                 proxy=get_proxy() or None,
             )
             try:
@@ -182,7 +162,7 @@ class WebParser:
         except Exception:  # best-effort: never let resolution break parsing
             logger.warning("Could not resolve redirects for %s", url, exc_info=True)
             return url
-        if not _is_public_url(resolved):
+        if not self._is_public(resolved):
             logger.warning(
                 "Blocked redirect to non-public host: %s -> %s",
                 url,
@@ -193,11 +173,44 @@ class WebParser:
             logger.info("Resolved %s -> %s", url, resolved)
         return resolved
 
-    def parse(self, url: str) -> PrefixedText:
-        """Extract main textual content from a URL.
+    @staticmethod
+    def _is_public(url: str) -> bool:
+        """Return True only if every resolved IP for the hostname is globally routable.
 
-        Parses with the primary backend first, falls back to the secondary on
-        failure.
+        Rejects localhost, private RFC1918 ranges, link-local (169.254.x.x / ::1),
+        and any other non-global address to block SSRF.
+        """
+        hostname = (urlsplit(url).hostname or "").rstrip(".")
+        if not hostname:
+            return False
+        try:
+            results = socket.getaddrinfo(hostname, None)
+        except OSError:
+            return False
+        return bool(results) and all(
+            ipaddress.ip_address(addr[4][0]).is_global for addr in results
+        )
+
+
+class WebParser:
+    """Orchestrate redirect resolution, then primary→fallback content extraction."""
+
+    def __init__(
+        self,
+        primary: ParserBackend,
+        fallback: ParserBackend,
+        resolver: UrlResolver,
+    ) -> None:
+        """Store the primary/fallback backends and the URL resolver."""
+        self._primary = primary
+        self._fallback = fallback
+        self._resolver = resolver
+
+    def parse(self, url: str) -> PrefixedText:
+        """Resolve redirects, then extract main textual content from the URL.
+
+        Resolves the final destination (best-effort, SSRF-guarded), parses with
+        the primary backend first, and falls back to the secondary on failure.
 
         Returns:
             PrefixedText: The extracted content and source display prefix.
@@ -208,6 +221,7 @@ class WebParser:
                 without attempting the fallback.
 
         """
+        url = self._resolver.resolve(url)
         try:
             return PrefixedText(
                 text=self._primary.parse(url),
@@ -235,9 +249,13 @@ class WebParser:
                 raise WebParseError(msg) from fallback_error
 
 
-web_parser = WebParser(ExaBackend(exa_client), TavilyBackend(tavily_client))
+web_parser = WebParser(
+    ExaBackend(exa_client),
+    TavilyBackend(tavily_client),
+    UrlResolver(),
+)
 
 
 def parse_url(url: str) -> PrefixedText:
-    """Resolve redirects, then extract content via the default WebParser."""
-    return web_parser.parse(WebParser.resolve_url(url))
+    """Extract main textual content from a URL via the default WebParser."""
+    return web_parser.parse(url)

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -185,7 +185,8 @@ class UrlResolver:
             return False
         try:
             results = socket.getaddrinfo(hostname, None)
-        except OSError:
+        except OSError, UnicodeError:
+            # UnicodeError: getaddrinfo rejects invalid/over-long IDNA labels.
             return False
         return bool(results) and all(
             ipaddress.ip_address(addr[4][0]).is_global for addr in results

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import ipaddress
 import logging
+import socket
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, cast
+from urllib.parse import urlsplit
 
 from curl_cffi import requests
 from tavily.errors import TimeoutError as TavilyTimeoutError
@@ -27,6 +30,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
+
+
+def _is_public_url(url: str) -> bool:
+    """Return True only if every resolved IP for the URL hostname is globally routable.
+
+    Rejects localhost, private RFC1918 ranges, link-local (169.254.x.x / ::1),
+    and any other non-global address to block SSRF.
+    """
+    hostname = (urlsplit(url).hostname or "").rstrip(".")
+    if not hostname:
+        return False
+    try:
+        results = socket.getaddrinfo(hostname, None)
+    except OSError:
+        return False
+    return bool(results) and all(
+        ipaddress.ip_address(addr[4][0]).is_global for addr in results
+    )
 
 
 class ParserBackend(ABC):
@@ -138,8 +159,12 @@ class WebParser:
         routed through the proxy pool, body never read) and follows 301/302
         redirects so the parser receives the real destination. Any failure
         (timeout, network error) is logged and the original URL is returned
-        unchanged.
+        unchanged. Non-public hosts (private, loopback, link-local) are
+        rejected before the request and after redirect to prevent SSRF.
         """
+        if not _is_public_url(url):
+            logger.warning("Blocked non-public URL: %s", url)
+            return url
         try:
             response = requests.get(
                 url,
@@ -156,6 +181,13 @@ class WebParser:
                 response.close()
         except Exception:  # best-effort: never let resolution break parsing
             logger.warning("Could not resolve redirects for %s", url, exc_info=True)
+            return url
+        if not _is_public_url(resolved):
+            logger.warning(
+                "Blocked redirect to non-public host: %s -> %s",
+                url,
+                resolved,
+            )
             return url
         if resolved != url:
             logger.info("Resolved %s -> %s", url, resolved)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -229,11 +229,89 @@ def test_parse_url_resolves_then_delegates_to_web_parser(mocker):
 
 
 # ---------------------------------------------------------------------------
+# _is_public_url tests
+# ---------------------------------------------------------------------------
+
+def test_is_public_url_returns_false_for_missing_hostname():
+    """_is_public_url returns False when the URL has no hostname."""
+    from parsing import _is_public_url
+
+    assert _is_public_url("https:///path") is False
+
+
+def test_is_public_url_returns_true_for_public_ip(mocker):
+    """_is_public_url returns True when the hostname resolves to a public IP."""
+    from parsing import _is_public_url
+
+    mocker.patch(
+        "parsing.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("93.184.216.34", 0))],
+    )
+    assert _is_public_url("https://example.com/article") is True
+
+
+def test_is_public_url_returns_false_for_private_ip(mocker):
+    """_is_public_url returns False when the hostname resolves to a private IP."""
+    from parsing import _is_public_url
+
+    mocker.patch(
+        "parsing.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("192.168.1.1", 0))],
+    )
+    assert _is_public_url("https://internal.example.com/") is False
+
+
+def test_is_public_url_returns_false_for_loopback(mocker):
+    """_is_public_url returns False for localhost."""
+    from parsing import _is_public_url
+
+    mocker.patch(
+        "parsing.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("127.0.0.1", 0))],
+    )
+    assert _is_public_url("http://localhost/admin") is False
+
+
+def test_is_public_url_returns_false_for_link_local(mocker):
+    """_is_public_url returns False for cloud metadata endpoint."""
+    from parsing import _is_public_url
+
+    mocker.patch(
+        "parsing.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("169.254.169.254", 0))],
+    )
+    assert _is_public_url("http://169.254.169.254/latest/meta-data/") is False
+
+
+def test_is_public_url_returns_false_when_dns_fails(mocker):
+    """_is_public_url returns False when DNS resolution raises OSError."""
+    from parsing import _is_public_url
+
+    mocker.patch("parsing.socket.getaddrinfo", side_effect=OSError("NXDOMAIN"))
+    assert _is_public_url("https://nonexistent.invalid/") is False
+
+
+def test_is_public_url_returns_false_when_any_addr_is_private(mocker):
+    """_is_public_url returns False if any resolved address is private (dual-stack)."""
+    from parsing import _is_public_url
+
+    mocker.patch(
+        "parsing.socket.getaddrinfo",
+        return_value=[
+            (None, None, None, None, ("93.184.216.34", 0)),
+            (None, None, None, None, ("10.0.0.1", 0)),
+        ],
+    )
+    assert _is_public_url("https://example.com/") is False
+
+
+# ---------------------------------------------------------------------------
 # WebParser.resolve_url tests
 # ---------------------------------------------------------------------------
 
 def test_resolve_url_returns_final_url_after_redirect(mocker):
     """resolve_url returns the redirected URL and closes the response."""
+    mocker.patch("parsing._is_public_url", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/final")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
@@ -249,6 +327,7 @@ def test_resolve_url_returns_final_url_after_redirect(mocker):
 
 def test_resolve_url_returns_original_when_no_redirect(mocker):
     """resolve_url returns the input unchanged when there is no redirect."""
+    mocker.patch("parsing._is_public_url", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mocker.patch("parsing.requests.get", return_value=mock_resp)
@@ -260,6 +339,7 @@ def test_resolve_url_returns_original_when_no_redirect(mocker):
 
 def test_resolve_url_falls_back_to_original_on_error(mocker, caplog):
     """resolve_url returns the original URL when the request raises."""
+    mocker.patch("parsing._is_public_url", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mocker.patch("parsing.requests.get", side_effect=RuntimeError("boom"))
 
@@ -272,6 +352,7 @@ def test_resolve_url_falls_back_to_original_on_error(mocker, caplog):
 
 def test_resolve_url_passes_proxy_when_configured(mocker):
     """resolve_url forwards a configured proxy to requests.get."""
+    mocker.patch("parsing._is_public_url", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="https://user:pass@proxy.com:1234")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
@@ -283,6 +364,7 @@ def test_resolve_url_passes_proxy_when_configured(mocker):
 
 def test_resolve_url_omits_proxy_when_none_configured(mocker):
     """resolve_url passes proxy=None when no proxy is set."""
+    mocker.patch("parsing._is_public_url", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
@@ -290,3 +372,33 @@ def test_resolve_url_omits_proxy_when_none_configured(mocker):
     WebParser.resolve_url("https://example.com/article")
 
     assert mock_get.call_args.kwargs["proxy"] is None
+
+
+def test_resolve_url_blocks_non_public_initial_url(mocker, caplog):
+    """resolve_url returns the original URL without fetching for a private host."""
+    mocker.patch("parsing._is_public_url", side_effect=lambda u: u != "http://192.168.1.1/")
+    mock_get = mocker.patch("parsing.requests.get")
+
+    with caplog.at_level(logging.WARNING, logger="parsing"):
+        result = WebParser.resolve_url("http://192.168.1.1/")
+
+    assert result == "http://192.168.1.1/"
+    mock_get.assert_not_called()
+    assert "Blocked non-public URL" in caplog.text
+
+
+def test_resolve_url_blocks_redirect_to_private_host(mocker, caplog):
+    """resolve_url returns the original URL when a redirect lands on a private host."""
+    mocker.patch(
+        "parsing._is_public_url",
+        side_effect=lambda u: "example.com" in u,
+    )
+    mocker.patch("parsing.get_proxy", return_value="")
+    mock_resp = mocker.Mock(url="http://169.254.169.254/latest/meta-data/")
+    mocker.patch("parsing.requests.get", return_value=mock_resp)
+
+    with caplog.at_level(logging.WARNING, logger="parsing"):
+        result = WebParser.resolve_url("https://example.com/start")
+
+    assert result == "https://example.com/start"
+    assert "Blocked redirect to non-public host" in caplog.text

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -210,14 +210,83 @@ def test_parse_url_propagates_non_retryable_exa_error(mocker):
     mock_tavily.extract.assert_not_called()
 
 
-def test_parse_url_delegates_to_web_parser(mocker):
-    """parse_url routes to the module-level web_parser singleton."""
+def test_parse_url_resolves_then_delegates_to_web_parser(mocker):
+    """parse_url resolves redirects, then routes the final URL to web_parser."""
     from domain import PrefixedText
 
+    mocker.patch.object(
+        parsing.WebParser,
+        "resolve_url",
+        return_value="https://example.com/final",
+    )
     mock_result = PrefixedText(text="hello", prefix="🌐")
     mock_parse = mocker.patch.object(parsing.web_parser, "parse", return_value=mock_result)
 
-    result = parse_url("https://example.com")
+    result = parse_url("https://example.com/start")
 
     assert result is mock_result
-    mock_parse.assert_called_once_with("https://example.com")
+    mock_parse.assert_called_once_with("https://example.com/final")
+
+
+# ---------------------------------------------------------------------------
+# WebParser.resolve_url tests
+# ---------------------------------------------------------------------------
+
+def test_resolve_url_returns_final_url_after_redirect(mocker):
+    """resolve_url returns the redirected URL and closes the response."""
+    mocker.patch("parsing.get_proxy", return_value="")
+    mock_resp = mocker.Mock(url="https://example.com/final")
+    mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
+
+    result = WebParser.resolve_url("https://example.com/start")
+
+    assert result == "https://example.com/final"
+    mock_resp.close.assert_called_once_with()
+    assert mock_get.call_args.args == ("https://example.com/start",)
+    assert mock_get.call_args.kwargs["allow_redirects"] is True
+    assert mock_get.call_args.kwargs["stream"] is True
+
+
+def test_resolve_url_returns_original_when_no_redirect(mocker):
+    """resolve_url returns the input unchanged when there is no redirect."""
+    mocker.patch("parsing.get_proxy", return_value="")
+    mock_resp = mocker.Mock(url="https://example.com/article")
+    mocker.patch("parsing.requests.get", return_value=mock_resp)
+
+    result = WebParser.resolve_url("https://example.com/article")
+
+    assert result == "https://example.com/article"
+
+
+def test_resolve_url_falls_back_to_original_on_error(mocker, caplog):
+    """resolve_url returns the original URL when the request raises."""
+    mocker.patch("parsing.get_proxy", return_value="")
+    mocker.patch("parsing.requests.get", side_effect=RuntimeError("boom"))
+
+    with caplog.at_level(logging.WARNING, logger="parsing"):
+        result = WebParser.resolve_url("https://example.com/article")
+
+    assert result == "https://example.com/article"
+    assert "Could not resolve redirects" in caplog.text
+
+
+def test_resolve_url_passes_proxy_when_configured(mocker):
+    """resolve_url forwards a configured proxy to requests.get."""
+    mocker.patch("parsing.get_proxy", return_value="https://user:pass@proxy.com:1234")
+    mock_resp = mocker.Mock(url="https://example.com/article")
+    mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
+
+    WebParser.resolve_url("https://example.com/article")
+
+    assert mock_get.call_args.kwargs["proxy"] == "https://user:pass@proxy.com:1234"
+
+
+def test_resolve_url_omits_proxy_when_none_configured(mocker):
+    """resolve_url passes proxy=None when no proxy is set."""
+    mocker.patch("parsing.get_proxy", return_value="")
+    mock_resp = mocker.Mock(url="https://example.com/article")
+    mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
+
+    WebParser.resolve_url("https://example.com/article")
+
+    assert mock_get.call_args.kwargs["proxy"] is None

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -301,6 +301,15 @@ def test_is_public_returns_false_when_dns_fails(mocker):
     assert UrlResolver._is_public("https://nonexistent.invalid/") is False
 
 
+def test_is_public_returns_false_on_invalid_idna_hostname(mocker):
+    """_is_public returns False when getaddrinfo raises UnicodeError (bad IDNA label)."""
+    mocker.patch(
+        "parsing.socket.getaddrinfo",
+        side_effect=UnicodeError("label empty or too long"),
+    )
+    assert UrlResolver._is_public("http://" + "a" * 64 + ".com/") is False
+
+
 def test_is_public_returns_false_when_any_addr_is_private(mocker):
     """_is_public returns False if any resolved address is private (dual-stack)."""
     mocker.patch(

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -6,7 +6,7 @@ from tenacity import RetryError
 
 import parsing
 from exceptions import WebParseError
-from parsing import ExaBackend, TavilyBackend, WebParser, parse_url
+from parsing import ExaBackend, TavilyBackend, UrlResolver, WebParser, parse_url
 
 
 # ---------------------------------------------------------------------------
@@ -14,10 +14,16 @@ from parsing import ExaBackend, TavilyBackend, WebParser, parse_url
 # ---------------------------------------------------------------------------
 
 def _make_parser(mocker):
-    """Return (parser, mock_exa_client, mock_tavily_client)."""
+    """Return (parser, mock_exa_client, mock_tavily_client).
+
+    Injects a stub resolver that passes the URL through unchanged so the
+    orchestration tests never touch the network.
+    """
     mock_exa = mocker.MagicMock()
     mock_tavily = mocker.MagicMock()
-    parser = WebParser(ExaBackend(mock_exa), TavilyBackend(mock_tavily))
+    resolver = mocker.Mock()
+    resolver.resolve.side_effect = lambda url: url
+    parser = WebParser(ExaBackend(mock_exa), TavilyBackend(mock_tavily), resolver)
     return parser, mock_exa, mock_tavily
 
 
@@ -210,91 +216,93 @@ def test_parse_url_propagates_non_retryable_exa_error(mocker):
     mock_tavily.extract.assert_not_called()
 
 
-def test_parse_url_resolves_then_delegates_to_web_parser(mocker):
-    """parse_url resolves redirects, then routes the final URL to web_parser."""
+def test_parse_resolves_url_before_extracting(mocker):
+    """parse resolves the URL via the injected resolver before calling backends."""
+    mock_exa = mocker.MagicMock()
+    mock_tavily = mocker.MagicMock()
+    resolver = mocker.Mock()
+    resolver.resolve.return_value = "https://example.com/final"
+    parser = WebParser(ExaBackend(mock_exa), TavilyBackend(mock_tavily), resolver)
+    mock_exa.get_contents.return_value = mocker.Mock(
+        results=[mocker.Mock(text="Hi.")],
+    )
+
+    result = parser.parse("https://example.com/start")
+
+    assert result.text == "Hi."
+    resolver.resolve.assert_called_once_with("https://example.com/start")
+    mock_exa.get_contents.assert_called_once_with(
+        urls=["https://example.com/final"],
+        text={"max_characters": 20000, "include_html_tags": True},
+    )
+
+
+def test_parse_url_delegates_to_web_parser(mocker):
+    """parse_url routes to the module-level web_parser singleton."""
     from domain import PrefixedText
 
-    mocker.patch.object(
-        parsing.WebParser,
-        "resolve_url",
-        return_value="https://example.com/final",
-    )
     mock_result = PrefixedText(text="hello", prefix="🌐")
     mock_parse = mocker.patch.object(parsing.web_parser, "parse", return_value=mock_result)
 
     result = parse_url("https://example.com/start")
 
     assert result is mock_result
-    mock_parse.assert_called_once_with("https://example.com/final")
+    mock_parse.assert_called_once_with("https://example.com/start")
 
 
 # ---------------------------------------------------------------------------
-# _is_public_url tests
+# UrlResolver._is_public tests
 # ---------------------------------------------------------------------------
 
-def test_is_public_url_returns_false_for_missing_hostname():
-    """_is_public_url returns False when the URL has no hostname."""
-    from parsing import _is_public_url
-
-    assert _is_public_url("https:///path") is False
+def test_is_public_returns_false_for_missing_hostname():
+    """_is_public returns False when the URL has no hostname."""
+    assert UrlResolver._is_public("https:///path") is False
 
 
-def test_is_public_url_returns_true_for_public_ip(mocker):
-    """_is_public_url returns True when the hostname resolves to a public IP."""
-    from parsing import _is_public_url
-
+def test_is_public_returns_true_for_public_ip(mocker):
+    """_is_public returns True when the hostname resolves to a public IP."""
     mocker.patch(
         "parsing.socket.getaddrinfo",
         return_value=[(None, None, None, None, ("93.184.216.34", 0))],
     )
-    assert _is_public_url("https://example.com/article") is True
+    assert UrlResolver._is_public("https://example.com/article") is True
 
 
-def test_is_public_url_returns_false_for_private_ip(mocker):
-    """_is_public_url returns False when the hostname resolves to a private IP."""
-    from parsing import _is_public_url
-
+def test_is_public_returns_false_for_private_ip(mocker):
+    """_is_public returns False when the hostname resolves to a private IP."""
     mocker.patch(
         "parsing.socket.getaddrinfo",
         return_value=[(None, None, None, None, ("192.168.1.1", 0))],
     )
-    assert _is_public_url("https://internal.example.com/") is False
+    assert UrlResolver._is_public("https://internal.example.com/") is False
 
 
-def test_is_public_url_returns_false_for_loopback(mocker):
-    """_is_public_url returns False for localhost."""
-    from parsing import _is_public_url
-
+def test_is_public_returns_false_for_loopback(mocker):
+    """_is_public returns False for localhost."""
     mocker.patch(
         "parsing.socket.getaddrinfo",
         return_value=[(None, None, None, None, ("127.0.0.1", 0))],
     )
-    assert _is_public_url("http://localhost/admin") is False
+    assert UrlResolver._is_public("http://localhost/admin") is False
 
 
-def test_is_public_url_returns_false_for_link_local(mocker):
-    """_is_public_url returns False for cloud metadata endpoint."""
-    from parsing import _is_public_url
-
+def test_is_public_returns_false_for_link_local(mocker):
+    """_is_public returns False for cloud metadata endpoint."""
     mocker.patch(
         "parsing.socket.getaddrinfo",
         return_value=[(None, None, None, None, ("169.254.169.254", 0))],
     )
-    assert _is_public_url("http://169.254.169.254/latest/meta-data/") is False
+    assert UrlResolver._is_public("http://169.254.169.254/latest/meta-data/") is False
 
 
-def test_is_public_url_returns_false_when_dns_fails(mocker):
-    """_is_public_url returns False when DNS resolution raises OSError."""
-    from parsing import _is_public_url
-
+def test_is_public_returns_false_when_dns_fails(mocker):
+    """_is_public returns False when DNS resolution raises OSError."""
     mocker.patch("parsing.socket.getaddrinfo", side_effect=OSError("NXDOMAIN"))
-    assert _is_public_url("https://nonexistent.invalid/") is False
+    assert UrlResolver._is_public("https://nonexistent.invalid/") is False
 
 
-def test_is_public_url_returns_false_when_any_addr_is_private(mocker):
-    """_is_public_url returns False if any resolved address is private (dual-stack)."""
-    from parsing import _is_public_url
-
+def test_is_public_returns_false_when_any_addr_is_private(mocker):
+    """_is_public returns False if any resolved address is private (dual-stack)."""
     mocker.patch(
         "parsing.socket.getaddrinfo",
         return_value=[
@@ -302,21 +310,21 @@ def test_is_public_url_returns_false_when_any_addr_is_private(mocker):
             (None, None, None, None, ("10.0.0.1", 0)),
         ],
     )
-    assert _is_public_url("https://example.com/") is False
+    assert UrlResolver._is_public("https://example.com/") is False
 
 
 # ---------------------------------------------------------------------------
-# WebParser.resolve_url tests
+# UrlResolver.resolve tests
 # ---------------------------------------------------------------------------
 
-def test_resolve_url_returns_final_url_after_redirect(mocker):
-    """resolve_url returns the redirected URL and closes the response."""
-    mocker.patch("parsing._is_public_url", return_value=True)
+def test_resolve_returns_final_url_after_redirect(mocker):
+    """resolve returns the redirected URL and closes the response."""
+    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/final")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
 
-    result = WebParser.resolve_url("https://example.com/start")
+    result = UrlResolver().resolve("https://example.com/start")
 
     assert result == "https://example.com/final"
     mock_resp.close.assert_called_once_with()
@@ -325,72 +333,90 @@ def test_resolve_url_returns_final_url_after_redirect(mocker):
     assert mock_get.call_args.kwargs["stream"] is True
 
 
-def test_resolve_url_returns_original_when_no_redirect(mocker):
-    """resolve_url returns the input unchanged when there is no redirect."""
-    mocker.patch("parsing._is_public_url", return_value=True)
+def test_resolve_returns_original_when_no_redirect(mocker):
+    """resolve returns the input unchanged when there is no redirect."""
+    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mocker.patch("parsing.requests.get", return_value=mock_resp)
 
-    result = WebParser.resolve_url("https://example.com/article")
+    result = UrlResolver().resolve("https://example.com/article")
 
     assert result == "https://example.com/article"
+    mock_resp.close.assert_called_once_with()
 
 
-def test_resolve_url_falls_back_to_original_on_error(mocker, caplog):
-    """resolve_url returns the original URL when the request raises."""
-    mocker.patch("parsing._is_public_url", return_value=True)
+def test_resolve_falls_back_to_original_on_error(mocker, caplog):
+    """resolve returns the original URL when the request raises."""
+    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mocker.patch("parsing.requests.get", side_effect=RuntimeError("boom"))
 
     with caplog.at_level(logging.WARNING, logger="parsing"):
-        result = WebParser.resolve_url("https://example.com/article")
+        result = UrlResolver().resolve("https://example.com/article")
 
     assert result == "https://example.com/article"
     assert "Could not resolve redirects" in caplog.text
 
 
-def test_resolve_url_passes_proxy_when_configured(mocker):
-    """resolve_url forwards a configured proxy to requests.get."""
-    mocker.patch("parsing._is_public_url", return_value=True)
+def test_resolve_passes_proxy_when_configured(mocker):
+    """resolve forwards a configured proxy to requests.get."""
+    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="https://user:pass@proxy.com:1234")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
 
-    WebParser.resolve_url("https://example.com/article")
+    UrlResolver().resolve("https://example.com/article")
 
     assert mock_get.call_args.kwargs["proxy"] == "https://user:pass@proxy.com:1234"
 
 
-def test_resolve_url_omits_proxy_when_none_configured(mocker):
-    """resolve_url passes proxy=None when no proxy is set."""
-    mocker.patch("parsing._is_public_url", return_value=True)
+def test_resolve_omits_proxy_when_none_configured(mocker):
+    """resolve passes proxy=None when no proxy is set."""
+    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
 
-    WebParser.resolve_url("https://example.com/article")
+    UrlResolver().resolve("https://example.com/article")
 
     assert mock_get.call_args.kwargs["proxy"] is None
 
 
-def test_resolve_url_blocks_non_public_initial_url(mocker, caplog):
-    """resolve_url returns the original URL without fetching for a private host."""
-    mocker.patch("parsing._is_public_url", side_effect=lambda u: u != "http://192.168.1.1/")
+def test_resolve_passes_configured_timeout(mocker):
+    """resolve forwards the instance timeout to requests.get."""
+    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
+    mocker.patch("parsing.get_proxy", return_value="")
+    mock_resp = mocker.Mock(url="https://example.com/article")
+    mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
+
+    UrlResolver(timeout=3).resolve("https://example.com/article")
+
+    assert mock_get.call_args.kwargs["timeout"] == 3
+
+
+def test_resolve_blocks_non_public_initial_url(mocker, caplog):
+    """resolve returns the original URL without fetching for a private host."""
+    mocker.patch.object(
+        parsing.UrlResolver,
+        "_is_public",
+        side_effect=lambda u: u != "http://192.168.1.1/",
+    )
     mock_get = mocker.patch("parsing.requests.get")
 
     with caplog.at_level(logging.WARNING, logger="parsing"):
-        result = WebParser.resolve_url("http://192.168.1.1/")
+        result = UrlResolver().resolve("http://192.168.1.1/")
 
     assert result == "http://192.168.1.1/"
     mock_get.assert_not_called()
     assert "Blocked non-public URL" in caplog.text
 
 
-def test_resolve_url_blocks_redirect_to_private_host(mocker, caplog):
-    """resolve_url returns the original URL when a redirect lands on a private host."""
-    mocker.patch(
-        "parsing._is_public_url",
+def test_resolve_blocks_redirect_to_private_host(mocker, caplog):
+    """resolve returns the original URL when a redirect lands on a private host."""
+    mocker.patch.object(
+        parsing.UrlResolver,
+        "_is_public",
         side_effect=lambda u: "example.com" in u,
     )
     mocker.patch("parsing.get_proxy", return_value="")
@@ -398,7 +424,7 @@ def test_resolve_url_blocks_redirect_to_private_host(mocker, caplog):
     mocker.patch("parsing.requests.get", return_value=mock_resp)
 
     with caplog.at_level(logging.WARNING, logger="parsing"):
-        result = WebParser.resolve_url("https://example.com/start")
+        result = UrlResolver().resolve("https://example.com/start")
 
     assert result == "https://example.com/start"
     assert "Blocked redirect to non-public host" in caplog.text


### PR DESCRIPTION
## **User description**
## Summary

- Sites with 301/302 redirects (e.g. `journal.tinkoff.ru` → `t-j.ru`) were causing `WebParseError` because parsing backends received the original, pre-redirect URL.
- Added `WebParser.resolve_url()` — a best-effort streamed GET that follows redirects and returns the final destination URL.
- `parse_url()` now resolves before parsing; `handle_url` is unchanged (resolution is internal to the parser).

## What changed

**`src/parsing.py`**
- New `WebParser.resolve_url(url, timeout=10)` `@staticmethod`: uses `curl_cffi.requests.get(stream=True, allow_redirects=True, impersonate="chrome")`, reads only `response.url`, closes immediately (no body transfer).
- Routes through `get_proxy()` (single `proxy=` param) to avoid datacenter-IP blocking.
- Any failure (timeout, network error) → logs a warning and returns the original URL unchanged; resolution never breaks the existing `WebParseError` path.
- `parse_url()` updated to `web_parser.parse(WebParser.resolve_url(url))`.

**`tests/test_parsing.py`**
- 5 new `WebParser.resolve_url` tests: redirect, no-redirect, error fallback, proxy on, proxy off.
- Updated `parse_url` delegation test to assert resolved URL is passed to `web_parser.parse`.

## Reviewer notes

- `WebParser.parse()` is unchanged — it stays a pure Exa→Tavily orchestration; all 11 existing parser tests pass without modification.
- Behavior edge: `resolve_url` follows redirects from the bot's network/IP. If a site 302s differently per geo/consent, Exa/Tavily may still see a different URL server-side. The proxy routing mitigates IP-based gating; the fallback keeps it safe regardless.

## Test plan

- [x] `uvx ruff format .` / `ruff check .` / `ty check .` — all pass
- [x] `uv run pytest --cov` — 210 passed, 100% coverage (`src/parsing.py` 88 stmts, 0 miss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Resolve redirects before sending a URL to the parser**

### What Changed
- URLs are now checked for redirects first, so pages like `journal.tinkoff.ru` that move to a different address can still be parsed successfully.
- If redirect resolution fails, the original URL is still used so parsing continues as before.
- Redirect checks now use the same proxy setup as the rest of the app, which helps avoid site blocks.
- Added coverage for redirected URLs, non-redirected URLs, failure fallback, and proxy handling.

### Impact
`✅ Fewer parsing failures for redirected sites`
`✅ More successful article fetching after URL changes`
`✅ Clearer handling of blocked or unreachable sites`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL parsing now resolves redirects to the final destination before extracting content, using a best-effort approach.
  * Redirect resolution includes safety checks to prevent non-public targets, and falls back to the original URL when resolution fails.
* **Tests**
  * Added unit tests to verify redirect resolution behavior (final URL vs original), proxy/timeout wiring, warning logging on failures, and SSRF-blocking for unsafe URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->