### PR TITLE
docs: update architecture for reversed transcript engines

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -29,7 +29,7 @@ polling-based (`bot.infinity_polling`); no webhooks, no async framework.
 | `main.py` | Telegram entry point. Command handlers + the unified `handle_message`; routes by `content_type`; top-level error → user-message mapping. |
 | `handlers.py` | Per-content-type handlers. Media validation, builds `SummaryKwargs` from the user record, picks the summarize path. |
 | `summary.py` | `Summarizer` — the core summarization orchestrator. Owns the input-type branching and the Gemini calls. |
-| `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (yt-dlp primary, `youtube_transcript_api` fallback). |
+| `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (orchestrator over `ApiBackend` primary → `YtDlpBackend` fallback, mirroring `parsing.py`'s `ParserBackend`). |
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
 | `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
 | `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (config, MIME, file upload/poll). |
@@ -81,8 +81,8 @@ to Gemini — return the raw model text with **no** prefix.
 
 | Prefix | Source |
 |--------|--------|
-| 📹 | YouTube transcript via yt-dlp |
-| 📺 | YouTube transcript via `youtube_transcript_api` (fallback) |
+| 📺 | YouTube transcript via `youtube_transcript_api` (primary) |
+| 📹 | YouTube transcript via yt-dlp (fallback) |
 | 📝 | Audio transcription via Replicate (Gemini-file rescue path) |
 | 🌐 | Webpage via Exa |
 | 🕸️ | Webpage via Tavily (fallback) |


### PR DESCRIPTION
## **User description**
## Summary

Updates `docs/context/architecture.md` to reflect the transcript engine reordering from PR #890.

- **YouTubeTranscriber** now orchestrates `ApiBackend` (primary) → `YtDlpBackend` (fallback)
- Component map now describes the backend abstraction pattern, mirroring `parsing.py`
- Source-provenance prefix table corrected: 📺 is now primary, 📹 is now fallback
- Prefix rows reordered for logical flow (primary precedes fallback)

## Why

PR #890 introduced a backend abstraction in `src/transcription.py` and reversed engine precedence:
- `youtube_transcript_api` is now the primary engine
- yt-dlp is the fallback

The architecture doc explicitly states it should be updated for "routing/fallback rewrites" — this falls under that scope. Changes are factual corrections to match the current source code.

## Verification

- ✓ All referenced class names verified in source: `ApiBackend`, `YtDlpBackend`, `TranscriptBackend`, `ParserBackend`
- ✓ Prefix assignments verified: `ApiBackend.prefix = "📺"` (primary), `YtDlpBackend.prefix = "📹"` (fallback)
- ✓ Backend wiring verified: `yt_transcriber = YouTubeTranscriber(api_backend, ytdlp_backend)` at src/transcription.py:489

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Update architecture docs to match the current transcript engine order**

### What Changed
- The architecture guide now describes YouTube transcription as an orchestrator with a primary API source and a yt-dlp fallback
- The source-provenance table now shows the API transcript source first, with yt-dlp listed as the fallback
- The updated wording now matches the current behavior described elsewhere in the docs

### Impact
`✅ Clearer transcription docs`
`✅ Less confusion about which YouTube source is used first`
`✅ Easier maintenance of architecture documentation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to accurately reflect transcription behavior and backend implementation details
  * Corrected source-provenance emoji mappings for transcript sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->