### PR TITLE
docs: clarify commit-not-push workflow and docs/ gitignore status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Before your first file edit, ensure you are not on `main`. If you are, create a 
 6. Do not bulk-read documents. Process one at a time: read, summarize to disk, release from context before reading next. For the detailed protocol, read `docs/context/processing-protocol.md`.
 7. Sub-agent returns must be structured (numbers, file paths, decisions, open items), not free-form prose. See `docs/context/subagent-rules.md`.
 8. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.
-9. Before every commit, pass: `uvx ruff format .`, `uvx ruff check .`, `uvx ty check .`, `uv run pytest --cov`. Review the coverage report and do not introduce new uncovered lines. See `docs/context/git-guide.md` for the full sequence.
+9. Before every commit, pass: `uvx ruff format .`, `uvx ruff check .`, `uvx ty check .`, `uv run pytest --cov`. Review the coverage report and do not introduce new uncovered lines. See `docs/context/git-guide.md` for the full sequence. Commit locally when a unit of work is complete, but do **not** `git push` unless the user explicitly asks — pushing triggers the GitHub code-review agent, which should only run on finished work. When staging, remember that `docs/summaries/` and `docs/archive/` are gitignored (only `docs/context/` under `docs/` is tracked); never try to add or commit handoff, recovery, or archive files.
 10. When changing code, update or add tests in the same PR. Treat test maintenance as mandatory — skipping it is equivalent to skipping the pre-commit checks in Rule 9.
 
 ## Handoff Template
@@ -61,8 +61,8 @@ Write to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`. Create it after the f
 
 ## Where Things Live
 
-- `docs/summaries/` — active session state (latest handoff + project-digest + decision records + source summaries)
-- `docs/context/` — reusable domain knowledge, loaded only when relevant to the current task
+- `docs/summaries/` — active session state (latest handoff + project-digest + decision records + source summaries). **(gitignored — not committed)**
+- `docs/context/` — reusable domain knowledge, loaded only when relevant to the current task. **(tracked in git)**
   - `architecture.md` — high-level component map and data flow. Stable; update only on architectural change, not every handoff.
   - `agent-templates.md` — decision, analysis, and source-summary templates (read on demand). The session handoff template lives inline in `AGENTS.md` above.
   - `processing-protocol.md` — full document processing steps
@@ -71,7 +71,7 @@ Write to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`. Create it after the f
   - `git-guide.md` — git workflow and repository conventions
   - `uv-guide.md` — running the project and managing dependencies with `uv`
   - `subagent-rules.md` — rules for sub-agent usage and outputs
-- `docs/archive/` — processed raw files. Do not read unless explicitly told.
+- `docs/archive/` — processed raw files. Do not read unless explicitly told. **(gitignored — not committed)**
 - `.claude/commands/` — step-by-step routine for **handoff** (`handoff.md`). Claude Code exposes it as the `/handoff` slash command; agents without slash-command support should read that file and follow the steps directly.
 
 ## Error Recovery


### PR DESCRIPTION
## **User description**
## Summary
- Rule 9 in AGENTS.md now instructs agents to commit locally but not `git push` unless explicitly asked, since pushing triggers the GitHub code-review agent on possibly-unfinished work.
- Annotates `docs/summaries/` and `docs/archive/` as gitignored, and `docs/context/` as tracked, so agents stop trying to stage/commit handoff and archive files.

## Test plan
- [x] Doc-only change; no code paths affected.
- [x] Verified gitignore status via `git check-ignore` and `git ls-files docs/` before writing the claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Clarify when to commit, push, and ignore docs folders**

### What Changed
- The workflow now says to commit finished work locally, but not push it unless the user asks for that explicitly.
- It warns that pushing can trigger code review too early, so unfinished work should stay local.
- It now clearly marks `docs/summaries/` and `docs/archive/` as not committed, and `docs/context/` as tracked, so agents stop trying to stage the wrong files.

### Impact
`✅ Fewer accidental pushes`
`✅ Less time spent staging ignored docs files`
`✅ Clearer handoff and archive workflow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repository guidance for where session notes and archived materials belong.
  * Reinforced that certain documentation folders are ignored by version control and should not be committed.
  * Improved status notes for tracked vs. untracked documentation locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->