### PR TITLE
tests: resolve ruff lint violations across the suite

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,7 +19,7 @@ jobs:
         run: pip install ruff
 
       - name: Run ruff check
-        run: ruff check src/
+        run: ruff check .
 
       - name: Run ruff format check
-        run: ruff format --check src/
+        run: ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,9 @@ repos:
     hooks:
       - id: ruff-check
         args: [--fix]
-        files: ^src/
+        files: ^(src|tests)/
       - id: ruff-format
-        files: ^src/
+        files: ^(src|tests)/
 
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ default-groups = ["dev", "test"]
 exclude-newer = "3 days"
 
 [tool.ruff]
-extend-exclude = ["temp", "migrations", "tests"]
+extend-exclude = ["temp", "migrations"]
 line-length = 88
 indent-width = 4
 target-version = "py314"
@@ -120,6 +120,9 @@ select = [
     "TRY",   # tryceratops
 ]
 ignore = ["S603", "S607", "D100", "D401", "PLR0913", "FBT001", "FBT002", "BLE001"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["ANN", "S101", "S105", "PLR2004", "SLF001", "ARG002", "ARG005", "PYI034", "E501", "RUF043", "EM101", "TRY003"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ select = [
 ignore = ["S603", "S607", "D100", "D401", "PLR0913", "FBT001", "FBT002", "BLE001"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ANN", "S101", "S105", "PLR2004", "SLF001", "ARG002", "ARG005", "PYI034", "E501", "RUF043", "EM101", "TRY003"]
+"tests/**/*.py" = ["ANN", "S101", "S105", "PLR2004", "SLF001", "ARG002", "ARG005", "PYI034", "E501", "EM101", "TRY003"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the AI summarizer Telegram bot."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ def mock_db_session(mocker):
 @pytest.fixture
 def message_factory():
     """Fixture to generate a mock telebot Message with variable content."""
+
     def _create_message(
         content_type="text",
         text="Hello world",
@@ -64,7 +65,8 @@ def message_factory():
         )
         chat = types.Chat(id=user_id, type="private")
 
-        # Message requires json_string and options in the constructor but they can be empty
+        # Message requires json_string and options in the constructor,
+        # but they can be empty
         msg = types.Message(
             message_id=1,
             from_user=user,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -118,14 +118,34 @@ def test_handle_myinfo_missing_user(message_factory, mocker):
 @pytest.mark.parametrize(
     ("handler", "expected_text", "expected_next_step"),
     [
-        (handle_set_target_language, "Select target language", proceed_set_target_language),
-        (handle_set_summarizing_model, "Select summarizing model", proceed_set_summarizing_model),
-        (handle_set_prompt_strategy, "Select summarization strategy", proceed_set_prompt_strategy),
-        (handle_set_thinking_level, "Select thinking level", proceed_set_thinking_level),
+        (
+            handle_set_target_language,
+            "Select target language",
+            proceed_set_target_language,
+        ),
+        (
+            handle_set_summarizing_model,
+            "Select summarizing model",
+            proceed_set_summarizing_model,
+        ),
+        (
+            handle_set_prompt_strategy,
+            "Select summarization strategy",
+            proceed_set_prompt_strategy,
+        ),
+        (
+            handle_set_thinking_level,
+            "Select thinking level",
+            proceed_set_thinking_level,
+        ),
     ],
 )
 def test_handle_set_setting_shows_keyboard(
-    message_factory, mocker, handler, expected_text, expected_next_step
+    message_factory,
+    mocker,
+    handler,
+    expected_text,
+    expected_next_step,
 ):
     """Test each /set_* command shows its selection keyboard."""
     msg = message_factory(content_type="text")
@@ -158,7 +178,9 @@ def test_proceed_set_summarizing_model_success(message_factory, mocker):
     proceed_set_summarizing_model(msg)
 
     mock_set_model.assert_called_once_with(msg.from_user.id, "gemini-3.5-flash")
-    assert "The summarizing model is set to Gemini 3.5 Flash" in mock_send.call_args[0][1]
+    assert (
+        "The summarizing model is set to Gemini 3.5 Flash" in mock_send.call_args[0][1]
+    )
 
 
 def test_proceed_set_prompt_strategy_success(message_factory, mocker):
@@ -169,7 +191,10 @@ def test_proceed_set_prompt_strategy_success(message_factory, mocker):
 
     proceed_set_prompt_strategy(msg)
 
-    mock_set_strategy.assert_called_once_with(msg.from_user.id, "basic_prompt_for_transcript")
+    mock_set_strategy.assert_called_once_with(
+        msg.from_user.id,
+        "basic_prompt_for_transcript",
+    )
     assert "The prompt strategy is set to Detailed Summary" in mock_send.call_args[0][1]
 
 
@@ -188,14 +213,39 @@ def test_proceed_set_thinking_level_success(message_factory, mocker):
 @pytest.mark.parametrize(
     ("proceed", "setter_path", "null_attr", "error_msg"),
     [
-        (proceed_set_target_language, "main.set_target_language", "text", "User information or language is missing."),
-        (proceed_set_summarizing_model, "main.set_summarizing_model", "from_user", "User information or model is missing."),
-        (proceed_set_prompt_strategy, "main.set_prompt_strategy", "text", "User information or strategy is missing."),
-        (proceed_set_thinking_level, "main.set_thinking_level", "text", "User information or level is missing."),
+        (
+            proceed_set_target_language,
+            "main.set_target_language",
+            "text",
+            "User information or language is missing.",
+        ),
+        (
+            proceed_set_summarizing_model,
+            "main.set_summarizing_model",
+            "from_user",
+            "User information or model is missing.",
+        ),
+        (
+            proceed_set_prompt_strategy,
+            "main.set_prompt_strategy",
+            "text",
+            "User information or strategy is missing.",
+        ),
+        (
+            proceed_set_thinking_level,
+            "main.set_thinking_level",
+            "text",
+            "User information or level is missing.",
+        ),
     ],
 )
 def test_proceed_set_setting_missing_input(
-    message_factory, mocker, proceed, setter_path, null_attr, error_msg
+    message_factory,
+    mocker,
+    proceed,
+    setter_path,
+    null_attr,
+    error_msg,
 ):
     """Test each setting selection fails fast when user or text is missing."""
     msg = message_factory(content_type="text", text="Anything")
@@ -212,13 +262,33 @@ def test_proceed_set_setting_missing_input(
 @pytest.mark.parametrize(
     ("proceed", "setter_path", "bad_text", "error_msg"),
     [
-        (proceed_set_summarizing_model, "main.set_summarizing_model", "Gemini 4 Pro", "Unknown model"),
-        (proceed_set_prompt_strategy, "main.set_prompt_strategy", "enterprise", "Unknown strategy"),
-        (proceed_set_thinking_level, "main.set_thinking_level", "Ludicrous", "Unknown level"),
+        (
+            proceed_set_summarizing_model,
+            "main.set_summarizing_model",
+            "Gemini 4 Pro",
+            "Unknown model",
+        ),
+        (
+            proceed_set_prompt_strategy,
+            "main.set_prompt_strategy",
+            "enterprise",
+            "Unknown strategy",
+        ),
+        (
+            proceed_set_thinking_level,
+            "main.set_thinking_level",
+            "Ludicrous",
+            "Unknown level",
+        ),
     ],
 )
 def test_proceed_set_setting_invalid_choice(
-    message_factory, mocker, proceed, setter_path, bad_text, error_msg
+    message_factory,
+    mocker,
+    proceed,
+    setter_path,
+    bad_text,
+    error_msg,
 ):
     """Test an invalid label short-circuits before calling the setter."""
     msg = message_factory(content_type="text", text=bad_text)
@@ -245,13 +315,33 @@ def test_proceed_set_target_language_invalid_choice(message_factory, mocker):
 @pytest.mark.parametrize(
     ("proceed", "setter_path", "valid_text", "error_msg"),
     [
-        (proceed_set_summarizing_model, "main.set_summarizing_model", "Gemini 3.5 Flash", "Failed to update summarizing model."),
-        (proceed_set_prompt_strategy, "main.set_prompt_strategy", "Detailed Summary", "Failed to update prompt strategy."),
-        (proceed_set_thinking_level, "main.set_thinking_level", "High", "Failed to update thinking level."),
+        (
+            proceed_set_summarizing_model,
+            "main.set_summarizing_model",
+            "Gemini 3.5 Flash",
+            "Failed to update summarizing model.",
+        ),
+        (
+            proceed_set_prompt_strategy,
+            "main.set_prompt_strategy",
+            "Detailed Summary",
+            "Failed to update prompt strategy.",
+        ),
+        (
+            proceed_set_thinking_level,
+            "main.set_thinking_level",
+            "High",
+            "Failed to update thinking level.",
+        ),
     ],
 )
 def test_proceed_set_setting_db_failure(
-    message_factory, mocker, proceed, setter_path, valid_text, error_msg
+    message_factory,
+    mocker,
+    proceed,
+    setter_path,
+    valid_text,
+    error_msg,
 ):
     """Test a DB failure returns a clear user-facing message, not success."""
     msg = message_factory(content_type="text", text=valid_text)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,17 +5,20 @@ import utils
 
 
 def test_get_proxy_returns_empty_when_no_proxies(mocker):
+    """Test get_proxy returns an empty string when no proxies are configured."""
     mocker.patch.object(utils, "PROXIES", [])
     assert utils.get_proxy() == ""
 
 
 def test_get_proxy_returns_single_value(mocker):
+    """Test get_proxy always returns the sole configured proxy."""
     mocker.patch.object(utils, "PROXIES", ["http://only:1"])
     for _ in range(5):
         assert utils.get_proxy() == "http://only:1"
 
 
 def test_get_proxy_picks_from_list(mocker):
+    """Test get_proxy selects a proxy from the configured pool at random."""
     pool = ["http://a:1", "http://b:2", "http://c:3"]
     mocker.patch.object(utils, "PROXIES", pool)
     mocker.patch("utils.random.choice", side_effect=pool)
@@ -25,12 +28,14 @@ def test_get_proxy_picks_from_list(mocker):
 
 
 def test_proxy_env_parsing_trims_and_drops_empty(monkeypatch):
+    """Test PROXY env parsing trims whitespace and drops empty entries."""
     monkeypatch.setenv("PROXY", " http://a:1 , http://b:2 ,, ")
     importlib.reload(config)
     assert config.PROXIES == ["http://a:1", "http://b:2"]
 
 
 def test_proxy_env_parsing_empty_string(monkeypatch):
+    """Test PROXY env parsing yields an empty list when the variable is unset."""
     monkeypatch.delenv("PROXY", raising=False)
     importlib.reload(config)
     assert config.PROXIES == []

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -81,13 +81,28 @@ def test_check_auth_unknown_user(mock_db_session):
     ("setter", "value", "orm_attr", "stored_value"),
     [
         (set_target_language, "English", "target_language", "English"),
-        (set_summarizing_model, "gemini-3.5-flash", "summarizing_model", "gemini-3.5-flash"),
-        (set_prompt_strategy, "basic_prompt_for_transcript", "prompt_key_for_summary", "basic_prompt_for_transcript"),
+        (
+            set_summarizing_model,
+            "gemini-3.5-flash",
+            "summarizing_model",
+            "gemini-3.5-flash",
+        ),
+        (
+            set_prompt_strategy,
+            "basic_prompt_for_transcript",
+            "prompt_key_for_summary",
+            "basic_prompt_for_transcript",
+        ),
         (set_thinking_level, "high", "thinking_level", "HIGH"),
     ],
 )
 def test_set_setting_persists(
-    monkeypatch, sqlite_session_factory, setter, value, orm_attr, stored_value
+    monkeypatch,
+    sqlite_session_factory,
+    setter,
+    value,
+    orm_attr,
+    stored_value,
 ):
     """Test each setting setter persists to a real SQLite database."""
     monkeypatch.setattr("database.Session", sqlite_session_factory)
@@ -111,7 +126,10 @@ def test_set_setting_persists(
     ],
 )
 def test_set_setting_rejects_unsupported(
-    monkeypatch, sqlite_session_factory, setter, bad_value
+    monkeypatch,
+    sqlite_session_factory,
+    setter,
+    bad_value,
 ):
     """Test each setting setter returns False for unsupported values."""
     monkeypatch.setattr("database.Session", sqlite_session_factory)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -6,7 +6,6 @@ from tenacity import RetryError
 from yt_dlp.utils import DownloadError
 
 from download import Downloader, download_castro, download_tg, download_yt
-from handlers import _classify_url
 
 
 def test_download_tg_happy_path(mocker):
@@ -474,14 +473,3 @@ def test_stream_to_file_unlink_oserror_does_not_hide_write_error(mocker):
     # PermissionError from unlink must not surface; original OSError propagates.
     with pytest.raises(OSError, match="connection reset"):
         download_tg(mock_file, ext=".ext")
-
-
-def test_classify_url_uppercase_youtube_host():
-    """Test _classify_url normalises uppercase YouTube hostnames to 'media'."""
-    assert _classify_url("https://YOUTU.BE/dQw4w9WgXcQ") == "media"
-    assert _classify_url("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "media"
-
-
-def test_classify_url_malformed_no_host():
-    """Test _classify_url returns None for URLs with no parseable hostname."""
-    assert _classify_url("https://") is None

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -75,7 +75,7 @@ def test_download_tg_missing_file_path(mocker):
     mock_file = mocker.MagicMock()
     mock_file.file_path = None
 
-    with pytest.raises(ValueError, match="Telegram file path is missing."):
+    with pytest.raises(ValueError, match=r"Telegram file path is missing\."):
         download_tg(mock_file)
 
 
@@ -342,7 +342,10 @@ def test_download_castro_missing_source_tag(mocker):
     mocker.patch("download.requests.get", return_value=mock_page_resp)
     mocker.patch("download.requote_uri", side_effect=lambda x: x)
 
-    with pytest.raises(ValueError, match="Audio source tag not found in Castro page."):
+    with pytest.raises(
+        ValueError,
+        match=r"Audio source tag not found in Castro page\.",
+    ):
         download_castro("https://castro.fm/episode/123")
 
 
@@ -353,7 +356,7 @@ def test_download_castro_missing_audio_url(mocker):
     mocker.patch("download.requests.get", return_value=mock_page_resp)
     mocker.patch("download.requote_uri", side_effect=lambda x: x)
 
-    with pytest.raises(ValueError, match="Audio URL not found in Castro page."):
+    with pytest.raises(ValueError, match=r"Audio URL not found in Castro page\."):
         download_castro("https://castro.fm/episode/123")
 
 
@@ -370,7 +373,7 @@ def test_download_castro_non_string_audio_url(mocker):
     mock_soup.source = mock_source
     mocker.patch("download.BeautifulSoup", return_value=mock_soup)
 
-    with pytest.raises(TypeError, match="Audio URL is not a string."):
+    with pytest.raises(TypeError, match=r"Audio URL is not a string\."):
         download_castro("https://castro.fm/episode/123")
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,8 +2,11 @@ from pathlib import Path
 
 import pytest
 from curl_cffi.requests.exceptions import HTTPError
+from tenacity import RetryError
+from yt_dlp.utils import DownloadError
 
 from download import Downloader, download_castro, download_tg, download_yt
+from handlers import _classify_url
 
 
 def test_download_tg_happy_path(mocker):
@@ -67,6 +70,7 @@ def test_download_tg_skips_empty_chunks(mocker):
     mock_path_open().write.assert_has_calls([mocker.call(b"data")])
     assert mock_path_open().write.call_count == 1
 
+
 def test_download_tg_missing_file_path(mocker):
     """Test download_tg raises ValueError when file_path is missing."""
     mock_file = mocker.MagicMock()
@@ -74,6 +78,7 @@ def test_download_tg_missing_file_path(mocker):
 
     with pytest.raises(ValueError, match="Telegram file path is missing."):
         download_tg(mock_file)
+
 
 def test_download_yt_happy_path(mocker):
     """Test downloading a YouTube audio successfully."""
@@ -83,8 +88,20 @@ def test_download_yt_happy_path(mocker):
     info_ydl = mocker.MagicMock()
     info_ydl.extract_info.return_value = {
         "formats": [
-            {"format_id": "251", "acodec": "opus", "vcodec": "none", "abr": 111, "tbr": 111},
-            {"format_id": "139", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+            {
+                "format_id": "251",
+                "acodec": "opus",
+                "vcodec": "none",
+                "abr": 111,
+                "tbr": 111,
+            },
+            {
+                "format_id": "139",
+                "acodec": "mp4a.40.5",
+                "vcodec": "none",
+                "abr": 49,
+                "tbr": 49,
+            },
         ],
     }
     download_ydl = mocker.MagicMock()
@@ -96,7 +113,10 @@ def test_download_yt_happy_path(mocker):
     result = download_yt("https://youtube.com/watch?v=123")
 
     assert result == "temp_yt.mp3"
-    info_ydl.extract_info.assert_called_once_with("https://youtube.com/watch?v=123", download=False)
+    info_ydl.extract_info.assert_called_once_with(
+        "https://youtube.com/watch?v=123",
+        download=False,
+    )
     mock_ydl.assert_any_call({"proxy": mocker.ANY, "nocheckcertificate": False})
     mock_ydl.assert_any_call(
         {
@@ -117,8 +137,6 @@ def test_download_yt_happy_path(mocker):
 
 def test_download_yt_extract_info_returns_none(mocker):
     """Test download_yt raises RetryError when extract_info returns None."""
-    from tenacity import RetryError
-
     mock_ydl = mocker.patch("download.YoutubeDL")
     mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
     mocker.patch("time.sleep")  # suppress tenacity wait between retries
@@ -133,9 +151,6 @@ def test_download_yt_extract_info_returns_none(mocker):
 
 def test_download_yt_removes_partials_on_download_error(mocker):
     """Test download_yt deletes yt-dlp partial files when the download fails."""
-    from tenacity import RetryError
-    from yt_dlp.utils import DownloadError
-
     mock_ydl = mocker.patch("download.YoutubeDL")
     mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
     mocker.patch("time.sleep")  # suppress tenacity wait between retries
@@ -143,7 +158,13 @@ def test_download_yt_removes_partials_on_download_error(mocker):
     info_ydl = mocker.MagicMock()
     info_ydl.extract_info.return_value = {
         "formats": [
-            {"format_id": "139", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+            {
+                "format_id": "139",
+                "acodec": "mp4a.40.5",
+                "vcodec": "none",
+                "abr": 49,
+                "tbr": 49,
+            },
         ],
     }
     download_ydl = mocker.MagicMock()
@@ -169,9 +190,6 @@ def test_download_yt_removes_partials_on_download_error(mocker):
 
 def test_download_yt_unlink_oserror_does_not_hide_download_error(mocker):
     """Test that an OSError from unlink is suppressed and DownloadError still propagates."""
-    from tenacity import RetryError
-    from yt_dlp.utils import DownloadError
-
     mock_ydl = mocker.patch("download.YoutubeDL")
     mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
     mocker.patch("time.sleep")
@@ -179,7 +197,13 @@ def test_download_yt_unlink_oserror_does_not_hide_download_error(mocker):
     info_ydl = mocker.MagicMock()
     info_ydl.extract_info.return_value = {
         "formats": [
-            {"format_id": "139", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+            {
+                "format_id": "139",
+                "acodec": "mp4a.40.5",
+                "vcodec": "none",
+                "abr": 49,
+                "tbr": 49,
+            },
         ],
     }
     download_ydl = mocker.MagicMock()
@@ -209,7 +233,13 @@ def test_download_yt_keeps_file_on_success(mocker):
     info_ydl = mocker.MagicMock()
     info_ydl.extract_info.return_value = {
         "formats": [
-            {"format_id": "139", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+            {
+                "format_id": "139",
+                "acodec": "mp4a.40.5",
+                "vcodec": "none",
+                "abr": 49,
+                "tbr": 49,
+            },
         ],
     }
     download_ydl = mocker.MagicMock()
@@ -229,7 +259,13 @@ def test_choose_yt_audio_format_falls_back_when_no_audio_only_formats():
     """Test selector fallback when yt-dlp has no audio-only format ids."""
     info = {
         "formats": [
-            {"format_id": "18", "acodec": "mp4a.40.2", "vcodec": "avc1.42001E", "abr": 44, "tbr": 365},
+            {
+                "format_id": "18",
+                "acodec": "mp4a.40.2",
+                "vcodec": "avc1.42001E",
+                "abr": 44,
+                "tbr": 365,
+            },
         ],
     }
 
@@ -243,14 +279,27 @@ def test_choose_yt_audio_format_ranks_missing_bitrates_last():
     info = {
         "formats": [
             {"format_id": "unknown", "acodec": "opus", "vcodec": "none"},
-            {"format_id": "zero", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 0, "tbr": 0},
-            {"format_id": "known", "acodec": "mp4a.40.5", "vcodec": "none", "abr": 49, "tbr": 49},
+            {
+                "format_id": "zero",
+                "acodec": "mp4a.40.5",
+                "vcodec": "none",
+                "abr": 0,
+                "tbr": 0,
+            },
+            {
+                "format_id": "known",
+                "acodec": "mp4a.40.5",
+                "vcodec": "none",
+                "abr": 49,
+                "tbr": 49,
+            },
         ],
     }
 
     result = Downloader._choose_yt_audio_format(info)
 
     assert result == "zero"
+
 
 def test_download_castro_happy_path(mocker):
     """Test downloading a Castro podcast successfully."""
@@ -286,6 +335,7 @@ def test_download_castro_happy_path(mocker):
     )
     assert mock_path_open().write.call_count == 2
 
+
 def test_download_castro_missing_source_tag(mocker):
     """Test download_castro raises ValueError when <source> tag is missing."""
     mock_page_resp = mocker.MagicMock()
@@ -295,6 +345,7 @@ def test_download_castro_missing_source_tag(mocker):
 
     with pytest.raises(ValueError, match="Audio source tag not found in Castro page."):
         download_castro("https://castro.fm/episode/123")
+
 
 def test_download_castro_missing_audio_url(mocker):
     """Test download_castro raises ValueError when source tag has no src."""
@@ -425,16 +476,12 @@ def test_stream_to_file_unlink_oserror_does_not_hide_write_error(mocker):
         download_tg(mock_file, ext=".ext")
 
 
-def test_classify_url_uppercase_youtube_host(mocker):
-    """_classify_url normalises uppercase YouTube hostnames to 'media'."""
-    from handlers import _classify_url
-
+def test_classify_url_uppercase_youtube_host():
+    """Test _classify_url normalises uppercase YouTube hostnames to 'media'."""
     assert _classify_url("https://YOUTU.BE/dQw4w9WgXcQ") == "media"
     assert _classify_url("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "media"
 
 
 def test_classify_url_malformed_no_host():
-    """_classify_url returns None for URLs with no parseable hostname."""
-    from handlers import _classify_url
-
+    """Test _classify_url returns None for URLs with no parseable hostname."""
     assert _classify_url("https://") is None

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -2,6 +2,7 @@ from telebot import types
 from tenacity import RetryError
 
 from exceptions import LimitExceededError, WebParseError
+from handlers import _classify_url
 from main import handle_message, process_message_content
 from services import PrefixedText
 
@@ -147,6 +148,17 @@ def test_handle_url_unsupported_pattern(message_factory, mocker):
 
     mock_send_message.assert_called_once_with(msg.chat.id, "No data to proceed.")
     mock_summarize_webpage.assert_not_called()
+
+
+def test_classify_url_uppercase_youtube_host():
+    """Test _classify_url normalises uppercase YouTube hostnames to 'media'."""
+    assert _classify_url("https://YOUTU.BE/dQw4w9WgXcQ") == "media"
+    assert _classify_url("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "media"
+
+
+def test_classify_url_malformed_no_host():
+    """Test _classify_url returns None for URLs with no parseable hostname."""
+    assert _classify_url("https://") is None
 
 
 def test_handle_url_youtube_pattern(message_factory, mocker):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -220,8 +220,6 @@ def test_handle_url_web_preflight_blocks_before_parse_url(message_factory, mocke
 
 def test_handle_url_web_parse_error_skips_summarize(message_factory, mocker):
     """Test that WebParseError from parse_url short-circuits before summarize_webpage."""
-    from exceptions import WebParseError
-
     url = "https://example.com/article"
     msg = message_factory(content_type="text", text=url)
     mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
@@ -343,7 +341,8 @@ def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker
 
 
 def test_handle_video_cleans_up_compressed_file_when_summarize_raises(
-    message_factory, mocker
+    message_factory,
+    mocker,
 ):
     """Test the compressed temp file is removed even if summarize() raises early.
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -5,13 +5,14 @@ from tavily.errors import TimeoutError as TavilyTimeoutError
 from tenacity import RetryError
 
 import parsing
+from domain import PrefixedText
 from exceptions import WebParseError
 from parsing import ExaBackend, TavilyBackend, UrlResolver, WebParser, parse_url
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_parser(mocker):
     """Return (parser, mock_exa_client, mock_tavily_client).
@@ -31,8 +32,9 @@ def _make_parser(mocker):
 # WebParser orchestration tests
 # ---------------------------------------------------------------------------
 
+
 def test_parse_url_returns_exa_content(mocker):
-    """parse returns Exa's text and does not call Tavily on success."""
+    """Test parse returns Exa's text and does not call Tavily on success."""
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(
         results=[mocker.Mock(text="Hello world.")],
@@ -51,7 +53,7 @@ def test_parse_url_returns_exa_content(mocker):
 
 
 def test_parse_url_falls_back_to_tavily_when_exa_has_no_results(mocker, caplog):
-    """parse falls back to Tavily when Exa returns no results."""
+    """Test parse falls back to Tavily when Exa returns no results."""
     mocker.patch("time.sleep")
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
@@ -73,7 +75,7 @@ def test_parse_url_falls_back_to_tavily_when_exa_has_no_results(mocker, caplog):
 
 
 def test_parse_url_falls_back_to_tavily_on_exa_empty_content(mocker):
-    """parse falls back to Tavily when Exa returns empty content."""
+    """Test parse falls back to Tavily when Exa returns empty content."""
     mocker.patch("time.sleep")
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(
@@ -91,7 +93,7 @@ def test_parse_url_falls_back_to_tavily_on_exa_empty_content(mocker):
 
 
 def test_parse_url_falls_back_to_tavily_when_exa_retries_exhausted(mocker):
-    """parse falls back to Tavily after Exa exhausts its retries."""
+    """Test parse falls back to Tavily after Exa exhausts its retries."""
     mocker.patch("time.sleep")
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
@@ -109,7 +111,7 @@ def test_parse_url_falls_back_to_tavily_when_exa_retries_exhausted(mocker):
 
 
 def test_parse_url_retries_exa_empty_then_succeeds(mocker):
-    """parse retries a transient empty Exa result and returns content."""
+    """Test parse retries a transient empty Exa result and returns content."""
     mocker.patch("time.sleep")
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.side_effect = [
@@ -126,7 +128,7 @@ def test_parse_url_retries_exa_empty_then_succeeds(mocker):
 
 
 def test_parse_url_tavily_fallback_retries_timeout_then_succeeds(mocker):
-    """parse's Tavily fallback retries a transient timeout then succeeds."""
+    """Test parse's Tavily fallback retries a transient timeout then succeeds."""
     mocker.patch("time.sleep")
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
@@ -146,7 +148,7 @@ def test_parse_url_tavily_fallback_retries_timeout_then_succeeds(mocker):
 
 
 def test_parse_url_raises_when_both_backends_fail(mocker, caplog):
-    """parse raises WebParseError when both Exa and Tavily fail."""
+    """Test parse raises WebParseError when both Exa and Tavily fail."""
     mocker.patch("time.sleep")
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
@@ -165,7 +167,7 @@ def test_parse_url_raises_when_both_backends_fail(mocker, caplog):
 
 
 def test_parse_url_raises_when_tavily_fallback_returns_empty_content(mocker, caplog):
-    """parse raises WebParseError when the Tavily fallback returns empty content."""
+    """Test parse raises WebParseError when the Tavily fallback returns empty content."""
     mocker.patch("time.sleep")
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
@@ -186,7 +188,7 @@ def test_parse_url_raises_when_tavily_fallback_returns_empty_content(mocker, cap
 
 
 def test_parse_url_falls_back_when_tavily_times_out(mocker, caplog):
-    """parse raises combined failure when the Tavily fallback keeps timing out."""
+    """Test parse raises combined failure when the Tavily fallback keeps timing out."""
     mocker.patch("time.sleep")
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.return_value = mocker.Mock(results=[])
@@ -206,7 +208,7 @@ def test_parse_url_falls_back_when_tavily_times_out(mocker, caplog):
 
 
 def test_parse_url_propagates_non_retryable_exa_error(mocker):
-    """parse lets non-retryable Exa errors propagate without trying Tavily."""
+    """Test parse lets non-retryable Exa errors propagate without trying Tavily."""
     parser, mock_exa, mock_tavily = _make_parser(mocker)
     mock_exa.get_contents.side_effect = RuntimeError("boom")
 
@@ -218,7 +220,7 @@ def test_parse_url_propagates_non_retryable_exa_error(mocker):
 
 
 def test_parse_resolves_url_before_extracting(mocker):
-    """parse resolves the URL via the injected resolver before calling backends."""
+    """Test parse resolves the URL via the injected resolver before calling backends."""
     mock_exa = mocker.MagicMock()
     mock_tavily = mocker.MagicMock()
     resolver = mocker.Mock()
@@ -240,11 +242,13 @@ def test_parse_resolves_url_before_extracting(mocker):
 
 
 def test_parse_url_delegates_to_web_parser(mocker):
-    """parse_url routes to the module-level web_parser singleton."""
-    from domain import PrefixedText
-
+    """Test parse_url routes to the module-level web_parser singleton."""
     mock_result = PrefixedText(text="hello", prefix="🌐")
-    mock_parse = mocker.patch.object(parsing.web_parser, "parse", return_value=mock_result)
+    mock_parse = mocker.patch.object(
+        parsing.web_parser,
+        "parse",
+        return_value=mock_result,
+    )
 
     result = parse_url("https://example.com/start")
 
@@ -255,6 +259,7 @@ def test_parse_url_delegates_to_web_parser(mocker):
 # ---------------------------------------------------------------------------
 # UrlResolver._is_public tests
 # ---------------------------------------------------------------------------
+
 
 def test_is_public_returns_false_for_missing_hostname():
     """_is_public returns False when the URL has no hostname."""
@@ -328,8 +333,9 @@ def test_is_public_returns_false_when_any_addr_is_private(mocker):
 # UrlResolver.resolve tests
 # ---------------------------------------------------------------------------
 
+
 def test_resolve_returns_final_url_after_redirect(mocker):
-    """resolve returns the redirected URL and closes the response."""
+    """Test resolve returns the redirected URL and closes the response."""
     mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/final")
@@ -345,7 +351,7 @@ def test_resolve_returns_final_url_after_redirect(mocker):
 
 
 def test_resolve_returns_original_when_no_redirect(mocker):
-    """resolve returns the input unchanged when there is no redirect."""
+    """Test resolve returns the input unchanged when there is no redirect."""
     mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
@@ -358,7 +364,7 @@ def test_resolve_returns_original_when_no_redirect(mocker):
 
 
 def test_resolve_falls_back_to_original_on_error(mocker, caplog):
-    """resolve returns the original URL when the request raises."""
+    """Test resolve returns the original URL when the request raises."""
     mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mocker.patch("parsing.requests.get", side_effect=RuntimeError("boom"))
@@ -371,7 +377,7 @@ def test_resolve_falls_back_to_original_on_error(mocker, caplog):
 
 
 def test_resolve_passes_proxy_when_configured(mocker):
-    """resolve forwards a configured proxy to requests.get."""
+    """Test resolve forwards a configured proxy to requests.get."""
     mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="https://user:pass@proxy.com:1234")
     mock_resp = mocker.Mock(url="https://example.com/article")
@@ -383,7 +389,7 @@ def test_resolve_passes_proxy_when_configured(mocker):
 
 
 def test_resolve_omits_proxy_when_none_configured(mocker):
-    """resolve passes proxy=None when no proxy is set."""
+    """Test resolve passes proxy=None when no proxy is set."""
     mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
@@ -395,7 +401,7 @@ def test_resolve_omits_proxy_when_none_configured(mocker):
 
 
 def test_resolve_passes_configured_timeout(mocker):
-    """resolve forwards the instance timeout to requests.get."""
+    """Test resolve forwards the instance timeout to requests.get."""
     mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
@@ -407,7 +413,7 @@ def test_resolve_passes_configured_timeout(mocker):
 
 
 def test_resolve_blocks_non_public_initial_url(mocker, caplog):
-    """resolve returns the original URL without fetching for a private host."""
+    """Test resolve returns the original URL without fetching for a private host."""
     mocker.patch.object(
         parsing.UrlResolver,
         "_is_public",
@@ -424,7 +430,7 @@ def test_resolve_blocks_non_public_initial_url(mocker, caplog):
 
 
 def test_resolve_blocks_redirect_to_private_host(mocker, caplog):
-    """resolve returns the original URL when a redirect lands on a private host."""
+    """Test resolve returns the original URL when a redirect lands on a private host."""
     mocker.patch.object(
         parsing.UrlResolver,
         "_is_public",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -54,7 +54,8 @@ def test_send_answer_single_chunk(mocker):
     mock_entity = mocker.MagicMock()
     mock_entity.to_dict.return_value = {"type": "bold"}
     mock_split = mocker.patch(
-        "services.split_entities", return_value=[("text", [mock_entity])]
+        "services.split_entities",
+        return_value=[("text", [mock_entity])],
     )
 
     mock_reply = mocker.patch.object(services_module.messenger, "_reply_with_retry")

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -2,10 +2,11 @@ from types import SimpleNamespace
 
 import pytest
 from google.genai.errors import ClientError
+from telebot.types import File
 from tenacity import RetryError
 
 import summary as summary_module
-from exceptions import FetchTranscriptError
+from exceptions import FetchTranscriptError, LimitExceededError
 from summary import (
     format_prefixed_summary,
     summarize,
@@ -264,7 +265,11 @@ def test_summarize_youtube_always_attempts_transcript(mocker):
         "summary.get_yt_transcript",
         return_value=SimpleNamespace(text="YT Transcript", prefix="📹"),
     )
-    mocker.patch.object(summary_module.summarizer, "summarize_with_transcript", return_value="Summary")
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_transcript",
+        return_value="Summary",
+    )
 
     summarize(
         data=url,
@@ -353,9 +358,16 @@ def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
         return_value=SimpleNamespace(text="YT Transcript content", prefix="📹"),
     )
     mock_download = mocker.patch("summary.download_yt")
-    mock_file_summary = mocker.patch.object(summary_module.summarizer, "summarize_with_file")
+    mock_file_summary = mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_file",
+    )
     mock_transcribe = mocker.patch("summary.transcribe")
-    mocker.patch.object(summary_module.summarizer, "summarize_with_transcript", side_effect=retry_error)
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_transcript",
+        side_effect=retry_error,
+    )
 
     with pytest.raises(RetryError):
         summarize(
@@ -381,14 +393,19 @@ def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
     ],
 )
 def test_summarize_youtube_transcript_failure_falls_back_to_download(
-    mocker, transcript_error
+    mocker,
+    transcript_error,
 ):
     """Test summarize() falls back to downloading YouTube audio when transcript fetch fails."""
     url = "https://youtube.com/watch?v=123"
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("summary.get_yt_transcript", side_effect=transcript_error)
     mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
-    mocker.patch.object(summary_module.summarizer, "summarize_with_file", return_value="File summary")
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_file",
+        return_value="File summary",
+    )
     mock_clean_up = mocker.patch("summary.clean_up")
     mock_logger = mocker.patch("summary.logger")
 
@@ -480,7 +497,11 @@ def test_summarize_castro(mocker):
     url = "https://castro.fm/episode/123"
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("summary.download_castro", return_value="downloaded.mp3")
-    mocker.patch.object(summary_module.summarizer, "summarize_with_file", return_value="Castro summary")
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_file",
+        return_value="Castro summary",
+    )
     mocker.patch("summary.clean_up")
 
     result = summarize(
@@ -498,8 +519,6 @@ def test_summarize_castro(mocker):
 
 def test_summarize_preflight_blocks_before_download(mocker):
     """Test summarize() blocks zero-quota users before any network IO."""
-    from exceptions import LimitExceededError
-
     mock_check = mocker.patch("summary.check_quota", side_effect=LimitExceededError)
     mock_download = mocker.patch("summary.download_castro")
 
@@ -520,9 +539,6 @@ def test_summarize_preflight_blocks_before_download(mocker):
 
 def test_summarize_with_file_deletes_gemini_file_when_quota_check_fails(mocker):
     """Test summarize_with_file cleans up the uploaded Gemini file if consuming check fails."""
-    from exceptions import LimitExceededError
-    from types import SimpleNamespace
-
     mock_audio_file = SimpleNamespace(
         name="files/audio123",
         uri="https://mock.uri",
@@ -531,7 +547,10 @@ def test_summarize_with_file_deletes_gemini_file_when_quota_check_fails(mocker):
     mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
-    mock_check = mocker.patch("summary.check_quota", side_effect=[True, LimitExceededError])
+    mock_check = mocker.patch(
+        "summary.check_quota",
+        side_effect=[True, LimitExceededError],
+    )
 
     with pytest.raises(LimitExceededError):
         summarize_with_file(
@@ -552,8 +571,6 @@ def test_summarize_with_file_deletes_gemini_file_when_quota_check_fails(mocker):
 
 def test_summarize_with_document_preflight_blocks_before_download(mocker):
     """Test summarize_with_document blocks zero-quota users before download or upload."""
-    from exceptions import LimitExceededError
-
     mock_check = mocker.patch("summary.check_quota", side_effect=LimitExceededError)
     mock_download = mocker.patch("summary.download_tg")
 
@@ -583,7 +600,9 @@ def test_summarize_with_file_logs_warning_on_delete_failure(mocker):
     )
     mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text="summary text")
+    mock_client.models.generate_content.return_value = mocker.MagicMock(
+        text="summary text",
+    )
     mock_client.files.delete.side_effect = Exception("delete failed")
     mock_logger = mocker.patch("summary.logger")
 
@@ -659,7 +678,10 @@ def test_summarize_with_document_raises_when_uri_none(mocker):
     mock_client = mocker.patch("summary.gemini_client")
     mocker.patch("services.gemini_client", mock_client)
     mock_file = SimpleNamespace(
-        state="ACTIVE", name="files/doc123", uri=None, mime_type="application/pdf"
+        state="ACTIVE",
+        name="files/doc123",
+        uri=None,
+        mime_type="application/pdf",
     )
     mock_client.files.upload.return_value = mock_file
 
@@ -686,7 +708,10 @@ def test_summarize_with_document_raises_when_mime_type_none(mocker):
     mock_client = mocker.patch("summary.gemini_client")
     mocker.patch("services.gemini_client", mock_client)
     mock_file = SimpleNamespace(
-        state="ACTIVE", name="files/doc123", uri="https://mock.uri", mime_type=None
+        state="ACTIVE",
+        name="files/doc123",
+        uri="https://mock.uri",
+        mime_type=None,
     )
     mock_client.files.upload.return_value = mock_file
 
@@ -749,7 +774,9 @@ def test_summarize_with_document_logs_warning_on_delete_failure(mocker):
         mime_type="application/pdf",
     )
     mock_client.files.upload.return_value = mock_file
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text="document summary")
+    mock_client.models.generate_content.return_value = mocker.MagicMock(
+        text="document summary",
+    )
     mock_client.files.delete.side_effect = Exception("delete failed")
     mock_logger = mocker.patch("summary.logger")
 
@@ -771,11 +798,16 @@ def test_summarize_with_document_logs_warning_on_delete_failure(mocker):
 
 def test_summarize_with_telegram_file(mocker):
     """Test summarize() downloads a Telegram File object before summarizing."""
-    from telebot.types import File
-
     mocker.patch("summary.check_quota", return_value=True)
-    mock_download_tg = mocker.patch("summary.download_tg", return_value="downloaded.ogg")
-    mocker.patch.object(summary_module.summarizer, "summarize_with_file", return_value="Telegram file summary")
+    mock_download_tg = mocker.patch(
+        "summary.download_tg",
+        return_value="downloaded.ogg",
+    )
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_file",
+        return_value="Telegram file summary",
+    )
     mocker.patch("summary.clean_up")
     mock_tg_file = mocker.MagicMock(spec=File)
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,10 +1,10 @@
 import textwrap
 
 import pytest
+from defusedxml.ElementTree import ParseError
 from replicate.exceptions import ModelError
 from requests.exceptions import ChunkedEncodingError, ProxyError, SSLError
 from tenacity import RetryError
-from defusedxml.ElementTree import ParseError
 from youtube_transcript_api._errors import (
     IpBlocked,
     NoTranscriptFound,
@@ -132,7 +132,11 @@ def test_get_yt_transcript_both_backends_fail_raises_error(mocker):
     """Test get_yt_transcript raises FetchTranscriptError chained from the fallback failure."""
     api_error = TranscriptsDisabled("dQw4w9WgXcQ")
     ytdlp_error = DownloadError("no subs")
-    mocker.patch.object(transcription.api_backend, "fetch_via_api", side_effect=api_error)
+    mocker.patch.object(
+        transcription.api_backend,
+        "fetch_via_api",
+        side_effect=api_error,
+    )
     mocker.patch.object(
         transcription.ytdlp_backend,
         "fetch_via_ytdlp",
@@ -149,7 +153,11 @@ def test_get_yt_transcript_both_backends_fail_raises_error(mocker):
 def test_get_yt_transcript_both_empty_raises_error(mocker):
     """Test get_yt_transcript raises FetchTranscriptError when both backends return empty."""
     mocker.patch.object(transcription.api_backend, "fetch_via_api", return_value="")
-    mocker.patch.object(transcription.ytdlp_backend, "fetch_via_ytdlp", return_value="  ")
+    mocker.patch.object(
+        transcription.ytdlp_backend,
+        "fetch_via_ytdlp",
+        return_value="  ",
+    )
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with pytest.raises(FetchTranscriptError, match="Both transcript backends failed"):
@@ -298,7 +306,7 @@ def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     mock_proxy_cfg = mocker.patch("transcription.GenericProxyConfig")
     mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
     mocker.patch(
-        "transcription.TextFormatter"
+        "transcription.TextFormatter",
     ).return_value.format_transcript.return_value = "Hello"
     mock_ytt.return_value.fetch.return_value = []
 
@@ -309,9 +317,7 @@ def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     mock_ytt.assert_called_once_with(proxy_config=mock_proxy_cfg.return_value)
 
 
-def test_fetch_transcript_via_ytdlp_download_error_logged_and_retried(
-    mocker, tmp_path
-):
+def test_fetch_transcript_via_ytdlp_download_error_logged_and_retried(mocker, tmp_path):
     """Test fetch_transcript_via_ytdlp retries DownloadError from yt-dlp twice then raises RetryError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
@@ -337,7 +343,8 @@ def test_fetch_transcript_via_ytdlp_download_error_logged_and_retried(
 
 
 def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_and_retried(
-    mocker, tmp_path
+    mocker,
+    tmp_path,
 ):
     """Test fetch_transcript_via_ytdlp wraps non-DownloadError exceptions and retries."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
@@ -386,7 +393,8 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp
 
 
 def test_fetch_transcript_via_ytdlp_probe_download_error_logged_and_retried(
-    mocker, tmp_path
+    mocker,
+    tmp_path,
 ):
     """Test fetch_transcript_via_ytdlp retries probe DownloadError twice then raises RetryError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
@@ -410,7 +418,8 @@ def test_fetch_transcript_via_ytdlp_probe_download_error_logged_and_retried(
 
 
 def test_fetch_transcript_via_ytdlp_probe_unexpected_error_wrapped_and_retried(
-    mocker, tmp_path
+    mocker,
+    tmp_path,
 ):
     """Test fetch_transcript_via_ytdlp wraps and retries unexpected errors from extract_info."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
@@ -453,7 +462,7 @@ def test_fetch_transcript_via_ytdlp_succeeds_on_second_attempt(mocker, tmp_path)
         def __init__(self, opts: object) -> None:
             self.opts = opts
 
-        def __enter__(self) -> "MockYDL":
+        def __enter__(self) -> MockYDL:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -523,7 +532,7 @@ def test_fetch_transcript_via_ytdlp_non_english_fallback(mocker, tmp_path):
         def __init__(self, opts: object) -> None:
             self.opts = opts
 
-        def __enter__(self) -> "MockYDL":
+        def __enter__(self) -> MockYDL:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -560,7 +569,7 @@ def test_fetch_transcript_via_ytdlp_prefers_english_when_available(mocker, tmp_p
         def __init__(self, opts: object) -> None:
             self.opts = opts
 
-        def __enter__(self) -> "MockYDL":
+        def __enter__(self) -> MockYDL:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -605,7 +614,7 @@ def test_fetch_transcript_via_ytdlp_manual_prefers_original_language_over_first_
         def __init__(self, opts: object) -> None:
             self.opts = opts
 
-        def __enter__(self) -> "MockYDL":
+        def __enter__(self) -> MockYDL:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -655,7 +664,7 @@ def test_fetch_transcript_via_ytdlp_auto_captions_uses_original_language(
         def __init__(self, opts: object) -> None:
             self.opts = opts
 
-        def __enter__(self) -> "MockYDL":
+        def __enter__(self) -> MockYDL:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -703,7 +712,7 @@ def test_fetch_transcript_via_ytdlp_auto_captions_prefers_orig_key_when_language
         def __init__(self, opts: object) -> None:
             self.opts = opts
 
-        def __enter__(self) -> "MockYDL":
+        def __enter__(self) -> MockYDL:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -751,7 +760,7 @@ def test_fetch_transcript_via_ytdlp_auto_captions_falls_back_to_first_key(
         def __init__(self, opts: object) -> None:
             self.opts = opts
 
-        def __enter__(self) -> "MockYDL":
+        def __enter__(self) -> MockYDL:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -797,7 +806,7 @@ def test_fetch_transcript_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_p
         def __init__(self, opts: object) -> None:
             self.opts = opts
 
-        def __enter__(self) -> "MockYDL":
+        def __enter__(self) -> MockYDL:
             return self
 
         def __exit__(self, *args: object) -> None:
@@ -853,14 +862,20 @@ def test_fetch_transcript_via_ytdlp_extract_info_none_raises(mocker, tmp_path):
     ctx.download.assert_not_called()
 
 
-def test_fetch_transcript_via_ytdlp_vtt_read_error_raises_download_error(mocker, tmp_path):
+def test_fetch_transcript_via_ytdlp_vtt_read_error_raises_download_error(
+    mocker,
+    tmp_path,
+):
     """Test fetch_transcript_via_ytdlp converts vtt_to_text OSError into DownloadError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("transcription.clean_up")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
-    ctx.extract_info.return_value = {"subtitles": {"en": [{}]}, "automatic_captions": {}}
+    ctx.extract_info.return_value = {
+        "subtitles": {"en": [{}]},
+        "automatic_captions": {},
+    }
     # create the vtt file so the glob finds it, but vtt_to_text raises OSError
     (tmp_path / "fake-uuid.en.vtt").write_text("WEBVTT\n", encoding="utf-8")
     mocker.patch.object(YtDlpBackend, "_vtt_to_text", side_effect=OSError("disk full"))
@@ -876,7 +891,10 @@ def test_fetch_transcript_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_pat
     mocker.patch("transcription.clean_up")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
-    ctx.extract_info.return_value = {"subtitles": {"en": [{}]}, "automatic_captions": {}}
+    ctx.extract_info.return_value = {
+        "subtitles": {"en": [{}]},
+        "automatic_captions": {},
+    }
     # download() succeeds but writes nothing to tmp_path
 
     with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
@@ -886,7 +904,8 @@ def test_fetch_transcript_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_pat
 
 
 def test_fetch_transcript_via_ytdlp_pins_proxy_across_probe_and_download(
-    mocker, tmp_path
+    mocker,
+    tmp_path,
 ):
     """Test fetch_transcript_via_ytdlp resolves the proxy once and reuses it for both YoutubeDL instances."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
@@ -934,12 +953,12 @@ def test_transcribe_happy_path(mocker):
     # sequence of statuses: processing -> succeeded
     # status is checked twice per loop (while condition and inside if)
     type(mock_prediction).status = mocker.PropertyMock(
-        side_effect=["processing", "processing", "succeeded", "succeeded"]
+        side_effect=["processing", "processing", "succeeded", "succeeded"],
     )
     mock_prediction.output = {"segments": [{"text": "Hello "}, {"text": "world!"}]}
 
     mock_replicate.models.get.return_value.versions.list.return_value = [
-        mocker.MagicMock(id="v1")
+        mocker.MagicMock(id="v1"),
     ]
     mock_replicate.predictions.create.return_value = mock_prediction
 
@@ -958,7 +977,7 @@ def test_transcribe_failed_prediction(mocker):
     mock_prediction.status = "failed"
     mock_replicate.predictions.create.return_value = mock_prediction
     mock_replicate.models.get.return_value.versions.list.return_value = [
-        mocker.MagicMock(id="v1")
+        mocker.MagicMock(id="v1"),
     ]
 
     with pytest.raises(ModelError):
@@ -975,7 +994,7 @@ def test_transcribe_null_output(mocker):
     mock_prediction.output = None
     mock_replicate.predictions.create.return_value = mock_prediction
     mock_replicate.models.get.return_value.versions.list.return_value = [
-        mocker.MagicMock(id="v1")
+        mocker.MagicMock(id="v1"),
     ]
 
     with pytest.raises(ModelError):
@@ -992,7 +1011,7 @@ def test_transcribe_invalid_segments_raises_model_error(mocker):
     mock_prediction.output = {"segments": "not-a-list"}
     mock_replicate.predictions.create.return_value = mock_prediction
     mock_replicate.models.get.return_value.versions.list.return_value = [
-        mocker.MagicMock(id="v1")
+        mocker.MagicMock(id="v1"),
     ]
 
     with pytest.raises(ModelError):
@@ -1001,9 +1020,14 @@ def test_transcribe_invalid_segments_raises_model_error(mocker):
 
 def test_extract_video_id_uppercase_host():
     """_extract_video_id handles uppercase and mixed-case hostnames."""
-    assert YouTubeTranscriber._extract_video_id("https://YOUTU.BE/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
     assert (
-        YouTubeTranscriber._extract_video_id("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ")
+        YouTubeTranscriber._extract_video_id("https://YOUTU.BE/dQw4w9WgXcQ")
+        == "dQw4w9WgXcQ"
+    )
+    assert (
+        YouTubeTranscriber._extract_video_id(
+            "https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ",
+        )
         == "dQw4w9WgXcQ"
     )
 
@@ -1022,5 +1046,8 @@ def test_extract_video_id_empty_path():
 
 def test_extract_video_id_unrecognized_path():
     """_extract_video_id returns None for youtube.com URLs with unrecognized paths."""
-    assert YouTubeTranscriber._extract_video_id("https://youtube.com/playlist?list=PLxxx") is None
+    assert (
+        YouTubeTranscriber._extract_video_id("https://youtube.com/playlist?list=PLxxx")
+        is None
+    )
     assert YouTubeTranscriber._extract_video_id("https://youtube.com/") is None


### PR DESCRIPTION
## **User description**
## Summary
- Resolved all 191 `uvx ruff check` violations, which were entirely confined to `tests/**` — `src/` was already clean.
- Auto-fixed mechanical issues (`COM812`, `UP037`, `D202`) and hoisted local imports to module scope, which surfaced and removed two dead duplicate imports (`test_handlers.py`, `test_summary.py`) and a 3x-repeated import in `test_summary.py`.
- Rewrote docstrings to satisfy `D403`/`D103`/`D104` instead of suppressing them (capitalized `parse`/`resolve` summaries to `Test parse`/`Test resolve`, added missing docstrings to `test_config.py` and `tests/__init__.py`).
- Narrowed `tests/**/*.py` per-file-ignores in `pyproject.toml` to only the rules that are genuinely intrinsic to test code (mock signatures, private-member access under test, literal `pytest.raises` patterns, long descriptive docstrings) rather than blanket-suppressing everything.
- Extended both `ruff-check` and `ruff-format` pre-commit hooks from `files: ^src/` to `files: ^(src|tests)/`, matching the existing `pytest` hook's scope, so tests are linted going forward.

## Test plan
- [x] `uvx ruff format .` — clean
- [x] `uvx ruff check .` — All checks passed!
- [x] `uvx ty check .` — All checks passed!
- [x] `uv run pytest --cov` — 231 passed, 100% coverage maintained
- [x] Pre-commit hooks (gitleaks, file hygiene, uv-lock, ruff, ty, pytest) all pass on the full commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Tighten test linting and keep the suite compliant**

### What Changed
- Test files now have clearer docstrings and imports, with duplicate and unused imports removed where they were only needed in individual tests.
- Test lint rules are narrowed to the cases that are normal in test code, instead of suppressing linting across the whole suite.
- Pre-commit lint and format checks now run on both app code and tests, so test files are checked automatically.
- Added the missing package-level test docstring and kept the suite formatting consistent.

### Impact
`✅ Fewer lint failures in test runs`
`✅ Test files checked before commit`
`✅ Cleaner, more consistent test output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded formatting and linting coverage to include both application and test files (pre-commit and CI now run across the full repo).
  * Updated lint configuration so test files use targeted rule exceptions instead of global exclusions.
* **Tests**
  * Improved test suite readability with reorganized imports and consistent formatting.
  * Added/expanded URL hostname normalization checks; no user-facing behavior changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->