### PR TITLE
hooks: block file edits on main branch

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(python3 -c \"import sys,json;print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file\" ] && exit 0; root=$(git -C \"$(dirname \"$file\")\" rev-parse --show-toplevel 2>/dev/null) || exit 0; branch=$(git -C \"$root\" branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo 'Blocked: editing a repo file on the protected main branch. Create a feature branch first (git checkout -b <scope>-<short-desc>), then retry.' >&2; exit 2; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|NotebookEdit",
+        "matcher": "Edit|MultiEdit|Write|NotebookEdit",
         "hooks": [
           {
             "type": "command",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ For a quick orientation to the codebase (component map and data flow), read `doc
 
 Before starting work, state: what you understand the project state to be, what you plan to do this session, and any open questions.
 
-Before your first file edit, ensure you are not on `main`. If you are, create a feature branch (`git checkout -b <scope>-<short-desc>`, matching the commit scope convention in `docs/context/git-guide.md`). A `PreToolUse` hook enforces this and will block edits made on `main`.
+Before your first file edit, ensure you are not on `main`. If you are, create a feature branch (`git checkout -b <scope>-<short-desc>`, matching the commit scope convention in `docs/context/git-guide.md`). A `PreToolUse` hook backs this up by blocking edits to repo files while on `main`.
 
 ## Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ For a quick orientation to the codebase (component map and data flow), read `doc
 
 Before starting work, state: what you understand the project state to be, what you plan to do this session, and any open questions.
 
+Before your first file edit, ensure you are not on `main`. If you are, create a feature branch (`git checkout -b <scope>-<short-desc>`, matching the commit scope convention in `docs/context/git-guide.md`). A `PreToolUse` hook enforces this and will block edits made on `main`.
+
 ## Rules
 
 1. Do not mix unrelated project contexts in one session.


### PR DESCRIPTION
## **User description**
## What

Add a `PreToolUse` hook in `.claude/settings.json` that blocks `Edit`, `Write`, and `NotebookEdit` calls when the target file belongs to a git repo whose current branch is `main`. Also adds a proactive note in `AGENTS.md` so the agent branches at session start.

## Why

`main` is push-protected on the remote, but nothing previously stopped the agent from editing and committing locally on `main`. The problem was only discovered at push time — after edits and commits had already landed on `main`, requiring a messy recovery (branch, cherry-pick, reset). The hook catches the issue at the **first edit attempt**, before anything is staged.

A rule in `AGENTS.md` alone is insufficient because instructions there are followed probabilistically — that's the failure mode causing the slip. A `PreToolUse` hook is enforced by the harness on every tool call, not by the model.

## How the hook works

- Reads `tool_input.file_path` from the hook's stdin JSON (via `python3`, always present on macOS — no `jq` dependency).
- Resolves the file's git repo root with `git rev-parse --show-toplevel`.
- Checks only **that repo's** branch — so writes to out-of-repo files (plan files under `~/.claude/plans`, memory files under `~/.claude/projects/.../memory`, other worktrees) are unaffected while the project sits on `main`.
- Blocks with exit 2 and an instructive message. The agent then creates a feature branch and retries.
- Fails open on any error (no git repo, missing parent dir, malformed stdin) — cannot wedge an edit.
- `Bash` is intentionally not matched, so git commands still run on any branch.

## Known limitation

A brand-new file in a **not-yet-existing** nested directory on `main` is not blocked (parent absent → `git rev-parse` fails → fail-open). New files in existing directories are blocked correctly. Left unfixed as an acceptable edge case.

## Reviewer notes

No Python changed — ruff/ty/pytest are no-ops. The only moving parts are `.claude/settings.json` (new) and `AGENTS.md` (2 lines added).


___

## **CodeAnt-AI Description**
**Block file edits on the main branch**

### What Changed
- File edits are now blocked when the target file is in a repo on `main`, so changes must be made on a feature branch first
- The block applies to edit, write, and notebook edits, with a clear message telling the user to create a branch and retry
- The agent guidance now reminds users to check out a branch before the first edit

### Impact
`✅ Fewer edits made on protected branches`
`✅ Less time spent recovering from accidental main-branch changes`
`✅ Earlier branch creation before file edits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an edit-protection guard that blocks file modifications when working directly on the main branch.

* **Documentation**
  * Introduced a contributor checklist (“Before your first file edit”) to verify you’re not on main, and guidance to create a feature branch using the recommended naming format before editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->