### PR TITLE
docs: make Rule 1 actionable, fix Error Recovery to read from disk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Before your first file edit, ensure you are not on `main`. If you are, create a 
 6. Do not bulk-read documents. Process one at a time: read, summarize to disk, release from context before reading next. For the detailed protocol, read `docs/context/processing-protocol.md`.
 7. Sub-agent returns must be structured (numbers, file paths, decisions, open items), not free-form prose. See `docs/context/subagent-rules.md`.
 8. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.
-9. Before every commit, pass: `uvx ruff format .`, `uvx ruff check .`, `uvx ty check .`, `uv run pytest --cov`. Review the coverage report and do not introduce new uncovered lines. See `docs/context/git-guide.md` for the full sequence. Commit locally when a unit of work is complete, but do **not** `git push` unless the user explicitly asks — pushing triggers the GitHub code-review agent, which should only run on finished work. When staging, remember that `docs/summaries/` and `docs/archive/` are gitignored (only `docs/context/` under `docs/` is tracked); never try to add or commit handoff, recovery, or archive files.
+9. Before every commit, pass: `uvx ruff format .`, `uvx ruff check .`, `uvx ty check .`, `uv run pytest --cov`. Review the coverage report and do not introduce new uncovered lines. See `docs/context/git-guide.md` for the full sequence. Commit locally when a unit of work is complete, but do **not** `git push` unless the user explicitly asks — pushing triggers the GitHub code-review agent, which should only run on finished work. When staging, remember that `docs/summaries/` and `docs/archive/` are gitignored (only `docs/context/` under `docs/` is tracked); never try to add or commit handoff or archive files.
 10. When changing code, update or add tests in the same PR. Treat test maintenance as mandatory — skipping it is equivalent to skipping the pre-commit checks in Rule 9.
 
 ## Handoff Template
@@ -76,7 +76,7 @@ Write to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`. Create it after the f
 
 ## Error Recovery
 
-If context degrades or auto-compact fires unexpectedly: do not try to reconstruct state from memory. Re-read the active handoff in `docs/summaries/` and verify its contents against the working tree (`git status`, `git log`) before continuing. Tell the user what may have been lost, and if the handoff is stale relative to the actual work, say so explicitly rather than guessing.
+If context degrades or auto-compact fires unexpectedly: do not try to reconstruct state from memory. Re-read the active handoff in `docs/summaries/` and verify its contents against the working tree (`git status`, `git log`) before continuing. Tell the user what may have been lost, and if the handoff is stale relative to the actual work, say so explicitly rather than guessing. If the handoff plus working tree cannot reconstruct reliable state, suggest a fresh session — the handoff exists precisely so a new session can pick up.
 
 ## Before Delivering Output
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,11 @@ For a quick orientation to the codebase (component map and data flow), read `doc
 
 Before starting work, state: what you understand the project state to be, what you plan to do this session, and any open questions.
 
-Before your first file edit, ensure you are not on `main`. If you are, create a feature branch (`git checkout -b <scope>-<short-desc>`, matching the commit scope convention in `docs/context/git-guide.md`). A `PreToolUse` hook backs this up by blocking edits to repo files while on `main` — but it exempts gitignored working files (session handoffs in `docs/summaries/`, recovery notes), so writing those on `main` needs no branch; only edits to tracked files trigger the branch requirement.
+Before your first file edit, ensure you are not on `main`. If you are, create a feature branch (`git checkout -b <scope>-<short-desc>`, matching the commit scope convention in `docs/context/git-guide.md`). A `PreToolUse` hook backs this up by blocking edits to repo files while on `main` — but it exempts gitignored working files (session handoffs in `docs/summaries/`), so writing those on `main` needs no branch; only edits to tracked files trigger the branch requirement.
 
 ## Rules
 
-1. Do not mix unrelated project contexts in one session.
+1. If the session pivots to an unrelated project or topic, do not absorb it: finalize the current handoff (Rule 4) and suggest a new session. One session = one context; `docs/summaries/` keeps one active handoff at a time.
 2. Write state to disk, not conversation. After completing meaningful work, record it in the session handoff at `docs/summaries/handoff-[date]-[topic].md` using the Handoff template below — create it on first write, update it as work progresses. Include: decisions with rationale, exact numbers, file paths, open items.
 3. Before compaction or session end, write to disk: every number, every decision with rationale, every open question, every file path, exact next action.
 4. When switching work types (research → writing → review) or ending the session, finalize the handoff at `docs/summaries/handoff-[date]-[topic].md` using the Handoff template below (fill the optional tail) and suggest a new session.
@@ -76,7 +76,7 @@ Write to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`. Create it after the f
 
 ## Error Recovery
 
-If context degrades or auto-compact fires unexpectedly: write current state to `docs/summaries/recovery-[date].md`, tell the user what may have been lost, suggest a fresh session.
+If context degrades or auto-compact fires unexpectedly: do not try to reconstruct state from memory. Re-read the active handoff in `docs/summaries/` and verify its contents against the working tree (`git status`, `git log`) before continuing. Tell the user what may have been lost, and if the handoff is stale relative to the actual work, say so explicitly rather than guessing.
 
 ## Before Delivering Output
 


### PR DESCRIPTION
## Summary
- Rule 1 reworded from a bare prohibition ("do not mix unrelated project contexts") to the concrete action for the real case: a mid-session pivot to an unrelated topic — finalize the current handoff and suggest a new session.
- Error Recovery rewritten: instead of writing a `recovery-[date].md` from already-degraded context (a mechanism that never fired once across 142 archived handoffs), the agent now re-reads the active handoff in `docs/summaries/` and verifies it against the working tree (`git status`, `git log`) before continuing. Falls back to suggesting a fresh session if the handoff + working tree can't reconstruct reliable state.
- Cleaned up the now-dangling "recovery notes" / "recovery" references left in Session Start and Rule 9 after the mechanism was removed (caught by a follow-up `/code-review` pass).
- Rules 2–10 and Before Delivering Output were reviewed against on-disk evidence and left unchanged — confirmed working as written.

## Test plan
- [x] `uvx ruff format .` — 29 files unchanged
- [x] `uvx ruff check .` — all checks passed
- [x] `uvx ty check .` — all checks passed
- [x] `uv run pytest --cov` — 231 passed, 100% coverage (1053/1053 statements), 0 new uncovered lines
- [x] `/code-review` (high effort) run on the branch diff — 2 findings surfaced and fixed in a follow-up commit, 0 remaining

Prose-only change to `AGENTS.md`; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repository start-up guidance, including when to create a branch before making edits.
  * Updated working-state instructions to better reflect acceptable files during recovery.
  * Revised recovery steps to emphasize re-reading the latest handoff and checking the current workspace.
  * Added clearer guidance for cases where a reliable reconstruction is not possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->