### PR TITLE
docker: ship LICENSE and NOTICE in the final image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-**/LICENSE
 **/README.md
 **/.gitignore
 **/.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,7 @@ RUN uv sync \
     --no-group modal \
     --no-group build \
     --compile-bytecode \
-    --no-managed-python \
-    && rm -f pyproject.toml uv.lock
+    --no-managed-python
 COPY --from=builder /app/src .
 RUN adduser -D -u 1000 -s /sbin/nologin bot \
     && chown -R bot:bot /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV SENTRY_ENVIRONMENT=${ENV}
 WORKDIR /app
 RUN apk add --no-cache ffmpeg deno
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock LICENSE NOTICE ./
 RUN uv sync \
     --frozen \
     --no-cache \
@@ -37,7 +37,6 @@ RUN uv sync \
     --no-managed-python \
     && rm -f pyproject.toml uv.lock
 COPY --from=builder /app/src .
-COPY LICENSE NOTICE ./
 RUN adduser -D -u 1000 -s /sbin/nologin bot \
     && chown -R bot:bot /app
 USER bot

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN uv sync \
     --no-managed-python \
     && rm -f pyproject.toml uv.lock
 COPY --from=builder /app/src .
+COPY LICENSE NOTICE ./
 RUN adduser -D -u 1000 -s /sbin/nologin bot \
     && chown -R bot:bot /app
 USER bot


### PR DESCRIPTION
## Summary
- Copy `LICENSE` and `NOTICE` into the final Docker image, folded into the existing `COPY pyproject.toml uv.lock ... ./` line before `uv sync`.
- Remove `**/LICENSE` from `.dockerignore` — it was silently stripping the root `LICENSE` file from the build context, which would have made the new `COPY` fail.
- Drop the `&& rm -f pyproject.toml uv.lock` cleanup step, so all four metadata files (`pyproject.toml`, `uv.lock`, `LICENSE`, `NOTICE`) now consistently stay in the final image together.

## Why
Defensive practice: `NOTICE` already documents that any distributed image is, as a whole, effectively GPL-2.0 (third-party copyleft deps + Alpine's GPL ffmpeg). The image itself carried neither `LICENSE` nor `NOTICE` — only `/app/src` and the venv. Third-party dependency license texts were already covered automatically via each package's `*.dist-info/licenses/` directory installed by `uv sync`, but the project's own root-level license files were missing from any artifact that might get built and distributed.

This is currently a dormant concern — per `NOTICE`, the project ships source-only and no image is published from CI — but it's a one-line fix that closes the gap if that ever changes.

## Reviewer notes
- Considered restoring `rm -f pyproject.toml uv.lock` for extra hardening, but rejected it: a same-stage `rm -f` only whitewashes the final container filesystem view — the earlier `COPY` layer's bytes remain part of the image artifact regardless (Docker layers are immutable), so it provides no protection against anyone with raw image/layer access. It also doesn't meaningfully reduce live-container disclosure, since the same dependency-version information is already recoverable from `site-packages/*/dist-info/METADATA` for every installed package. Recorded as a project memory so this isn't re-litigated in a future review.
- Verified the `COPY`/`.dockerignore` interaction and that `LICENSE`/`NOTICE` survive intact using a throwaway test Dockerfile against the real build context, rather than running the actual multi-stage build — the builder stage executes a live `alembic upgrade head` and `modal deploy`, which needs real credentials and shouldn't be triggered incidentally.

## Test plan
- [x] `docker build --check .` — only the two pre-existing `SecretsUsedInArgOrEnv` warnings (unrelated ARGs in the builder stage), no new warnings
- [x] Throwaway test Dockerfile confirms `LICENSE`/`NOTICE` land in `/app` with correct content, and are unaffected by removing the `rm -f` step
- [x] Docs-only/Dockerfile-only change; no Python touched, so ruff/ty/pytest are not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production container setup to include license and notice information in the image.
  * Kept packaging metadata available in the final image after dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->