### PR TITLE
docs: document dev-only GPL ffmpeg build fetched via pixi

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -38,6 +38,16 @@ The base image (python:*-alpine) also contains its own operating-system
 packages (e.g. BusyBox, GPL-2.0-only) under their respective licenses, as any
 Linux distribution image does.
 
+Local development environment (pixi)
+-------------------------------------
+The optional pixi environment (see the README) is for local development only
+and is never packaged or distributed. It fetches its own ffmpeg build from
+conda-forge (`ffmpeg-*-gpl_*`, GPL-2.0-or-later) — a different binary than the
+one Alpine installs into the Docker image above, but also GPL-licensed, so its
+obligations are equally dormant under the source-only distribution model
+below. The committed `pixi.lock` records only download URLs and hashes, not
+the binaries themselves, and so is not a redistribution of that code.
+
 Distribution model
 ------------------
 This project is distributed as SOURCE ONLY. Dependencies are fetched at build


### PR DESCRIPTION
## **User description**
## Summary
- The NOTICE (added in #919) scoped ffmpeg only to the Alpine build installed into the Docker image, but the optional local `pixi` dev environment (see README) fetches a separate conda-forge ffmpeg build (`ffmpeg-*-gpl_*`, GPL-2.0-or-later) that wasn't documented.
- Adds a dedicated "Local development environment (pixi)" section to NOTICE explaining that this ffmpeg build is dev-only, never packaged or distributed, and that its GPL obligations are equally dormant under the existing source-only distribution model.
- Also clarifies that the committed `pixi.lock` is a manifest of download URLs and hashes, not a redistribution of the ffmpeg binary itself.

## Why
Accuracy gap, not a compliance gap — pixi never ships in the Docker image (confirmed: Dockerfile installs ffmpeg via Alpine's `apk add`, not pixi), so no new obligation is created. This just makes NOTICE reflect the ffmpeg binary developers actually run locally.

## Test plan
- [x] Confirmed `pixi.lock` pins `ffmpeg-8.1.2-gpl_haa6735b_101.conda` with `license: GPL-2.0-or-later`
- [x] Confirmed `Dockerfile` never invokes pixi (uses `apk add ffmpeg deno` + `uv sync`)
- [x] Docs-only change; no code touched, so ruff/ty/pytest are not applicable
- [x] Re-read NOTICE end-to-end for coherence with the new section placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document the GPL-licensed ffmpeg used in the local pixi dev environment**

### What Changed
- Adds a NOTICE section explaining that the optional pixi setup is for local development only and is not distributed
- Clarifies that pixi downloads a separate GPL-licensed ffmpeg build from the Docker image’s ffmpeg
- States that `pixi.lock` only records download links and hashes, not the binary itself

### Impact
`✅ Clearer license notice for local development`
`✅ Fewer questions about the pixi ffmpeg binary`
`✅ Clearer distinction between dev-only and distributed dependencies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section covering the optional local development environment.
  * Clarified that this environment is for development only and is not included in distributed releases.
  * Explained how the environment obtains its media tooling and how the included lockfile should be interpreted under the source-only distribution model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->