### PR TITLE
fix(exa): use max_age_hours=0 instead of deprecated livecrawl

### DIFF
--- a/src/parsing.py
+++ b/src/parsing.py
@@ -71,7 +71,7 @@ class ExaBackend(ParserBackend):
         response = self._client.get_contents(
             urls=[url],
             text={"max_characters": 20000, "include_html_tags": True},
-            livecrawl="preferred",
+            max_age_hours=0,
         )
         results = response.results or []
         if not results:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -45,7 +45,7 @@ def test_parse_url_returns_exa_content(mocker):
     mock_exa.get_contents.assert_called_once_with(
         urls=["https://example.com"],
         text={"max_characters": 20000, "include_html_tags": True},
-        livecrawl="preferred",
+        max_age_hours=0,
     )
     mock_tavily.extract.assert_not_called()
 
@@ -235,7 +235,7 @@ def test_parse_resolves_url_before_extracting(mocker):
     mock_exa.get_contents.assert_called_once_with(
         urls=["https://example.com/final"],
         text={"max_characters": 20000, "include_html_tags": True},
-        livecrawl="preferred",
+        max_age_hours=0,
     )
 
 


### PR DESCRIPTION
## Summary
Migrate from the deprecated `livecrawl="preferred"` (PR #904) to the recommended `max_age_hours=0` control for forcing fresh content fetches. `livecrawl` proved unreliable.

## Root Cause
Exa docs mark `livecrawl` as deprecated because it "does not guarantee freshly fetched parser output and may be served according to server freshness policy." PR #904 proved this: even with `livecrawl="preferred"`.

## Solution
Use `max_age_hours=0` (the non-deprecated, recommended control):
- `max_age_hours=0` means "always fetch fresh content" (per exa-py docstring)
- Bypasses Exa's cache entirely, preventing stale bot-walls

## What Changed
- **src/parsing.py**: `livecrawl="preferred"` → `max_age_hours=0` in `ExaBackend.parse()`
- **tests/test_parsing.py**: Updated two `get_contents` assertions

## Testing
- All 231 tests pass, 100% coverage
- Pre-commit sequence verified: ruff/ty/pytest all pass

## Note on Cost
`max_age_hours=0` forces a live crawl on every fetch (slower, higher Exa API cost). This is the deliberate tradeoff — reliability over speed/cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified content fetching parameters.

* **Tests**
  * Updated test expectations to align with implementation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->