### PR TITLE
test: remove dead fixture and parametrize redundant test groups

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from telebot import TeleBot, types
+from telebot import types
 
 # Ensure `src` is in the PYTHONPATH so we can import modules like config, database, etc.
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -25,12 +25,6 @@ import sentry_sdk
 
 # Disable Sentry in tests to avoid connection errors
 sentry_sdk.init = lambda *args, **kwargs: None
-
-
-@pytest.fixture
-def mock_bot(mocker):
-    """Fixture to provide a mocked TeleBot instance."""
-    return mocker.MagicMock(spec=TeleBot)
 
 
 @pytest.fixture

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,5 @@
+import pytest
+
 from main import (
     handle_info,
     handle_myinfo,
@@ -113,15 +115,26 @@ def test_handle_myinfo_missing_user(message_factory, mocker):
     mock_reply.assert_called_once_with(msg, "User information is missing.")
 
 
-def test_handle_set_target_language(message_factory, mocker):
-    """Test /set_target_language shows keyboard."""
+@pytest.mark.parametrize(
+    ("handler", "expected_text"),
+    [
+        (handle_set_target_language, "Select target language"),
+        (handle_set_summarizing_model, "Select summarizing model"),
+        (handle_set_prompt_strategy, "Select summarization strategy"),
+        (handle_set_thinking_level, "Select thinking level"),
+    ],
+)
+def test_handle_set_setting_shows_keyboard(
+    message_factory, mocker, handler, expected_text
+):
+    """Test each /set_* command shows its selection keyboard."""
     msg = message_factory(content_type="text")
     mock_send = mocker.patch("main.bot.send_message")
     mock_register = mocker.patch("main.bot.register_next_step_handler")
 
-    handle_set_target_language(msg)
+    handler(msg)
 
-    assert "Select target language" in mock_send.call_args[0][1]
+    assert expected_text in mock_send.call_args[0][1]
     assert mock_register.called
 
 
@@ -136,42 +149,6 @@ def test_proceed_set_target_language_success(message_factory, mocker):
     assert "The target language is set to Russian" in mock_send.call_args[0][1]
 
 
-def test_proceed_set_target_language_missing_input(message_factory, mocker):
-    """Test target language selection fails fast when user or text is missing."""
-    msg = message_factory(content_type="text", text="Russian")
-    msg.text = None
-    mock_reply = mocker.patch("main.bot.reply_to")
-    mock_set_language = mocker.patch("main.set_target_language")
-
-    proceed_set_target_language(msg)
-
-    mock_reply.assert_called_once_with(msg, "User information or language is missing.")
-    mock_set_language.assert_not_called()
-
-
-def test_proceed_set_target_language_invalid_choice(message_factory, mocker):
-    """Test invalid target language returns a clear user-facing message."""
-    msg = message_factory(content_type="text", text="Klingon")
-    mocker.patch("main.set_target_language", return_value=False)
-    mock_send = mocker.patch("main.bot.send_message")
-
-    proceed_set_target_language(msg)
-
-    mock_send.assert_called_once_with(msg.chat.id, "Unknown language")
-
-
-def test_handle_set_summarizing_model(message_factory, mocker):
-    """Test /set_summarizing_model shows keyboard."""
-    msg = message_factory(content_type="text")
-    mock_send = mocker.patch("main.bot.send_message")
-    mock_register = mocker.patch("main.bot.register_next_step_handler")
-
-    handle_set_summarizing_model(msg)
-
-    assert "Select summarizing model" in mock_send.call_args[0][1]
-    assert mock_register.called
-
-
 def test_proceed_set_summarizing_model_success(message_factory, mocker):
     """Test successful model selection."""
     msg = message_factory(content_type="text", text="Gemini 3.5 Flash")
@@ -182,54 +159,6 @@ def test_proceed_set_summarizing_model_success(message_factory, mocker):
 
     mock_set_model.assert_called_once_with(msg.from_user.id, "gemini-3.5-flash")
     assert "The summarizing model is set to Gemini 3.5 Flash" in mock_send.call_args[0][1]
-
-
-def test_proceed_set_summarizing_model_missing_input(message_factory, mocker):
-    """Test model selection fails fast when user or text is missing."""
-    msg = message_factory(content_type="text", text="gemini-3.5-flash")
-    msg.from_user = None
-    mock_reply = mocker.patch("main.bot.reply_to")
-    mock_set_model = mocker.patch("main.set_summarizing_model")
-
-    proceed_set_summarizing_model(msg)
-
-    mock_reply.assert_called_once_with(msg, "User information or model is missing.")
-    mock_set_model.assert_not_called()
-
-
-def test_proceed_set_summarizing_model_db_failure(message_factory, mocker):
-    """Test DB failure returns a clear user-facing message."""
-    msg = message_factory(content_type="text", text="Gemini 3.5 Flash")
-    mocker.patch("main.set_summarizing_model", return_value=False)
-    mock_send = mocker.patch("main.bot.send_message")
-
-    proceed_set_summarizing_model(msg)
-
-    mock_send.assert_called_once_with(msg.chat.id, "Failed to update summarizing model.")
-
-
-def test_proceed_set_summarizing_model_invalid_choice(message_factory, mocker):
-    """Test invalid label short-circuits before calling set_summarizing_model."""
-    msg = message_factory(content_type="text", text="Gemini 4 Pro")
-    mock_set_model = mocker.patch("main.set_summarizing_model")
-    mock_send = mocker.patch("main.bot.send_message")
-
-    proceed_set_summarizing_model(msg)
-
-    mock_send.assert_called_once_with(msg.chat.id, "Unknown model")
-    mock_set_model.assert_not_called()
-
-
-def test_handle_set_prompt_strategy(message_factory, mocker):
-    """Test /set_prompt_strategy shows keyboard."""
-    msg = message_factory(content_type="text")
-    mock_send = mocker.patch("main.bot.send_message")
-    mock_register = mocker.patch("main.bot.register_next_step_handler")
-
-    handle_set_prompt_strategy(msg)
-
-    assert "Select summarization strategy" in mock_send.call_args[0][1]
-    assert mock_register.called
 
 
 def test_proceed_set_prompt_strategy_success(message_factory, mocker):
@@ -244,54 +173,6 @@ def test_proceed_set_prompt_strategy_success(message_factory, mocker):
     assert "The prompt strategy is set to Detailed Summary" in mock_send.call_args[0][1]
 
 
-def test_proceed_set_prompt_strategy_persistence_failure(message_factory, mocker):
-    """Test that a DB failure from set_prompt_strategy sends an error, not success."""
-    msg = message_factory(content_type="text", text="Detailed Summary")
-    mocker.patch("main.set_prompt_strategy", return_value=False)
-    mock_send = mocker.patch("main.bot.send_message")
-
-    proceed_set_prompt_strategy(msg)
-
-    mock_send.assert_called_once_with(msg.chat.id, "Failed to update prompt strategy.")
-
-
-def test_proceed_set_prompt_strategy_missing_input(message_factory, mocker):
-    """Test prompt selection fails fast when user or text is missing."""
-    msg = message_factory(content_type="text", text="basic")
-    msg.text = None
-    mock_reply = mocker.patch("main.bot.reply_to")
-    mock_set_strategy = mocker.patch("main.set_prompt_strategy")
-
-    proceed_set_prompt_strategy(msg)
-
-    mock_reply.assert_called_once_with(msg, "User information or strategy is missing.")
-    mock_set_strategy.assert_not_called()
-
-
-def test_proceed_set_prompt_strategy_invalid_choice(message_factory, mocker):
-    """Test invalid prompt strategy returns a clear user-facing message."""
-    msg = message_factory(content_type="text", text="enterprise")
-    mock_set_strategy = mocker.patch("main.set_prompt_strategy")
-    mock_send = mocker.patch("main.bot.send_message")
-
-    proceed_set_prompt_strategy(msg)
-
-    mock_send.assert_called_once_with(msg.chat.id, "Unknown strategy")
-    mock_set_strategy.assert_not_called()
-
-
-def test_handle_set_thinking_level(message_factory, mocker):
-    """Test /set_thinking_level shows keyboard."""
-    msg = message_factory(content_type="text")
-    mock_send = mocker.patch("main.bot.send_message")
-    mock_register = mocker.patch("main.bot.register_next_step_handler")
-
-    handle_set_thinking_level(msg)
-
-    assert "Select thinking level" in mock_send.call_args[0][1]
-    assert mock_register.called
-
-
 def test_proceed_set_thinking_level_success(message_factory, mocker):
     """Test successful thinking level selection."""
     msg = message_factory(content_type="text", text="High")
@@ -304,40 +185,79 @@ def test_proceed_set_thinking_level_success(message_factory, mocker):
     assert "The thinking level is set to High" in mock_send.call_args[0][1]
 
 
-def test_proceed_set_thinking_level_missing_input(message_factory, mocker):
-    """Test thinking level selection fails fast when user or text is missing."""
-    msg = message_factory(content_type="text", text="High")
-    msg.text = None
+@pytest.mark.parametrize(
+    ("proceed", "setter_path", "null_attr", "error_msg"),
+    [
+        (proceed_set_target_language, "main.set_target_language", "text", "User information or language is missing."),
+        (proceed_set_summarizing_model, "main.set_summarizing_model", "from_user", "User information or model is missing."),
+        (proceed_set_prompt_strategy, "main.set_prompt_strategy", "text", "User information or strategy is missing."),
+        (proceed_set_thinking_level, "main.set_thinking_level", "text", "User information or level is missing."),
+    ],
+)
+def test_proceed_set_setting_missing_input(
+    message_factory, mocker, proceed, setter_path, null_attr, error_msg
+):
+    """Test each setting selection fails fast when user or text is missing."""
+    msg = message_factory(content_type="text", text="Anything")
+    setattr(msg, null_attr, None)
     mock_reply = mocker.patch("main.bot.reply_to")
-    mock_set = mocker.patch("main.set_thinking_level")
+    mock_setter = mocker.patch(setter_path)
 
-    proceed_set_thinking_level(msg)
+    proceed(msg)
 
-    mock_reply.assert_called_once_with(msg, "User information or level is missing.")
-    mock_set.assert_not_called()
+    mock_reply.assert_called_once_with(msg, error_msg)
+    mock_setter.assert_not_called()
 
 
-def test_proceed_set_thinking_level_invalid_choice(message_factory, mocker):
-    """Test invalid label short-circuits before calling set_thinking_level."""
-    msg = message_factory(content_type="text", text="Ludicrous")
-    mock_set = mocker.patch("main.set_thinking_level")
+@pytest.mark.parametrize(
+    ("proceed", "setter_path", "bad_text", "error_msg"),
+    [
+        (proceed_set_summarizing_model, "main.set_summarizing_model", "Gemini 4 Pro", "Unknown model"),
+        (proceed_set_prompt_strategy, "main.set_prompt_strategy", "enterprise", "Unknown strategy"),
+        (proceed_set_thinking_level, "main.set_thinking_level", "Ludicrous", "Unknown level"),
+    ],
+)
+def test_proceed_set_setting_invalid_choice(
+    message_factory, mocker, proceed, setter_path, bad_text, error_msg
+):
+    """Test an invalid label short-circuits before calling the setter."""
+    msg = message_factory(content_type="text", text=bad_text)
+    mock_setter = mocker.patch(setter_path)
     mock_send = mocker.patch("main.bot.send_message")
 
-    proceed_set_thinking_level(msg)
+    proceed(msg)
 
-    mock_send.assert_called_once_with(msg.chat.id, "Unknown level")
-    mock_set.assert_not_called()
+    mock_send.assert_called_once_with(msg.chat.id, error_msg)
+    mock_setter.assert_not_called()
 
 
-def test_proceed_set_thinking_level_db_failure(message_factory, mocker):
-    """Test DB failure returns a clear user-facing message."""
-    msg = message_factory(content_type="text", text="High")
-    mocker.patch("main.set_thinking_level", return_value=False)
+def test_proceed_set_target_language_invalid_choice(message_factory, mocker):
+    """Test an unknown language is rejected via the setter returning False."""
+    msg = message_factory(content_type="text", text="Klingon")
+    mocker.patch("main.set_target_language", return_value=False)
     mock_send = mocker.patch("main.bot.send_message")
 
-    proceed_set_thinking_level(msg)
+    proceed_set_target_language(msg)
 
-    mock_send.assert_called_once_with(
-        msg.chat.id,
-        "Failed to update thinking level.",
-    )
+    mock_send.assert_called_once_with(msg.chat.id, "Unknown language")
+
+
+@pytest.mark.parametrize(
+    ("proceed", "setter_path", "valid_text", "error_msg"),
+    [
+        (proceed_set_summarizing_model, "main.set_summarizing_model", "Gemini 3.5 Flash", "Failed to update summarizing model."),
+        (proceed_set_prompt_strategy, "main.set_prompt_strategy", "Detailed Summary", "Failed to update prompt strategy."),
+        (proceed_set_thinking_level, "main.set_thinking_level", "High", "Failed to update thinking level."),
+    ],
+)
+def test_proceed_set_setting_db_failure(
+    message_factory, mocker, proceed, setter_path, valid_text, error_msg
+):
+    """Test a DB failure returns a clear user-facing message, not success."""
+    msg = message_factory(content_type="text", text=valid_text)
+    mocker.patch(setter_path, return_value=False)
+    mock_send = mocker.patch("main.bot.send_message")
+
+    proceed(msg)
+
+    mock_send.assert_called_once_with(msg.chat.id, error_msg)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -116,16 +116,16 @@ def test_handle_myinfo_missing_user(message_factory, mocker):
 
 
 @pytest.mark.parametrize(
-    ("handler", "expected_text"),
+    ("handler", "expected_text", "expected_next_step"),
     [
-        (handle_set_target_language, "Select target language"),
-        (handle_set_summarizing_model, "Select summarizing model"),
-        (handle_set_prompt_strategy, "Select summarization strategy"),
-        (handle_set_thinking_level, "Select thinking level"),
+        (handle_set_target_language, "Select target language", proceed_set_target_language),
+        (handle_set_summarizing_model, "Select summarizing model", proceed_set_summarizing_model),
+        (handle_set_prompt_strategy, "Select summarization strategy", proceed_set_prompt_strategy),
+        (handle_set_thinking_level, "Select thinking level", proceed_set_thinking_level),
     ],
 )
 def test_handle_set_setting_shows_keyboard(
-    message_factory, mocker, handler, expected_text
+    message_factory, mocker, handler, expected_text, expected_next_step
 ):
     """Test each /set_* command shows its selection keyboard."""
     msg = message_factory(content_type="text")
@@ -135,7 +135,7 @@ def test_handle_set_setting_shows_keyboard(
     handler(msg)
 
     assert expected_text in mock_send.call_args[0][1]
-    assert mock_register.called
+    mock_register.assert_called_once_with(msg, expected_next_step)
 
 
 def test_proceed_set_target_language_success(message_factory, mocker):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -77,111 +77,51 @@ def test_check_auth_unknown_user(mock_db_session):
     mock_db_session.get.assert_called_once_with(UsersOrm, 999)
 
 
-def test_set_target_language_persists(monkeypatch, sqlite_session_factory):
-    """Test setting target language persists to a real SQLite database."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-    register_user(123, "First", "Last", "user")
-
-    result = set_target_language(123, "English")
-
-    assert result is True
-    with sqlite_session_factory() as session:
-        user = session.get(UsersOrm, 123)
-        assert user is not None
-        assert user.target_language == "English"
-
-
-def test_set_target_language_rejects_unsupported(monkeypatch, sqlite_session_factory):
-    """Test set_target_language returns False for unsupported languages."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-    register_user(123, "First", "Last", "user")
-
-    assert set_target_language(123, "Klingon") is False
-
-
-def test_set_target_language_returns_false_for_missing_user(
-    monkeypatch, sqlite_session_factory
+@pytest.mark.parametrize(
+    ("setter", "value", "orm_attr", "stored_value"),
+    [
+        (set_target_language, "English", "target_language", "English"),
+        (set_summarizing_model, "gemini-3.5-flash", "summarizing_model", "gemini-3.5-flash"),
+        (set_prompt_strategy, "basic_prompt_for_transcript", "prompt_key_for_summary", "basic_prompt_for_transcript"),
+        (set_thinking_level, "high", "thinking_level", "HIGH"),
+    ],
+)
+def test_set_setting_persists(
+    monkeypatch, sqlite_session_factory, setter, value, orm_attr, stored_value
 ):
-    """Test set_target_language returns False when the user does not exist."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-
-    assert set_target_language(123, "English") is False
-
-
-def test_set_summarizing_model_persists(monkeypatch, sqlite_session_factory):
-    """Test setting summarizing model persists to a real SQLite database."""
+    """Test each setting setter persists to a real SQLite database."""
     monkeypatch.setattr("database.Session", sqlite_session_factory)
     register_user(123, "First", "Last", "user")
 
-    result = set_summarizing_model(123, "gemini-3.5-flash")
+    result = setter(123, value)
 
     assert result is True
     with sqlite_session_factory() as session:
         user = session.get(UsersOrm, 123)
         assert user is not None
-        assert user.summarizing_model == "gemini-3.5-flash"
+        assert getattr(user, orm_attr) == stored_value
 
 
-def test_set_summarizing_model_rejects_unknown(monkeypatch, sqlite_session_factory):
-    """Test set_summarizing_model returns False for unsupported models."""
+@pytest.mark.parametrize(
+    ("setter", "bad_value"),
+    [
+        (set_target_language, "Klingon"),
+        (set_summarizing_model, "gpt-4"),
+        (set_prompt_strategy, "bogus"),
+    ],
+)
+def test_set_setting_rejects_unsupported(
+    monkeypatch, sqlite_session_factory, setter, bad_value
+):
+    """Test each setting setter returns False for unsupported values."""
     monkeypatch.setattr("database.Session", sqlite_session_factory)
     register_user(123, "First", "Last", "user")
 
-    assert set_summarizing_model(123, "gpt-4") is False
-
-
-def test_set_summarizing_model_missing_user(monkeypatch, sqlite_session_factory):
-    """Test set_summarizing_model returns False when the user does not exist."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-
-    assert set_summarizing_model(999, "gemini-3.5-flash") is False
-
-
-def test_set_prompt_strategy_persists(monkeypatch, sqlite_session_factory):
-    """Test setting prompt strategy persists to a real SQLite database."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-    register_user(123, "First", "Last", "user")
-
-    result = set_prompt_strategy(123, "basic_prompt_for_transcript")
-
-    assert result is True
-    with sqlite_session_factory() as session:
-        user = session.get(UsersOrm, 123)
-        assert user is not None
-        assert user.prompt_key_for_summary == "basic_prompt_for_transcript"
-
-
-def test_set_prompt_strategy_rejects_unknown(monkeypatch, sqlite_session_factory):
-    """Test set_prompt_strategy returns False for unsupported prompt keys."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-    register_user(123, "First", "Last", "user")
-
-    assert set_prompt_strategy(123, "bogus") is False
-
-
-def test_set_prompt_strategy_missing_user(monkeypatch, sqlite_session_factory):
-    """Test set_prompt_strategy returns False when the user does not exist."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-
-    assert set_prompt_strategy(999, "key_points_for_transcript") is False
-
-
-def test_set_thinking_level_persists(monkeypatch, sqlite_session_factory):
-    """Test setting thinking level persists to a real SQLite database."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-    register_user(123, "First", "Last", "user")
-
-    result = set_thinking_level(123, "high")
-
-    assert result is True
-    with sqlite_session_factory() as session:
-        user = session.get(UsersOrm, 123)
-        assert user is not None
-        assert user.thinking_level == "HIGH"
+    assert setter(123, bad_value) is False
 
 
 def test_set_thinking_level_rejects_unknown_value(monkeypatch, sqlite_session_factory):
-    """Test set_thinking_level returns False for unsupported values."""
+    """Test set_thinking_level returns False and leaves the default unchanged."""
     monkeypatch.setattr("database.Session", sqlite_session_factory)
     register_user(123, "First", "Last", "user")
 
@@ -192,8 +132,17 @@ def test_set_thinking_level_rejects_unknown_value(monkeypatch, sqlite_session_fa
         assert user.thinking_level == "MINIMAL"
 
 
-def test_set_thinking_level_missing_user(monkeypatch, sqlite_session_factory):
-    """Test set_thinking_level returns False when the user does not exist."""
+@pytest.mark.parametrize(
+    ("setter", "value"),
+    [
+        (set_target_language, "English"),
+        (set_summarizing_model, "gemini-3.5-flash"),
+        (set_prompt_strategy, "key_points_for_transcript"),
+        (set_thinking_level, "HIGH"),
+    ],
+)
+def test_set_setting_missing_user(monkeypatch, sqlite_session_factory, setter, value):
+    """Test each setting setter returns False when the user does not exist."""
     monkeypatch.setattr("database.Session", sqlite_session_factory)
 
-    assert set_thinking_level(999, "HIGH") is False
+    assert setter(999, value) is False

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -373,43 +373,20 @@ def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
     mock_transcribe.assert_not_called()
 
 
-def test_summarize_youtube_transcript_failure_falls_back_to_download(mocker):
+@pytest.mark.parametrize(
+    "transcript_error",
+    [
+        FetchTranscriptError("transcript failed"),
+        ValueError("no transcript"),
+    ],
+)
+def test_summarize_youtube_transcript_failure_falls_back_to_download(
+    mocker, transcript_error
+):
     """Test summarize() falls back to downloading YouTube audio when transcript fetch fails."""
     url = "https://youtube.com/watch?v=123"
     mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch(
-        "summary.get_yt_transcript",
-        side_effect=FetchTranscriptError("transcript failed"),
-    )
-    mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
-    mocker.patch.object(summary_module.summarizer, "summarize_with_file", return_value="File summary")
-    mock_clean_up = mocker.patch("summary.clean_up")
-    mock_logger = mocker.patch("summary.logger")
-
-    result = summarize(
-        data=url,
-        model="test-model",
-        prompt_key="basic_prompt_for_transcript",
-        target_language="English",
-        user_id=123,
-        daily_limit=10,
-        thinking_level="MINIMAL",
-    )
-
-    assert result == "File summary"
-    mock_download.assert_called_once_with(url)
-    mock_clean_up.assert_called_once_with(file="downloaded.ogg")
-    mock_logger.warning.assert_called_once_with(
-        "get_yt_transcript failed, falling back to download: %s",
-        mocker.ANY,
-    )
-
-
-def test_summarize_youtube_transcript_value_error_falls_back_to_download(mocker):
-    """Test summarize() falls back to downloading YouTube audio when get_yt_transcript raises ValueError."""
-    url = "https://youtube.com/watch?v=123"
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.get_yt_transcript", side_effect=ValueError("no transcript"))
+    mocker.patch("summary.get_yt_transcript", side_effect=transcript_error)
     mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
     mocker.patch.object(summary_module.summarizer, "summarize_with_file", return_value="File summary")
     mock_clean_up = mocker.patch("summary.clean_up")


### PR DESCRIPTION
## **User description**
## Summary

- **Remove dead code:** the `mock_bot` fixture in `conftest.py` was defined but never requested by any test — every test that needs a mocked bot patches `handlers.bot`/`services.bot` directly. Removed the fixture and the now-unused `TeleBot` import.
- **De-duplicate `test_database.py`:** four near-identical `set_*_persists`, `set_*_rejects`, and `set_*_missing_user` test clusters collapsed into `@pytest.mark.parametrize` groups. The `set_thinking_level` reject test stays standalone because it carries an extra assertion confirming the default value is preserved.
- **De-duplicate `test_commands.py`:** four parallel `proceed_set_*` groups (keyboard display, missing-input guard, invalid-choice, DB-failure) consolidated via parametrize. `success` tests and the `target_language` invalid-choice test remain standalone because their assertions genuinely differ (language validation happens via DB `False`; others validate the label client-side before hitting the DB).
- **De-duplicate `test_summary.py`:** two byte-for-byte identical YouTube transcript fallback tests (differing only in exception type) merged into one parametrized test.

## What did NOT change

Several items were flagged by automated scanning and explicitly **not** changed after verification:
- `src/parsing.py:188` `except OSError, UnicodeError:` — valid PEP 758 syntax on Python 3.14, not a bug.
- `src/transcription.py:497-498` module-level aliases — used by 40+ refs in `test_transcription.py`, not dead.
- `fetch()` adapters + `summarize_*` thin wrappers — intentional OOP polymorphism seams.

## Test plan

- [x] `uv run pytest --cov` → 231 passed, 100% line coverage (no newly-uncovered lines)
- [x] `uvx ruff check .` → no errors
- [x] `uvx ruff format .` → no changes
- [x] `uvx ty check .` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove unused test setup and merge repeated test cases**

### What Changed
- Removed an unused bot mock fixture from the shared test setup
- Combined repeated database tests for saved settings, rejected values, and missing users into shared parameterized cases
- Combined repeated command tests for showing selection keyboards, missing input, invalid choices, and database failures
- Merged the two YouTube transcript fallback tests into one case that covers both failure paths

### Impact
`✅ Shorter test suite`
`✅ Easier test maintenance`
`✅ Same coverage with fewer repeated checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated command handler coverage using parametrized tests to reduce repetition while maintaining the same expected user-facing prompts and error handling.
  * Refactored database persistence/validation tests for setting updates (including missing-user and unsupported-value scenarios) with parametrization.
  * Merged transcript-fetch failure fallback checks into a single parametrized test covering multiple exception types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->