### PR TITLE
Exempt gitignored files from main-branch edit guard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "file=$(python3 -c \"import sys,json;print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file\" ] && exit 0; root=$(git -C \"$(dirname \"$file\")\" rev-parse --show-toplevel 2>/dev/null) || exit 0; if git -C \"$root\" check-ignore -q \"$file\" 2>/dev/null; then exit 0; fi; branch=$(git -C \"$root\" branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo 'Blocked: editing a repo file on the protected main branch. Create a feature branch first (git checkout -b <scope>-<short-desc>), then retry.' >&2; exit 2; fi"
+            "command": "file=$(python3 -c \"import sys,json;print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file\" ] && exit 0; dir=$(dirname \"$file\"); while [ ! -d \"$dir\" ] && [ \"$dir\" != \"/\" ]; do dir=$(dirname \"$dir\"); done; root=$(git -C \"$dir\" rev-parse --show-toplevel 2>/dev/null) || exit 0; if git -C \"$root\" check-ignore -q \"$file\" 2>/dev/null; then exit 0; fi; branch=$(git -C \"$root\" branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo 'Blocked: editing a repo file on the protected main branch. Create a feature branch first (git checkout -b <scope>-<short-desc>), then retry.' >&2; exit 2; fi"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "file=$(python3 -c \"import sys,json;print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file\" ] && exit 0; root=$(git -C \"$(dirname \"$file\")\" rev-parse --show-toplevel 2>/dev/null) || exit 0; branch=$(git -C \"$root\" branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo 'Blocked: editing a repo file on the protected main branch. Create a feature branch first (git checkout -b <scope>-<short-desc>), then retry.' >&2; exit 2; fi"
+            "command": "file=$(python3 -c \"import sys,json;print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file\" ] && exit 0; root=$(git -C \"$(dirname \"$file\")\" rev-parse --show-toplevel 2>/dev/null) || exit 0; if git -C \"$root\" check-ignore -q \"$file\" 2>/dev/null; then exit 0; fi; branch=$(git -C \"$root\" branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo 'Blocked: editing a repo file on the protected main branch. Create a feature branch first (git checkout -b <scope>-<short-desc>), then retry.' >&2; exit 2; fi"
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ For a quick orientation to the codebase (component map and data flow), read `doc
 
 Before starting work, state: what you understand the project state to be, what you plan to do this session, and any open questions.
 
-Before your first file edit, ensure you are not on `main`. If you are, create a feature branch (`git checkout -b <scope>-<short-desc>`, matching the commit scope convention in `docs/context/git-guide.md`). A `PreToolUse` hook backs this up by blocking edits to repo files while on `main`.
+Before your first file edit, ensure you are not on `main`. If you are, create a feature branch (`git checkout -b <scope>-<short-desc>`, matching the commit scope convention in `docs/context/git-guide.md`). A `PreToolUse` hook backs this up by blocking edits to repo files while on `main` — but it exempts gitignored working files (session handoffs in `docs/summaries/`, recovery notes), so writing those on `main` needs no branch; only edits to tracked files trigger the branch requirement.
 
 ## Rules
 


### PR DESCRIPTION
## **User description**
## Summary
- The `PreToolUse` hook in `.claude/settings.json` blocked edits to *any* repo file while on `main`, checking only branch name — not whether the file was actually tracked. Session handoffs live in `docs/summaries/` (gitignored), so writing one on `main` forced a throwaway feature branch that ended up with nothing to commit.
- The hook now short-circuits with `git check-ignore -q "$file"` before the branch check: gitignored files (handoffs, recovery notes) write freely on `main`; edits to tracked files still require a feature branch, unchanged.
- Clarified `AGENTS.md`'s branch-guard paragraph to document the exemption.

## Test plan
- [x] `.claude/settings.json` still parses as valid JSON after the shell-command edit
- [x] Simulated hook against `docs/summaries/*.md` and `docs/archive/*` on a throwaway `main` branch → exit 0 (allowed)
- [x] Simulated hook against tracked files (`src/*.py`, `AGENTS.md`) on the same throwaway `main` branch → exit 2 (blocked, same message as before)
- [x] Empty `file_path` / outside-repo paths still exit 0 cleanly
- [x] `/code-review` (high effort) run against the diff — 0 findings

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Allow gitignored notes and handoffs to be edited on main**

### What Changed
- Gitignored working files, such as session handoffs in `docs/summaries/` and recovery notes, can now be written on `main`
- Edits to tracked repository files still require a feature branch
- The branch-guard guidance now explains this exemption so the rule matches the actual behavior

### Impact
`✅ Fewer empty throwaway branches`
`✅ Easier session handoffs on main`
`✅ Clearer branch rules for tracked files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editing safeguards so git-ignored working files can be updated even when the repository is on the protected main branch.
  * Existing restrictions for tracked repository files remain unchanged.

* **Documentation**
  * Clarified when edits are allowed on main, including an explicit exemption for git-ignored session notes and recovery files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->