### PR TITLE
refactor: reverse transcript engines to API-default + backend abstraction

### DIFF
--- a/src/transcription.py
+++ b/src/transcription.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs, urlsplit
@@ -105,73 +106,24 @@ class AudioTranscriber:
         )
 
 
-class YouTubeTranscriber:
-    """Retrieves YouTube transcripts via yt-dlp (primary) or the API (fallback)."""
+class TranscriptBackend(ABC):
+    """Abstract base for YouTube transcript-fetching backends."""
 
-    @staticmethod
-    def _extract_video_id(url: str) -> str | None:
-        """Extract the video id from any supported YouTube URL form.
+    name: str
+    prefix: str
+    recoverable_errors: tuple[type[Exception], ...]
 
-        Returns None when the host is not a known YouTube host or the id cannot
-        be located in the path/query.
+    @abstractmethod
+    def fetch(self, url: str, video_id: str) -> str:
+        """Fetch transcript text; backends use the argument(s) they need."""
 
-        """
-        parts = urlsplit(url)
-        hostname = (parts.hostname or "").lower()
-        hostname = hostname.removeprefix("www.")
-        if hostname not in YT_HOSTS:
-            return None
-        if hostname == "youtu.be":
-            video_id = parts.path.lstrip("/").split("/", 1)[0]
-            return video_id or None
-        path_parts = [p for p in parts.path.split("/") if p]
-        prefixed_paths = ("live", "shorts", "embed")
-        if len(path_parts) >= 2 and path_parts[0] in prefixed_paths:  # noqa: PLR2004
-            return path_parts[1]
-        if path_parts and path_parts[0] == "watch":
-            return parse_qs(parts.query).get("v", [None])[0]
-        return None
 
-    @staticmethod
-    def _vtt_to_text(vtt_path: Path) -> str:
-        """Convert a VTT subtitle file to deduplicated plain text.
+class ApiBackend(TranscriptBackend):
+    """youtube_transcript_api transcript backend (fallback by default)."""
 
-        Args:
-            vtt_path (Path): Path to the .vtt file.
-
-        Returns:
-            str: Clean transcript text with duplicate lines removed.
-
-        """
-        lines = vtt_path.read_text(encoding="utf-8").splitlines()
-        out: list[str] = []
-        prev = ""
-        in_note = False
-        for i, raw in enumerate(lines):
-            line = raw.strip()
-            if not line:
-                in_note = False
-                continue
-            if in_note:
-                continue
-            if "-->" in line:
-                continue
-            if line.startswith(("WEBVTT", "Kind:", "Language:")):
-                continue
-            if line.startswith("NOTE"):
-                in_note = True
-                continue
-            next_line = lines[i + 1].strip() if i + 1 < len(lines) else ""
-            if "-->" in next_line:
-                continue
-            clean = re.sub(r"<[^>]*>", "", line)
-            clean = (
-                clean.replace("&amp;", "&").replace("&gt;", ">").replace("&lt;", "<")
-            )
-            if clean and clean != prev:
-                out.append(clean)
-                prev = clean
-        return "\n".join(out)
+    name = "youtube_transcript_api"
+    prefix = "📺"
+    recoverable_errors = (CouldNotRetrieveTranscript, RetryError)
 
     @retry(
         stop=stop_after_attempt(2),
@@ -220,6 +172,59 @@ class YouTubeTranscriber:
             time.sleep(60)
             transcript = ytt_api.fetch(video_id, languages=language_codes)
         return TextFormatter().format_transcript(transcript)
+
+    def fetch(self, url: str, video_id: str) -> str:  # noqa: ARG002
+        """Adapt the uniform backend interface to youtube_transcript_api."""
+        return self.fetch_via_api(video_id)
+
+
+class YtDlpBackend(TranscriptBackend):
+    """yt-dlp subtitle-download transcript backend (primary by default)."""
+
+    name = "yt-dlp"
+    prefix = "📹"
+    recoverable_errors = (DownloadError, RetryError)
+
+    @staticmethod
+    def _vtt_to_text(vtt_path: Path) -> str:
+        """Convert a VTT subtitle file to deduplicated plain text.
+
+        Args:
+            vtt_path (Path): Path to the .vtt file.
+
+        Returns:
+            str: Clean transcript text with duplicate lines removed.
+
+        """
+        lines = vtt_path.read_text(encoding="utf-8").splitlines()
+        out: list[str] = []
+        prev = ""
+        in_note = False
+        for i, raw in enumerate(lines):
+            line = raw.strip()
+            if not line:
+                in_note = False
+                continue
+            if in_note:
+                continue
+            if "-->" in line:
+                continue
+            if line.startswith(("WEBVTT", "Kind:", "Language:")):
+                continue
+            if line.startswith("NOTE"):
+                in_note = True
+                continue
+            next_line = lines[i + 1].strip() if i + 1 < len(lines) else ""
+            if "-->" in next_line:
+                continue
+            clean = re.sub(r"<[^>]*>", "", line)
+            clean = (
+                clean.replace("&amp;", "&").replace("&gt;", ">").replace("&lt;", "<")
+            )
+            if clean and clean != prev:
+                out.append(clean)
+                prev = clean
+        return "\n".join(out)
 
     @retry(
         stop=stop_after_attempt(2),
@@ -364,17 +369,60 @@ class YouTubeTranscriber:
             for f in Path.cwd().glob(f"{temp_basename}.*"):
                 clean_up(file=str(f))
 
+    def fetch(self, url: str, video_id: str) -> str:  # noqa: ARG002
+        """Adapt the uniform backend interface to yt-dlp."""
+        return self.fetch_via_ytdlp(url)
+
+
+class YouTubeTranscriber:
+    """Orchestrate primary→fallback transcript fetching across backends."""
+
+    def __init__(
+        self,
+        primary: TranscriptBackend,
+        fallback: TranscriptBackend,
+    ) -> None:
+        """Store the primary and fallback transcript backends."""
+        self._primary = primary
+        self._fallback = fallback
+
+    @staticmethod
+    def _extract_video_id(url: str) -> str | None:
+        """Extract the video id from any supported YouTube URL form.
+
+        Returns None when the host is not a known YouTube host or the id cannot
+        be located in the path/query.
+
+        """
+        parts = urlsplit(url)
+        hostname = (parts.hostname or "").lower()
+        hostname = hostname.removeprefix("www.")
+        if hostname not in YT_HOSTS:
+            return None
+        if hostname == "youtu.be":
+            video_id = parts.path.lstrip("/").split("/", 1)[0]
+            return video_id or None
+        path_parts = [p for p in parts.path.split("/") if p]
+        prefixed_paths = ("live", "shorts", "embed")
+        if len(path_parts) >= 2 and path_parts[0] in prefixed_paths:  # noqa: PLR2004
+            return path_parts[1]
+        if path_parts and path_parts[0] == "watch":
+            return parse_qs(parts.query).get("v", [None])[0]
+        return None
+
     def get_transcript(self, url: str) -> PrefixedText:
         """Retrieve the transcript from a YouTube video URL.
 
-        Tries yt-dlp first; falls back to youtube_transcript_api.
+        Tries the primary backend first, falling back to the secondary on a
+        recoverable failure. With the default wiring this means the API first,
+        then yt-dlp.
 
         Args:
             url (str): The YouTube video URL.
 
         Returns:
-            PrefixedText: The transcript text and display prefix. 📹 = yt-dlp;
-                📺 = youtube_transcript_api fallback.
+            PrefixedText: The transcript text and display prefix. 📺 =
+                youtube_transcript_api; 📹 = yt-dlp.
 
         Raises:
             ValueError: If the URL format is not recognized.
@@ -387,20 +435,26 @@ class YouTubeTranscriber:
             raise ValueError(msg)
 
         try:
-            text = self.fetch_via_ytdlp(url)
-        except (DownloadError, RetryError) as ytdlp_error:
+            text = self._primary.fetch(url, video_id)
+        except self._primary.recoverable_errors as primary_error:
             logger.warning(
-                "yt-dlp transcript backend failed, falling back to API: %s",
-                ytdlp_error,
+                "%s transcript backend failed, falling back to %s: %s",
+                self._primary.name,
+                self._fallback.name,
+                primary_error,
             )
             try:
-                text = self.fetch_via_api(video_id)
-            except (CouldNotRetrieveTranscript, RetryError) as api_error:
-                logger.warning("API fallback backend also failed: %s", api_error)
+                text = self._fallback.fetch(url, video_id)
+            except self._fallback.recoverable_errors as fallback_error:
+                logger.warning(
+                    "%s fallback backend also failed: %s",
+                    self._fallback.name,
+                    fallback_error,
+                )
                 msg = "Both transcript backends failed"
-                raise FetchTranscriptError(msg) from api_error
-            return PrefixedText(text=text, prefix="📺")
-        return PrefixedText(text=text, prefix="📹")
+                raise FetchTranscriptError(msg) from fallback_error
+            return PrefixedText(text=text, prefix=self._fallback.prefix)
+        return PrefixedText(text=text, prefix=self._primary.prefix)
 
 
 # ---------------------------------------------------------------------------
@@ -408,7 +462,9 @@ class YouTubeTranscriber:
 # ---------------------------------------------------------------------------
 
 audio_transcriber = AudioTranscriber(replicate_client)
-yt_transcriber = YouTubeTranscriber()
+api_backend = ApiBackend()
+ytdlp_backend = YtDlpBackend()
+yt_transcriber = YouTubeTranscriber(api_backend, ytdlp_backend)
 
 
 # ---------------------------------------------------------------------------
@@ -416,6 +472,6 @@ yt_transcriber = YouTubeTranscriber()
 # ---------------------------------------------------------------------------
 
 transcribe = audio_transcriber.transcribe
-fetch_transcript_via_api = yt_transcriber.fetch_via_api
-fetch_transcript_via_ytdlp = yt_transcriber.fetch_via_ytdlp
+fetch_transcript_via_api = api_backend.fetch_via_api
+fetch_transcript_via_ytdlp = ytdlp_backend.fetch_via_ytdlp
 get_yt_transcript = yt_transcriber.get_transcript

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -12,7 +12,6 @@ from defusedxml.ElementTree import ParseError
 from replicate.exceptions import ModelError, ReplicateError
 from requests.exceptions import ChunkedEncodingError, ProxyError, SSLError
 from tenacity import (
-    RetryError,
     before_sleep_log,
     retry,
     retry_if_exception_type,
@@ -21,7 +20,6 @@ from tenacity import (
 )
 from youtube_transcript_api import YouTubeTranscriptApi
 from youtube_transcript_api._errors import (
-    CouldNotRetrieveTranscript,
     IpBlocked,
     NoTranscriptFound,
     RequestBlocked,
@@ -111,7 +109,6 @@ class TranscriptBackend(ABC):
 
     name: str
     prefix: str
-    recoverable_errors: tuple[type[Exception], ...]
 
     @abstractmethod
     def fetch(self, url: str, video_id: str) -> str:
@@ -123,7 +120,6 @@ class ApiBackend(TranscriptBackend):
 
     name = "youtube_transcript_api"
     prefix = "📺"
-    recoverable_errors = (CouldNotRetrieveTranscript, RetryError)
 
     @retry(
         stop=stop_after_attempt(2),
@@ -169,6 +165,9 @@ class ApiBackend(TranscriptBackend):
         except NoTranscriptFound:
             transcript_list = ytt_api.list(video_id)
             language_codes = [t.language_code for t in transcript_list]
+            # Deliberate cooldown between back-to-back requests: rapid calls get
+            # rate-limited/blocked by YouTube. Do not shorten or remove.
+            # See https://github.com/jdepoix/youtube-transcript-api/issues/572
             time.sleep(60)
             transcript = ytt_api.fetch(video_id, languages=language_codes)
         return TextFormatter().format_transcript(transcript)
@@ -183,7 +182,6 @@ class YtDlpBackend(TranscriptBackend):
 
     name = "yt-dlp"
     prefix = "📹"
-    recoverable_errors = (DownloadError, RetryError)
 
     @staticmethod
     def _vtt_to_text(vtt_path: Path) -> str:
@@ -410,12 +408,34 @@ class YouTubeTranscriber:
             return parse_qs(parts.query).get("v", [None])[0]
         return None
 
+    @staticmethod
+    def _fetch_validated(
+        backend: TranscriptBackend,
+        url: str,
+        video_id: str,
+    ) -> str:
+        """Fetch from a backend, treating an empty transcript as a failure.
+
+        An empty/whitespace result is a soft failure: raising lets the
+        orchestrator fall back to the other backend instead of returning a
+        useless empty transcript.
+
+        Raises:
+            FetchTranscriptError: If the backend returns empty content.
+
+        """
+        text = backend.fetch(url, video_id)
+        if not text.strip():
+            msg = f"{backend.name} returned an empty transcript"
+            raise FetchTranscriptError(msg)
+        return text
+
     def get_transcript(self, url: str) -> PrefixedText:
         """Retrieve the transcript from a YouTube video URL.
 
-        Tries the primary backend first, falling back to the secondary on a
-        recoverable failure. With the default wiring this means the API first,
-        then yt-dlp.
+        Tries the primary backend first, falling back to the secondary on any
+        failure (including an empty result). With the default wiring this means
+        the API first, then yt-dlp.
 
         Args:
             url (str): The YouTube video URL.
@@ -435,8 +455,10 @@ class YouTubeTranscriber:
             raise ValueError(msg)
 
         try:
-            text = self._primary.fetch(url, video_id)
-        except self._primary.recoverable_errors as primary_error:
+            text = self._fetch_validated(self._primary, url, video_id)
+        except Exception as primary_error:
+            # Any primary failure — expected or not — should try the fallback;
+            # crashing here would skip the second engine entirely.
             logger.warning(
                 "%s transcript backend failed, falling back to %s: %s",
                 self._primary.name,
@@ -444,8 +466,8 @@ class YouTubeTranscriber:
                 primary_error,
             )
             try:
-                text = self._fallback.fetch(url, video_id)
-            except self._fallback.recoverable_errors as fallback_error:
+                text = self._fetch_validated(self._fallback, url, video_id)
+            except Exception as fallback_error:
                 logger.warning(
                     "%s fallback backend also failed: %s",
                     self._fallback.name,

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -116,7 +116,7 @@ class TranscriptBackend(ABC):
 
 
 class ApiBackend(TranscriptBackend):
-    """youtube_transcript_api transcript backend (fallback by default)."""
+    """youtube_transcript_api transcript backend (primary by default)."""
 
     name = "youtube_transcript_api"
     prefix = "📺"
@@ -178,7 +178,7 @@ class ApiBackend(TranscriptBackend):
 
 
 class YtDlpBackend(TranscriptBackend):
-    """yt-dlp subtitle-download transcript backend (primary by default)."""
+    """yt-dlp subtitle-download transcript backend (fallback by default)."""
 
     name = "yt-dlp"
     prefix = "📹"

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -84,6 +84,50 @@ def test_get_yt_transcript_falls_back_to_ytdlp(mocker, url):
     mock_ytdlp.assert_called_once_with(url)
 
 
+def test_get_yt_transcript_falls_back_on_unexpected_primary_error(mocker):
+    """Test get_yt_transcript falls back when the primary raises an unexpected error.
+
+    A primary failure outside the known transcript-exception types (e.g. a raw
+    network error) must still trigger the fallback rather than escaping.
+    """
+    mocker.patch.object(
+        transcription.api_backend,
+        "fetch_via_api",
+        side_effect=ConnectionError("network down"),
+    )
+    mock_ytdlp = mocker.patch.object(
+        transcription.ytdlp_backend,
+        "fetch_via_ytdlp",
+        return_value="from fallback",
+    )
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    result = get_yt_transcript(url)
+
+    assert result == PrefixedText(text="from fallback", prefix="📹")
+    mock_ytdlp.assert_called_once_with(url)
+
+
+def test_get_yt_transcript_falls_back_on_empty_primary(mocker):
+    """Test get_yt_transcript falls back when the primary returns an empty transcript."""
+    mocker.patch.object(
+        transcription.api_backend,
+        "fetch_via_api",
+        return_value="   \n  ",
+    )
+    mock_ytdlp = mocker.patch.object(
+        transcription.ytdlp_backend,
+        "fetch_via_ytdlp",
+        return_value="from fallback",
+    )
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    result = get_yt_transcript(url)
+
+    assert result == PrefixedText(text="from fallback", prefix="📹")
+    mock_ytdlp.assert_called_once_with(url)
+
+
 def test_get_yt_transcript_both_backends_fail_raises_error(mocker):
     """Test get_yt_transcript raises FetchTranscriptError chained from the fallback failure."""
     api_error = TranscriptsDisabled("dQw4w9WgXcQ")
@@ -100,6 +144,16 @@ def test_get_yt_transcript_both_backends_fail_raises_error(mocker):
         get_yt_transcript(url)
 
     assert exc_info.value.__cause__ is ytdlp_error
+
+
+def test_get_yt_transcript_both_empty_raises_error(mocker):
+    """Test get_yt_transcript raises FetchTranscriptError when both backends return empty."""
+    mocker.patch.object(transcription.api_backend, "fetch_via_api", return_value="")
+    mocker.patch.object(transcription.ytdlp_backend, "fetch_via_ytdlp", return_value="  ")
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    with pytest.raises(FetchTranscriptError, match="Both transcript backends failed"):
+        get_yt_transcript(url)
 
 
 def test_get_yt_transcript_unknown_url(mocker):

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -20,44 +20,37 @@ from exceptions import (
     TranscriptDownloadError,
 )
 from transcription import (
+    ApiBackend,
     AudioTranscriber,
     YouTubeTranscriber,
+    YtDlpBackend,
     fetch_transcript_via_api,
     fetch_transcript_via_ytdlp,
     get_yt_transcript,
 )
 
 
-def test_get_yt_transcript_uses_ytdlp_primary(mocker, tmp_path):
-    """Test get_yt_transcript uses yt-dlp first and does not touch the API on success."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
+def test_yt_transcriber_wires_api_as_primary():
+    """Test the default transcriber uses the API as primary and yt-dlp as fallback."""
+    assert isinstance(transcription.yt_transcriber._primary, ApiBackend)
+    assert isinstance(transcription.yt_transcriber._fallback, YtDlpBackend)
 
-    vtt_content = textwrap.dedent("""\
-        WEBVTT
 
-        00:00:01.000 --> 00:00:03.000
-        Hello world
-    """)
-    vtt_file = tmp_path / "fake-uuid.en.vtt"
-    vtt_file.write_text(vtt_content, encoding="utf-8")
-
-    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-    mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
-    mock_ydl_inst = mock_ydl_cls.return_value.__enter__.return_value
-    mock_ydl_inst.extract_info.return_value = {
-        "subtitles": {"en": [{}]},
-        "automatic_captions": {},
-    }
-    mock_api = mocker.patch.object(transcription.yt_transcriber, "fetch_via_api")
+def test_get_yt_transcript_uses_api_primary(mocker):
+    """Test get_yt_transcript uses the API first and does not touch yt-dlp on success."""
+    mock_api = mocker.patch.object(
+        transcription.api_backend,
+        "fetch_via_api",
+        return_value="from api",
+    )
+    mock_ytdlp = mocker.patch.object(transcription.ytdlp_backend, "fetch")
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     result = get_yt_transcript(url)
 
-    assert "Hello world" in result.text
-    assert result.prefix == "📹"
-    mock_ydl_inst.download.assert_called_once_with([url])
-    mock_api.assert_not_called()
+    assert result == PrefixedText(text="from api", prefix="📺")
+    mock_api.assert_called_once_with("dQw4w9WgXcQ")
+    mock_ytdlp.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -68,47 +61,51 @@ def test_get_yt_transcript_uses_ytdlp_primary(mocker, tmp_path):
         "https://www.youtube.com/live/dQw4w9WgXcQ",
     ],
 )
-def test_get_yt_transcript_falls_back_to_api(mocker, url):
-    """Test get_yt_transcript falls back to the API when yt-dlp fails.
+def test_get_yt_transcript_falls_back_to_ytdlp(mocker, url):
+    """Test get_yt_transcript falls back to yt-dlp when the API fails.
 
     Parametrized across URL formats to confirm each resolves to the same
-    video_id that is handed to the API backend.
+    video_id that is handed to the yt-dlp backend.
     """
     mocker.patch.object(
-        transcription.yt_transcriber,
-        "fetch_via_ytdlp",
-        side_effect=DownloadError("no subs"),
-    )
-    mock_api = mocker.patch.object(
-        transcription.yt_transcriber,
+        transcription.api_backend,
         "fetch_via_api",
+        side_effect=TranscriptsDisabled("dQw4w9WgXcQ"),
+    )
+    mock_ytdlp = mocker.patch.object(
+        transcription.ytdlp_backend,
+        "fetch_via_ytdlp",
         return_value="from fallback",
     )
 
     result = get_yt_transcript(url)
 
-    assert result == PrefixedText(text="from fallback", prefix="📺")
-    mock_api.assert_called_once_with("dQw4w9WgXcQ")
+    assert result == PrefixedText(text="from fallback", prefix="📹")
+    mock_ytdlp.assert_called_once_with(url)
 
 
 def test_get_yt_transcript_both_backends_fail_raises_error(mocker):
-    """Test get_yt_transcript raises FetchTranscriptError chained from the API failure."""
-    ytdlp_error = DownloadError("no subs")
+    """Test get_yt_transcript raises FetchTranscriptError chained from the fallback failure."""
     api_error = TranscriptsDisabled("dQw4w9WgXcQ")
-    mocker.patch.object(transcription.yt_transcriber, "fetch_via_ytdlp", side_effect=ytdlp_error)
-    mocker.patch.object(transcription.yt_transcriber, "fetch_via_api", side_effect=api_error)
+    ytdlp_error = DownloadError("no subs")
+    mocker.patch.object(transcription.api_backend, "fetch_via_api", side_effect=api_error)
+    mocker.patch.object(
+        transcription.ytdlp_backend,
+        "fetch_via_ytdlp",
+        side_effect=ytdlp_error,
+    )
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with pytest.raises(FetchTranscriptError) as exc_info:
         get_yt_transcript(url)
 
-    assert exc_info.value.__cause__ is api_error
+    assert exc_info.value.__cause__ is ytdlp_error
 
 
 def test_get_yt_transcript_unknown_url(mocker):
     """Test get_yt_transcript raises ValueError for unknown URL formats."""
-    mock_api = mocker.patch.object(transcription.yt_transcriber, "fetch_via_api")
-    mock_ytdlp = mocker.patch.object(transcription.yt_transcriber, "fetch_via_ytdlp")
+    mock_api = mocker.patch.object(transcription.api_backend, "fetch")
+    mock_ytdlp = mocker.patch.object(transcription.ytdlp_backend, "fetch")
 
     with pytest.raises(ValueError, match="Unknown URL"):
         get_yt_transcript("https://example.com/not-youtube")
@@ -166,7 +163,7 @@ def test_vtt_to_text_dedupes_and_strips_tags(tmp_path):
     vtt_path = tmp_path / "test.vtt"
     vtt_path.write_text(vtt_content, encoding="utf-8")
 
-    result = YouTubeTranscriber._vtt_to_text(vtt_path)
+    result = YtDlpBackend._vtt_to_text(vtt_path)
 
     assert result == "Hello & world\nSecond line"
 
@@ -187,7 +184,7 @@ def test_vtt_to_text_skips_cue_identifiers(tmp_path):
     vtt_path = tmp_path / "test.vtt"
     vtt_path.write_text(vtt_content, encoding="utf-8")
 
-    result = YouTubeTranscriber._vtt_to_text(vtt_path)
+    result = YtDlpBackend._vtt_to_text(vtt_path)
 
     assert result == "Hello\nWorld"
 
@@ -212,7 +209,7 @@ def test_vtt_to_text_skips_multiline_note_block(tmp_path):
     vtt_path = tmp_path / "test.vtt"
     vtt_path.write_text(vtt_content, encoding="utf-8")
 
-    result = YouTubeTranscriber._vtt_to_text(vtt_path)
+    result = YtDlpBackend._vtt_to_text(vtt_path)
 
     assert result == "Hello\nWorld"
     assert "comment" not in result
@@ -236,7 +233,7 @@ def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
     vtt_path = tmp_path / "test.vtt"
     vtt_path.write_text(vtt_content, encoding="utf-8")
 
-    result = YouTubeTranscriber._vtt_to_text(vtt_path)
+    result = YtDlpBackend._vtt_to_text(vtt_path)
 
     assert result == "Hello\nWorld\nHello"
 
@@ -812,7 +809,7 @@ def test_fetch_transcript_via_ytdlp_vtt_read_error_raises_download_error(mocker,
     ctx.extract_info.return_value = {"subtitles": {"en": [{}]}, "automatic_captions": {}}
     # create the vtt file so the glob finds it, but vtt_to_text raises OSError
     (tmp_path / "fake-uuid.en.vtt").write_text("WEBVTT\n", encoding="utf-8")
-    mocker.patch.object(YouTubeTranscriber, "_vtt_to_text", side_effect=OSError("disk full"))
+    mocker.patch.object(YtDlpBackend, "_vtt_to_text", side_effect=OSError("disk full"))
 
     with pytest.raises(DownloadError, match="Failed to read downloaded VTT file"):
         fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")


### PR DESCRIPTION
## **User description**
## Summary

- Makes `youtube_transcript_api` the primary transcript engine and `yt-dlp` the fallback, reversing the previous order.
- Introduces a `TranscriptBackend` ABC mirroring the `ParserBackend` pattern in `parsing.py`: each backend declares `name`, `prefix`, and an abstract `fetch(url, video_id)` method. `YouTubeTranscriber` becomes a thin orchestrator that accepts injected `(primary, fallback)` backends — swapping the order is now a one-line change at construction.
- Hardens the orchestrator so *any* primary failure (including unexpected errors and empty transcripts) falls back to the second engine, matching the robustness of the existing `fetch_via_ytdlp` error handling.
- Public aliases `fetch_transcript_via_api(video_id)` and `fetch_transcript_via_ytdlp(url)` keep their signatures unchanged; callers in `summary.py` are unaffected.

## What changed

**`src/transcription.py`**
- New `TranscriptBackend` ABC with `name`, `prefix`, and abstract `fetch(url, video_id)`.
- `ApiBackend` (📺) wraps the existing `@retry`-decorated `fetch_via_api(video_id)` and adds a `fetch` adapter.
- `YtDlpBackend` (📹) holds `_vtt_to_text` and the existing `fetch_via_ytdlp(url)` with its `fetch` adapter.
- `YouTubeTranscriber` is now a pure orchestrator: `__init__(primary, fallback)`, `_extract_video_id` (unchanged), `_fetch_validated` (raises on empty output), `get_transcript` (catches `Exception` from each backend to ensure the fallback is always tried).
- Singletons: `api_backend = ApiBackend()`, `ytdlp_backend = YtDlpBackend()`, `yt_transcriber = YouTubeTranscriber(api_backend, ytdlp_backend)`.
- Removed now-unused `CouldNotRetrieveTranscript` and `RetryError` imports.
- Added an explanatory comment on `time.sleep(60)` citing the upstream rate-limit issue it works around ([jdepoix/youtube-transcript-api#572](https://github.com/jdepoix/youtube-transcript-api/issues/572)).

**`tests/test_transcription.py`**
- Reworked orchestration tests for the reversed engine order; backend-instance patching (`transcription.api_backend`, `transcription.ytdlp_backend`) replaces the old `yt_transcriber.fetch_via_*` patches.
- `_vtt_to_text` references updated to `YtDlpBackend._vtt_to_text`.
- Added `test_yt_transcriber_wires_api_as_primary`, `test_get_yt_transcript_falls_back_on_unexpected_primary_error`, `test_get_yt_transcript_falls_back_on_empty_primary`, `test_get_yt_transcript_both_empty_raises_error`.

## Test plan

- [x] `uvx ruff format .` / `uvx ruff check .` — clean
- [x] `uvx ty check .` — All checks passed
- [x] `uv run pytest --cov` — 231 passed, `src/transcription.py` 100%, TOTAL 100%
- [x] Runtime spot-check: `transcription.yt_transcriber._primary.name == "youtube_transcript_api"`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


___

## **CodeAnt-AI Description**
**Use the API transcript source first, with fallback to yt-dlp when needed**

### What Changed
- Transcript fetching now tries the API first and switches to yt-dlp if the first source fails
- Any primary failure now triggers the fallback, including unexpected network errors and empty transcript results
- When both sources fail, the error now points to the final failed source instead of stopping early
- The transcript source labels shown to users now match the actual source used

### Impact
`✅ Fewer transcript failures`
`✅ Clearer transcript source labels`
`✅ Fallback on empty transcript results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved transcript fetching reliability by automatically falling back to an alternative method when the primary source fails.
  * Added stricter validation to reject empty or whitespace-only transcripts.
  * Improved error handling so users get consistent failures when all available retrieval methods fail.
* **New Features**
  * Introduced selectable transcript backends (API-based and yt-dlp-based), with standardized behavior and consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->