### PR TITLE
fix: clean up partial yt-dlp and stream download files on failure

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import math
 from pathlib import Path
@@ -90,7 +91,8 @@ class Downloader:
                         if chunk:
                             f.write(chunk)
             except Exception:
-                Path(dest).unlink(missing_ok=True)
+                with contextlib.suppress(OSError):
+                    Path(dest).unlink(missing_ok=True)
                 raise
         finally:
             r.close()
@@ -144,7 +146,8 @@ class Downloader:
                 # with no extension) on disk when a download or post-processing
                 # step fails. Remove them so failed attempts don't accumulate.
                 for leftover in Path.cwd().glob(f"{output_stem}*"):
-                    leftover.unlink(missing_ok=True)
+                    with contextlib.suppress(OSError):
+                        leftover.unlink(missing_ok=True)
                 raise
         return temporary_file_name
 

--- a/src/download.py
+++ b/src/download.py
@@ -84,10 +84,14 @@ class Downloader:
             except HTTPError:
                 logger.exception("%s: status code", r.status_code)
                 raise
-            with Path(dest).open("wb") as f:
-                for chunk in r.iter_content(chunk_size=8192):
-                    if chunk:
-                        f.write(chunk)
+            try:
+                with Path(dest).open("wb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+            except Exception:
+                Path(dest).unlink(missing_ok=True)
+                raise
         finally:
             r.close()
 
@@ -112,6 +116,7 @@ class Downloader:
 
         """
         temporary_file_name = generate_temporary_name(ext=".mp3")
+        output_stem = temporary_file_name.split(".", maxsplit=1)[0]
         proxy = get_proxy()
         with YoutubeDL({"proxy": proxy, "nocheckcertificate": False}) as ydl:
             info = ydl.extract_info(url, download=False)
@@ -121,7 +126,7 @@ class Downloader:
         audio_format = self._choose_yt_audio_format(cast("dict[str, Any]", info))
         ydl_opts = {
             "format": audio_format,
-            "outtmpl": temporary_file_name.split(".", maxsplit=1)[0],
+            "outtmpl": output_stem,
             "nocheckcertificate": False,
             "proxy": proxy,
             "postprocessors": [
@@ -132,7 +137,15 @@ class Downloader:
             ],
         }
         with YoutubeDL(ydl_opts) as ydl:
-            ydl.download(url)
+            try:
+                ydl.download(url)
+            except DownloadError:
+                # yt-dlp leaves partial fragment files (named after output_stem,
+                # with no extension) on disk when a download or post-processing
+                # step fails. Remove them so failed attempts don't accumulate.
+                for leftover in Path.cwd().glob(f"{output_stem}*"):
+                    leftover.unlink(missing_ok=True)
+                raise
         return temporary_file_name
 
     @retry(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -131,6 +131,66 @@ def test_download_yt_extract_info_returns_none(mocker):
         download_yt("https://youtube.com/watch?v=123")
 
 
+def test_download_yt_removes_partials_on_download_error(mocker):
+    """Test download_yt deletes yt-dlp partial files when the download fails."""
+    from tenacity import RetryError
+    from yt_dlp.utils import DownloadError
+
+    mock_ydl = mocker.patch("download.YoutubeDL")
+    mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
+    mocker.patch("time.sleep")  # suppress tenacity wait between retries
+
+    info_ydl = mocker.MagicMock()
+    info_ydl.extract_info.return_value = {
+        "formats": [
+            {"format_id": "139", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+        ],
+    }
+    download_ydl = mocker.MagicMock()
+    download_ydl.download.side_effect = DownloadError("boom")
+    # extract_info + download contexts alternate across the two retry attempts.
+    mock_ydl.side_effect = [
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
+    ]
+
+    partial = mocker.MagicMock(spec=Path)
+    mock_cwd = mocker.patch("download.Path.cwd")
+    mock_cwd.return_value.glob.return_value = [partial]
+
+    with pytest.raises(RetryError):
+        download_yt("https://youtube.com/watch?v=123")
+
+    mock_cwd.return_value.glob.assert_called_with("temp_yt*")
+    partial.unlink.assert_called_with(missing_ok=True)
+
+
+def test_download_yt_keeps_file_on_success(mocker):
+    """Test download_yt does not run partial cleanup on the happy path."""
+    mock_ydl = mocker.patch("download.YoutubeDL")
+    mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
+
+    info_ydl = mocker.MagicMock()
+    info_ydl.extract_info.return_value = {
+        "formats": [
+            {"format_id": "139", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+        ],
+    }
+    download_ydl = mocker.MagicMock()
+    mock_ydl.side_effect = [
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
+    ]
+    mock_cwd = mocker.patch("download.Path.cwd")
+
+    result = download_yt("https://youtube.com/watch?v=123")
+
+    assert result == "temp_yt.mp3"
+    mock_cwd.return_value.glob.assert_not_called()
+
+
 def test_choose_yt_audio_format_falls_back_when_no_audio_only_formats():
     """Test selector fallback when yt-dlp has no audio-only format ids."""
     info = {
@@ -285,6 +345,29 @@ def test_download_tg_http_error(mocker):
         download_tg(mock_file, ext=".ext")
 
     mock_logger.exception.assert_called_once_with("%s: status code", 403)
+
+
+def test_stream_to_file_removes_partial_on_failure(mocker):
+    """Test _stream_to_file deletes the partial dest file when the write fails."""
+    mocker.patch("download.TG_API_TOKEN", "TEST_TOKEN")
+    mocker.patch("download.generate_temporary_name", return_value="temp_file.ext")
+
+    mock_file = mocker.MagicMock()
+    mock_file.file_path = "path/to/file"
+
+    mock_resp = mocker.MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.iter_content.side_effect = OSError("connection reset")
+    mocker.patch("download.requests.get", return_value=mock_resp)
+
+    mocker.patch("pathlib.Path.open", mocker.mock_open())
+    mock_unlink = mocker.patch("pathlib.Path.unlink")
+
+    with pytest.raises(OSError, match="connection reset"):
+        download_tg(mock_file, ext=".ext")
+
+    mock_unlink.assert_called_once_with(missing_ok=True)
+    mock_resp.close.assert_called_once()
 
 
 def test_classify_url_uppercase_youtube_host(mocker):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -167,6 +167,40 @@ def test_download_yt_removes_partials_on_download_error(mocker):
     partial.unlink.assert_called_with(missing_ok=True)
 
 
+def test_download_yt_unlink_oserror_does_not_hide_download_error(mocker):
+    """Test that an OSError from unlink is suppressed and DownloadError still propagates."""
+    from tenacity import RetryError
+    from yt_dlp.utils import DownloadError
+
+    mock_ydl = mocker.patch("download.YoutubeDL")
+    mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
+    mocker.patch("time.sleep")
+
+    info_ydl = mocker.MagicMock()
+    info_ydl.extract_info.return_value = {
+        "formats": [
+            {"format_id": "139", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+        ],
+    }
+    download_ydl = mocker.MagicMock()
+    download_ydl.download.side_effect = DownloadError("boom")
+    mock_ydl.side_effect = [
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
+    ]
+
+    partial = mocker.MagicMock(spec=Path)
+    partial.unlink.side_effect = PermissionError("locked")
+    mock_cwd = mocker.patch("download.Path.cwd")
+    mock_cwd.return_value.glob.return_value = [partial]
+
+    # PermissionError from unlink must not surface; RetryError wraps DownloadError.
+    with pytest.raises(RetryError):
+        download_yt("https://youtube.com/watch?v=123")
+
+
 def test_download_yt_keeps_file_on_success(mocker):
     """Test download_yt does not run partial cleanup on the happy path."""
     mock_ydl = mocker.patch("download.YoutubeDL")
@@ -368,6 +402,27 @@ def test_stream_to_file_removes_partial_on_failure(mocker):
 
     mock_unlink.assert_called_once_with(missing_ok=True)
     mock_resp.close.assert_called_once()
+
+
+def test_stream_to_file_unlink_oserror_does_not_hide_write_error(mocker):
+    """Test that an OSError from unlink is suppressed and the original write error propagates."""
+    mocker.patch("download.TG_API_TOKEN", "TEST_TOKEN")
+    mocker.patch("download.generate_temporary_name", return_value="temp_file.ext")
+
+    mock_file = mocker.MagicMock()
+    mock_file.file_path = "path/to/file"
+
+    mock_resp = mocker.MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.iter_content.side_effect = OSError("connection reset")
+    mocker.patch("download.requests.get", return_value=mock_resp)
+
+    mocker.patch("pathlib.Path.open", mocker.mock_open())
+    mocker.patch("pathlib.Path.unlink", side_effect=PermissionError("locked"))
+
+    # PermissionError from unlink must not surface; original OSError propagates.
+    with pytest.raises(OSError, match="connection reset"):
+        download_tg(mock_file, ext=".ext")
 
 
 def test_classify_url_uppercase_youtube_host(mocker):


### PR DESCRIPTION
## **User description**
## What

After a failed `yt-dlp` download (proxy drop, 429, FFmpeg post-processing error), the in-process DASH merger leaves a bare-UUID file (~34.5 MB each) on disk. Because `download_yt` raises `DownloadError` before returning the filename, no caller ever learns the partial's name, and tenacity generates a fresh UUID on each retry — so two failed attempts leave two permanent leftovers that are never cleaned up.

The same gap exists in `_stream_to_file`: a mid-stream network failure leaves a partial `.mp3`/`.ogg` behind.

## Changes

- **`download_yt`**: wraps `ydl.download(url)` in a narrow `except DownloadError` that glob-deletes all files matching `{output_stem}*` (catches the bare UUID, `.part`, fragment files, and any `.mp3`), then re-raises so tenacity's retry logic is unchanged.
- **`_stream_to_file`**: on any write failure, `unlink(missing_ok=True)` the partial `dest` file — covers Castro and Telegram downloads too.

## Why not fix `clean_up`

`clean_up` itself is correct. The gap is that partial filenames never reach it: `download_yt` raises before returning the name; the on-disk partial is a bare UUID that doesn't match the would-be `<uuid>.mp3`. Broadening `clean_up` would risk deleting concurrent in-flight downloads.

## Tests

Three new tests: cleanup-on-error (yt-dlp), no-cleanup-on-success (yt-dlp), and cleanup-on-failure (stream). All 225 tests pass, `src/download.py` stays at 100% coverage.

## Reviewer notes

The code review flagged that `except DownloadError` is narrower than `_stream_to_file`'s `except Exception`. In practice yt-dlp wraps all download and postprocessing failures as `DownloadError` (confirmed by the production log), so the realistic paths are covered. The narrow catch is intentional to stay consistent with the `@retry(retry=retry_if_exception_type(DownloadError))` decorator above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove partial download files when a download fails**

### What Changed
- Failed YouTube downloads now clean up leftover partial files before retrying, so repeated failures do not leave extra files behind
- Failed direct file streams now delete the incomplete output file instead of keeping a broken partial download
- Added tests for failed YouTube downloads, successful YouTube downloads, and failed stream downloads

### Impact
`✅ Fewer leftover download files`
`✅ Cleaner retry behavior after YouTube failures`
`✅ Fewer broken partial files after stream errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved download error handling: if a download or streaming write fails, any partially written files are now removed automatically.
* Ensured cleanup failures (e.g., filesystem permission issues) do not mask the original download/streaming error.

## Tests
* Expanded test coverage to verify partial-file cleanup on YouTube and streaming failures.
* Added assertions that cleanup errors are suppressed while the original failure is still raised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->