### PR TITLE
fix(exa): enable livecrawl to fetch fresh pages instead of stale cache

### DIFF
--- a/src/parsing.py
+++ b/src/parsing.py
@@ -71,6 +71,7 @@ class ExaBackend(ParserBackend):
         response = self._client.get_contents(
             urls=[url],
             text={"max_characters": 20000, "include_html_tags": True},
+            livecrawl="preferred",
         )
         results = response.results or []
         if not results:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -45,6 +45,7 @@ def test_parse_url_returns_exa_content(mocker):
     mock_exa.get_contents.assert_called_once_with(
         urls=["https://example.com"],
         text={"max_characters": 20000, "include_html_tags": True},
+        livecrawl="preferred",
     )
     mock_tavily.extract.assert_not_called()
 
@@ -234,6 +235,7 @@ def test_parse_resolves_url_before_extracting(mocker):
     mock_exa.get_contents.assert_called_once_with(
         urls=["https://example.com/final"],
         text={"max_characters": 20000, "include_html_tags": True},
+        livecrawl="preferred",
     )
 
 


### PR DESCRIPTION
## Summary
Exa was serving cached/indexed copies of bot-protected pages (e.g. showing CAPTCHA) instead of live-crawled content. Adding `livecrawl="preferred"` forces Exa to live-crawl first, matching the Exa playground behavior and preventing CAPTCHA summaries.

## What Changed
- **src/parsing.py**: Added `livecrawl="preferred"` parameter to `ExaBackend.parse()` get_contents call
- **tests/test_parsing.py**: Updated two test assertions to verify the livecrawl parameter is passed

## Why
Without livecrawl, Sometimes Exa returns its cached copy — a CAPTCHA wall captured during an earlier blocked crawl. The Exa playground live-crawls the page, so it fetches fresh content and bypasses the stale cache. This is exactly why the playground works but the bot does not.

With `"preferred"`, Exa will:
1. Live-crawl the page first
2. Fall back to cache only if the live crawl fails

This matches the playground and solves the issue.

## Testing
- All 231 tests pass, 100% coverage on parsing.py
- Code review (high effort, 8 angles) shows no bugs
- Pre-commit sequence verified: ruff format, ruff check, ty check, pytest all pass

## Note
This change will cause all web page fetches to live-crawl first (slightly slower, higher Exa costs), not just bot-protected ones. This is the deliberate tradeoff to match the playground behavior.