### PR TITLE
docs: document effective GPL-2.0 license of distributed builds

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,55 @@
+NOTICE — License information for ai-summarizer-telegram-bot
+
+This project's own source code is dedicated to the public domain under the
+Unlicense. See the LICENSE file for the full text.
+
+However, the application imports and runs third-party dependencies, some of
+which are copyleft-licensed. Because of this, any *built or distributed
+artifact* (for example, a Docker image or a compiled binary) that bundles
+these dependencies is, taken as a whole, effectively governed by the
+GNU General Public License, version 2 (GPL-2.0). The Unlicense dedication
+covers only this project's own source files, not the combined work.
+
+Key copyleft dependencies:
+
+  - pyTelegramBotAPI  — GPL-2.0            (direct runtime dependency)
+  - mutagen           — GPL-2.0-or-later   (transitive, via yt-dlp)
+  - psycopg2-binary   — LGPL-3.0-or-later, with a special exception
+                        permitting linking with OpenSSL
+  - certifi           — MPL-2.0 (file-level copyleft)
+  - tqdm              — MPL-2.0 AND MIT (file-level copyleft on the MPL part)
+
+System packages in the Docker image
+------------------------------------
+The Dockerfile installs additional system packages into the image with
+`apk add` (see the Dockerfile):
+
+  - ffmpeg — GPL-2.0-or-later AND LGPL-2.1-or-later. Alpine builds it with
+    `--enable-gpl --enable-version3`, so the shipped binary is GPL-licensed.
+    It is invoked as a separate executable (a subprocess) — both by yt-dlp's
+    postprocessors and directly by this project's own audio-compression code
+    (see `src/utils.py`). Invoking a separate program this way is mere
+    aggregation — it does NOT make this project's own code a derivative work of
+    ffmpeg. Distributing an image that contains the ffmpeg binary does, however,
+    carry ffmpeg's own GPL obligations for that binary.
+  - deno — MIT (notice retention only).
+
+The base image (python:*-alpine) also contains its own operating-system
+packages (e.g. BusyBox, GPL-2.0-only) under their respective licenses, as any
+Linux distribution image does.
+
+Distribution model
+------------------
+This project is distributed as SOURCE ONLY. Dependencies are fetched at build
+time (via `uv sync`) and are not vendored or committed to this repository, and
+no prebuilt image or binary is published from CI. Under this model the copyleft
+obligations above are DORMANT: they would attach only to a prebuilt artifact
+that you choose to distribute. If you ever publish such an artifact, you become
+responsible for meeting those obligations — for the GPL dependencies this means
+offering the corresponding source and retaining their license and copyright
+notices; for Apache-2.0 dependencies it means retaining their NOTICE files.
+
+Each dependency's own license text is preserved in its `*.dist-info/licenses/`
+directory within an installed environment.
+
+This notice is practical guidance, not legal advice.

--- a/README.md
+++ b/README.md
@@ -252,3 +252,9 @@ Redis: [Redis.io](https://redis.io/), [Upstash x Redis](https://upstash.com/), [
 - [Gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
 - [NumPy Docstrings Style Guide | Docstrings](https://numpydoc.readthedocs.io/en/latest/format.html).
 - Frontend to configure access.
+
+## License
+
+This project's own source code is released into the public domain under the [Unlicense](LICENSE).
+
+Note that the app depends on copyleft-licensed components (notably `pyTelegramBotAPI`, GPL-2.0, and `mutagen`, GPL-2.0-or-later; plus the GPL-licensed `ffmpeg` binary installed into the Docker image). The project is distributed **source only**, so those obligations stay dormant — but any prebuilt artifact you build and distribute (e.g. a Docker image) is, as a whole, effectively **GPL-2.0**. See [NOTICE](NOTICE) for details. Not legal advice.


### PR DESCRIPTION
## **User description**
## Summary
- Add a `NOTICE` file explaining that this project's own source is Unlicense, but any distributed build (Docker image or binary) is, as a whole, effectively **GPL-2.0** — because it bundles `pyTelegramBotAPI` (GPL-2.0, direct dep), `mutagen` (GPL-2.0-or-later, transitive via yt-dlp), and the GPL-licensed Alpine `ffmpeg` binary (built with `--enable-gpl --enable-version3`, verified against Alpine's APKBUILD).
- Add a `## License` section to `README.md` pointing to `LICENSE` and `NOTICE`.
- Distribution today is **source-only** (deps fetched at build time via `uv sync`, no CI-published image/binary), so these copyleft obligations are dormant; the NOTICE explains what would activate them and notes ffmpeg is invoked as a subprocess (mere aggregation), which does not make the project's own code a derivative of ffmpeg.

Follows a license compliance audit done earlier in this session (full report captured in a local plan file, not part of this PR).

## Test plan
- [x] `uvx ruff format --check .` — 29 files already formatted
- [x] `uvx ruff check .` — all checks passed
- [x] `uvx ty check .` — all checks passed
- [x] `npx markdownlint-cli2 README.md` — 0 errors
- [x] Docs-only change; no code, dependency, or license-field changes


___

## **CodeAnt-AI Description**
**Document licensing for source and distributed builds**

### What Changed
- Added a NOTICE file that explains the project’s source is Unlicense, while any packaged build or Docker image must also follow the licenses of bundled third-party components.
- Listed the main copyleft dependencies and explained that shipping a prebuilt artifact triggers their notice and source-sharing requirements.
- Added a License section to the README so the licensing terms and NOTICE file are visible from the project overview.

### Impact
`✅ Clearer license terms for released builds`
`✅ Easier compliance for Docker images and binaries`
`✅ Fewer licensing surprises for distributors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new NOTICE document detailing that the project’s own source is dedicated to the public domain (Unlicense), while bundled third-party copyleft dependencies and certain included binaries may impose additional distribution obligations.
  * Updated the README with a new **License** section summarizing these points and directing readers to NOTICE for full details.
  * Clarified expectations for distributing artifacts (including container images) and noted that obligations are only triggered upon distribution of built artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->