### PR TITLE
Migrate Gemini calls to the Interactions API

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,6 @@ import sentry_sdk
 import telebot
 from exa_py import Exa
 from google import genai
-from google.genai import types
 from limits import parse as parse_rate_limit
 from limits.storage import RedisStorage
 from limits.strategies import FixedWindowRateLimiter
@@ -72,24 +71,6 @@ MODEL_LABELS_REVERSE: dict[str, str] = {v: k for k, v in MODEL_LABELS.items()}
 ALLOWED_MODELS_FOR_SUMMARY = list(MODEL_LABELS.keys())
 # If you change DEFAULT_MODEL_ID_FOR_SUMMARY, also change it in models.py.
 DEFAULT_MODEL_ID_FOR_SUMMARY = "gemini-3.5-flash"
-SAFETY_SETTINGS = [
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-]
 DEFAULT_THINKING_LEVEL = "MINIMAL"
 THINKING_LEVEL_LABELS: dict[str, str] = {
     "MINIMAL": "Minimal",
@@ -101,11 +82,6 @@ THINKING_LEVEL_LABELS_REVERSE: dict[str, str] = {
     v: k for k, v in THINKING_LEVEL_LABELS.items()
 }
 ALLOWED_THINKING_LEVELS = list(THINKING_LEVEL_LABELS.keys())
-GEMINI_CONFIG = types.GenerateContentConfig(
-    system_instruction=None,
-    safety_settings=SAFETY_SETTINGS,
-    response_mime_type="text/plain",
-)
 
 
 # Prompts

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -12,3 +12,7 @@ class TranscriptDownloadError(Exception):
 
 class FetchTranscriptError(Exception):
     """Exception raised when transcript retrieval fails via all backends."""
+
+
+class GeminiIncompleteResponseError(Exception):
+    """Exception raised when Gemini returns empty output or incomplete file metadata."""

--- a/src/services.py
+++ b/src/services.py
@@ -5,9 +5,8 @@ import mimetypes
 import time
 from functools import lru_cache
 from textwrap import dedent
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, TypedDict, cast
 
-from google.genai import types
 from limits import parse as _parse_rate_limit
 from requests.exceptions import ReadTimeout
 from telebot.apihelper import ApiTelegramException
@@ -22,7 +21,6 @@ from tenacity import (
 
 from config import (
     DAILY_LIMIT_KEY,
-    GEMINI_CONFIG,
     MINUTE_LIMIT_KEY,
     bot,
     gemini_client,
@@ -34,6 +32,8 @@ from exceptions import LimitExceededError
 from prompts import SYSTEM_INSTRUCTION
 
 if TYPE_CHECKING:
+    from google.genai import types
+    from google.genai.interactions import GenerationConfigParam, ThinkingLevel
     from telebot.types import File, Message
     from tenacity import _utils as tenacity_utils
 
@@ -123,6 +123,14 @@ class QuotaManager:
         return max(0, stats.remaining)
 
 
+class GeminiKwargs(TypedDict):
+    """Keyword arguments shared by every `client.interactions.create` call."""
+
+    system_instruction: str
+    generation_config: GenerationConfigParam
+    store: bool
+
+
 class GeminiHelper:
     """Utilities for Gemini model configuration and file management."""
 
@@ -134,23 +142,22 @@ class GeminiHelper:
         ".mp4": "video/mp4",
     }
 
-    def get_gemini_config(
+    def get_gemini_kwargs(
         self,
         target_language: str,
         thinking_level: str,
-    ) -> types.GenerateContentConfig:
-        """Get Gemini config with system instruction and thinking enabled."""
+    ) -> GeminiKwargs:
+        """Build kwargs shared by every `client.interactions.create` call."""
         system_instruction = dedent(
             SYSTEM_INSTRUCTION.format(language=target_language),
         ).strip()
-        return GEMINI_CONFIG.model_copy(
-            update={
-                "system_instruction": system_instruction,
-                "thinking_config": types.ThinkingConfig(
-                    thinking_level=types.ThinkingLevel(thinking_level),
-                ),
+        return {
+            "system_instruction": system_instruction,
+            "generation_config": {
+                "thinking_level": cast("ThinkingLevel", thinking_level.lower()),
             },
-        )
+            "store": False,
+        }
 
     def resolve_mime_type(self, file: str) -> str:
         """Resolve the MIME type for a file path, with fallbacks."""
@@ -206,7 +213,7 @@ send_answer = messenger.send_answer
 check_quota = quota_manager.check_quota
 get_remaining_quota = quota_manager.get_remaining_quota
 
-get_gemini_config = gemini_helper.get_gemini_config
+get_gemini_kwargs = gemini_helper.get_gemini_kwargs
 resolve_mime_type = gemini_helper.resolve_mime_type
 upload_and_wait_for_file = gemini_helper.upload_and_wait_for_file
 
@@ -217,7 +224,7 @@ __all__ = [
     "check_quota",
     "gemini_helper",
     "get_file_with_retry",
-    "get_gemini_config",
+    "get_gemini_kwargs",
     "get_remaining_quota",
     "messenger",
     "quota_manager",

--- a/src/services.py
+++ b/src/services.py
@@ -28,7 +28,7 @@ from config import (
     rate_limiter,
 )
 from domain import PrefixedText
-from exceptions import LimitExceededError
+from exceptions import GeminiIncompleteResponseError, LimitExceededError
 from prompts import SYSTEM_INSTRUCTION
 
 if TYPE_CHECKING:
@@ -181,7 +181,7 @@ class GeminiHelper:
             config={"mime_type": mime_type},
         )
         if uploaded.name is None:
-            raise AttributeError
+            raise GeminiIncompleteResponseError
         file_name = uploaded.name
         while uploaded.state == "PROCESSING":
             time.sleep(sleep_time)
@@ -189,7 +189,7 @@ class GeminiHelper:
         if uploaded.state == "FAILED":
             raise ValueError(uploaded.state)
         if uploaded.uri is None or uploaded.mime_type is None:
-            raise AttributeError
+            raise GeminiIncompleteResponseError
         return uploaded
 
 

--- a/src/summary.py
+++ b/src/summary.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING, cast
 
 from curl_cffi.requests.exceptions import ConnectionError as CurlConnectionError
 from curl_cffi.requests.exceptions import SSLError as CurlSSLError
-from google.genai import types
+
+# Private import: 2.10.0 exposes no public path for the Interactions error
+# hierarchy (the `google.genai._interactions` module referenced in SDK
+# docstrings does not exist). Revisit this on the next SDK bump.
+from google.genai._gaos.lib.compat_errors import APIError as InteractionsAPIError
 from google.genai.errors import ClientError, ServerError
 from requests.exceptions import SSLError
 from telebot.types import File
@@ -26,7 +30,7 @@ from exceptions import FetchTranscriptError
 from prompts import PROMPTS
 from services import (
     check_quota,
-    get_gemini_config,
+    get_gemini_kwargs,
     resolve_mime_type,
     upload_and_wait_for_file,
 )
@@ -34,6 +38,7 @@ from transcription import get_yt_transcript, transcribe
 from utils import clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
+    from google.genai.interactions import Interaction
     from tenacity import _utils as tenacity_utils
 
 logger = logging.getLogger(__name__)
@@ -51,21 +56,23 @@ class Summarizer:
         thinking_level: str,
     ) -> str:
         """Run a single Gemini text-prompt generation with the standard config."""
-        config = get_gemini_config(target_language, thinking_level=thinking_level)
-        response = gemini_client.models.generate_content(
-            model=model,
-            contents=prompt,
-            config=config,
+        interaction = cast(
+            "Interaction",
+            gemini_client.interactions.create(
+                model=model,
+                input=prompt,
+                **get_gemini_kwargs(target_language, thinking_level=thinking_level),
+            ),
         )
-        if response.text is None:
+        if not interaction.output_text:
             raise AttributeError
-        return response.text
+        return interaction.output_text
 
     @retry(
         stop=stop_after_attempt(2),
         wait=wait_fixed(30),
         retry=retry_if_exception_type(
-            (ServerError, AttributeError, ClientError, SSLError),
+            (ServerError, AttributeError, ClientError, SSLError, InteractionsAPIError),
         ),
         before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
         reraise=False,
@@ -115,28 +122,24 @@ class Summarizer:
             if audio_file.uri is None or audio_file.mime_type is None:
                 raise AttributeError
             check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-            response = gemini_client.models.generate_content(
-                model=model,
-                contents=[
-                    types.Content(
-                        role="user",
-                        parts=[
-                            types.Part.from_text(text=prompt),
-                            types.Part.from_uri(
-                                file_uri=audio_file.uri,
-                                mime_type=audio_file.mime_type,
-                            ),
-                        ],
-                    ),
-                ],
-                config=get_gemini_config(
-                    target_language,
-                    thinking_level=thinking_level,
+            interaction = cast(
+                "Interaction",
+                gemini_client.interactions.create(
+                    model=model,
+                    input=[
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "audio",
+                            "uri": audio_file.uri,
+                            "mime_type": audio_file.mime_type,
+                        },
+                    ],
+                    **get_gemini_kwargs(target_language, thinking_level=thinking_level),
                 ),
             )
-            if response.text is None:
+            if not interaction.output_text:
                 raise AttributeError
-            return response.text
+            return interaction.output_text
         finally:
             if audio_file_name is not None:
                 try:
@@ -152,7 +155,7 @@ class Summarizer:
         stop=stop_after_attempt(2),
         wait=wait_fixed(30),
         retry=retry_if_exception_type(
-            (ServerError, AttributeError, ClientError),
+            (ServerError, AttributeError, ClientError, InteractionsAPIError),
         ),
         before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
         reraise=False,
@@ -251,6 +254,7 @@ class Summarizer:
                 SSLError,
                 CurlSSLError,
                 CurlConnectionError,
+                InteractionsAPIError,
             ),
         ),
         before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
@@ -302,27 +306,25 @@ class Summarizer:
                 sleep_time=sleep_time,
             )
             document_file_name = document_file.name
+            if document_file.uri is None or document_file.mime_type is None:
+                raise AttributeError
             check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-            response = gemini_client.models.generate_content(
-                model=model,
-                contents=[
-                    types.Content(
-                        role="user",
-                        parts=[
-                            types.Part.from_text(text=prompt),
-                            types.Part.from_uri(
-                                file_uri=cast("str", document_file.uri),
-                                mime_type=cast("str", document_file.mime_type),
-                            ),
-                        ],
-                    ),
-                ],
-                config=get_gemini_config(
-                    target_language,
-                    thinking_level=thinking_level,
+            interaction = cast(
+                "Interaction",
+                gemini_client.interactions.create(
+                    model=model,
+                    input=[
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "document",
+                            "uri": document_file.uri,
+                            "mime_type": document_file.mime_type,
+                        },
+                    ],
+                    **get_gemini_kwargs(target_language, thinking_level=thinking_level),
                 ),
             )
-            if response.text is None:
+            if not interaction.output_text:
                 raise AttributeError
         finally:
             if document_file_name is not None:
@@ -336,7 +338,7 @@ class Summarizer:
                     )
             if data is not None:
                 clean_up(file=data)
-        return response.text
+        return interaction.output_text
 
     def summarize(
         self,

--- a/src/summary.py
+++ b/src/summary.py
@@ -8,8 +8,8 @@ from curl_cffi.requests.exceptions import ConnectionError as CurlConnectionError
 from curl_cffi.requests.exceptions import SSLError as CurlSSLError
 
 # Private import: 2.10.0 exposes no public path for the Interactions error
-# hierarchy (the `google.genai._interactions` module referenced in SDK
-# docstrings does not exist). Revisit this on the next SDK bump.
+# hierarchy. A canary test in tests/test_summary.py ("no_public_import_path")
+# fails the suite when an SDK bump adds one — switch this import then.
 from google.genai._gaos.lib.compat_errors import APIError as InteractionsAPIError
 from google.genai.errors import ClientError, ServerError
 from requests.exceptions import SSLError

--- a/src/summary.py
+++ b/src/summary.py
@@ -26,7 +26,7 @@ from tenacity import (
 from config import gemini_client
 from domain import format_prefixed_summary
 from download import download_castro, download_tg, download_yt
-from exceptions import FetchTranscriptError
+from exceptions import FetchTranscriptError, GeminiIncompleteResponseError
 from prompts import PROMPTS
 from services import (
     check_quota,
@@ -65,14 +65,20 @@ class Summarizer:
             ),
         )
         if not interaction.output_text:
-            raise AttributeError
+            raise GeminiIncompleteResponseError
         return interaction.output_text
 
     @retry(
         stop=stop_after_attempt(2),
         wait=wait_fixed(30),
         retry=retry_if_exception_type(
-            (ServerError, AttributeError, ClientError, SSLError, InteractionsAPIError),
+            (
+                ServerError,
+                GeminiIncompleteResponseError,
+                ClientError,
+                SSLError,
+                InteractionsAPIError,
+            ),
         ),
         before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
         reraise=False,
@@ -104,7 +110,8 @@ class Summarizer:
             str: Generated summary text from the audio content.
 
         Raises:
-            AttributeError: If Gemini returns incomplete file or response metadata.
+            GeminiIncompleteResponseError: If Gemini returns incomplete file or
+                response metadata.
             ValueError: If Gemini reports a failed processing state.
             RetryError: If transient Gemini or network errors persist after retries.
 
@@ -120,7 +127,7 @@ class Summarizer:
         audio_file_name = audio_file.name
         try:
             if audio_file.uri is None or audio_file.mime_type is None:
-                raise AttributeError
+                raise GeminiIncompleteResponseError
             check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
             return self._generate_text(
                 [
@@ -150,7 +157,12 @@ class Summarizer:
         stop=stop_after_attempt(2),
         wait=wait_fixed(30),
         retry=retry_if_exception_type(
-            (ServerError, AttributeError, ClientError, InteractionsAPIError),
+            (
+                ServerError,
+                GeminiIncompleteResponseError,
+                ClientError,
+                InteractionsAPIError,
+            ),
         ),
         before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
         reraise=False,
@@ -180,7 +192,7 @@ class Summarizer:
             str: Generated summary text.
 
         Raises:
-            AttributeError: If Gemini returns an empty response.
+            GeminiIncompleteResponseError: If Gemini returns an empty response.
             RetryError: If transient Gemini or network errors persist after retries.
 
         """
@@ -244,7 +256,7 @@ class Summarizer:
         retry=retry_if_exception_type(
             (
                 ServerError,
-                AttributeError,
+                GeminiIncompleteResponseError,
                 ClientError,
                 SSLError,
                 CurlSSLError,
@@ -284,7 +296,8 @@ class Summarizer:
             str: Generated summary text from the document content.
 
         Raises:
-            AttributeError: If Gemini returns incomplete file or response metadata.
+            GeminiIncompleteResponseError: If Gemini returns incomplete file or
+                response metadata.
             ValueError: If the document processing fails on Gemini's side.
             RetryError: If the operation fails after all retry attempts.
 
@@ -302,7 +315,7 @@ class Summarizer:
             )
             document_file_name = document_file.name
             if document_file.uri is None or document_file.mime_type is None:
-                raise AttributeError
+                raise GeminiIncompleteResponseError
             check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
             summary_text = self._generate_text(
                 [

--- a/src/summary.py
+++ b/src/summary.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from textwrap import dedent
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from curl_cffi.requests.exceptions import ConnectionError as CurlConnectionError
 from curl_cffi.requests.exceptions import SSLError as CurlSSLError
@@ -50,17 +50,17 @@ class Summarizer:
 
     @staticmethod
     def _generate_text(
-        prompt: str,
+        contents: str | list[Any],
         model: str,
         target_language: str,
         thinking_level: str,
     ) -> str:
-        """Run a single Gemini text-prompt generation with the standard config."""
+        """Run a single Gemini interaction and return its non-empty text output."""
         interaction = cast(
             "Interaction",
             gemini_client.interactions.create(
                 model=model,
-                input=prompt,
+                input=contents,
                 **get_gemini_kwargs(target_language, thinking_level=thinking_level),
             ),
         )
@@ -122,24 +122,19 @@ class Summarizer:
             if audio_file.uri is None or audio_file.mime_type is None:
                 raise AttributeError
             check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-            interaction = cast(
-                "Interaction",
-                gemini_client.interactions.create(
-                    model=model,
-                    input=[
-                        {"type": "text", "text": prompt},
-                        {
-                            "type": "audio",
-                            "uri": audio_file.uri,
-                            "mime_type": audio_file.mime_type,
-                        },
-                    ],
-                    **get_gemini_kwargs(target_language, thinking_level=thinking_level),
-                ),
+            return self._generate_text(
+                [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "audio",
+                        "uri": audio_file.uri,
+                        "mime_type": audio_file.mime_type,
+                    },
+                ],
+                model,
+                target_language,
+                thinking_level,
             )
-            if not interaction.output_text:
-                raise AttributeError
-            return interaction.output_text
         finally:
             if audio_file_name is not None:
                 try:
@@ -309,23 +304,19 @@ class Summarizer:
             if document_file.uri is None or document_file.mime_type is None:
                 raise AttributeError
             check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-            interaction = cast(
-                "Interaction",
-                gemini_client.interactions.create(
-                    model=model,
-                    input=[
-                        {"type": "text", "text": prompt},
-                        {
-                            "type": "document",
-                            "uri": document_file.uri,
-                            "mime_type": document_file.mime_type,
-                        },
-                    ],
-                    **get_gemini_kwargs(target_language, thinking_level=thinking_level),
-                ),
+            summary_text = self._generate_text(
+                [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "document",
+                        "uri": document_file.uri,
+                        "mime_type": document_file.mime_type,
+                    },
+                ],
+                model,
+                target_language,
+                thinking_level,
             )
-            if not interaction.output_text:
-                raise AttributeError
         finally:
             if document_file_name is not None:
                 try:
@@ -338,7 +329,7 @@ class Summarizer:
                     )
             if data is not None:
                 clean_up(file=data)
-        return interaction.output_text
+        return summary_text
 
     def summarize(
         self,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -197,13 +197,16 @@ def test_upload_and_wait_for_file_name_none(mocker):
         upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
-def test_upload_and_wait_for_file_missing_uri(mocker):
+@pytest.mark.parametrize("missing_field", ["uri", "mime_type"])
+def test_upload_and_wait_for_file_missing_metadata(mocker, missing_field):
     """upload_and_wait_for_file raises when uri or mime_type is None."""
     mock_client = mocker.patch("services.gemini_client")
     mock_file = mocker.MagicMock()
     mock_file.name = "name"
     mock_file.state = "ACTIVE"
-    mock_file.uri = None
+    mock_file.uri = "uri"
+    mock_file.mime_type = "audio/ogg"
+    setattr(mock_file, missing_field, None)
     mock_client.files.upload.return_value = mock_file
 
     with pytest.raises(GeminiIncompleteResponseError):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,5 +1,4 @@
 import pytest
-from google.genai import types
 from limits.util import WindowStats
 
 import services as services_module
@@ -7,7 +6,7 @@ from exceptions import LimitExceededError
 from services import (
     check_quota,
     get_file_with_retry,
-    get_gemini_config,
+    get_gemini_kwargs,
     get_remaining_quota,
     resolve_mime_type,
     send_answer,
@@ -81,31 +80,33 @@ def test_send_answer_multi_chunk(mocker):
     assert mock_reply.call_count == 2
 
 
-def test_get_gemini_config_content():
-    """Test get_gemini_config includes the correct language in instruction."""
-    config = get_gemini_config("French", thinking_level="HIGH")
-    assert "French" in config.system_instruction
+def test_get_gemini_kwargs_content():
+    """Test get_gemini_kwargs includes the correct language in the system instruction."""
+    kwargs = get_gemini_kwargs("French", thinking_level="HIGH")
+    assert "French" in kwargs["system_instruction"]
 
 
-def test_get_gemini_config_thinking_enabled():
-    """Test that thinking config is set based on the passed thinking level."""
-    config = get_gemini_config("English", thinking_level="MEDIUM")
-    assert config.thinking_config is not None
-    assert config.thinking_config.thinking_level == types.ThinkingLevel.MEDIUM
+def test_get_gemini_kwargs_thinking_level_lowercased():
+    """Test that the per-user thinking level is lowercased for generation_config."""
+    kwargs = get_gemini_kwargs("English", thinking_level="MEDIUM")
+    assert kwargs["generation_config"] == {"thinking_level": "medium"}
 
 
-def test_get_gemini_config_invalid_thinking_level():
+def test_get_gemini_kwargs_store_false():
+    """Test that store is always False (no server-side retention of interactions)."""
+    kwargs = get_gemini_kwargs("English", thinking_level="HIGH")
+    assert kwargs["store"] is False
+
+
+def test_get_gemini_kwargs_invalid_thinking_level_passes_through():
     """Lock current behavior on unknown thinking levels.
 
-    ``google.genai.types.ThinkingLevel`` accepts unknown values, emits a
-    ``UserWarning``, and returns a dynamically-created enum member rather than
-    raising. ``get_gemini_config`` inherits that lenient behavior — it does not
-    validate or fall back. This test pins both halves of the contract so any
-    future change (added validation, silent fallback, or raise) is caught.
+    ``generation_config`` is a plain TypedDict now, so there is no enum
+    validation: unknown levels flow through to the API untouched (just
+    lowercased), with no warning and no raise.
     """
-    with pytest.warns(UserWarning, match="INVALID is not a valid ThinkingLevel"):
-        config = get_gemini_config("English", thinking_level="INVALID")
-    assert config.thinking_config is not None
+    kwargs = get_gemini_kwargs("English", thinking_level="INVALID")
+    assert kwargs["generation_config"] == {"thinking_level": "invalid"}
 
 
 def test_upload_and_wait_for_file_happy(mocker):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2,7 +2,7 @@ import pytest
 from limits.util import WindowStats
 
 import services as services_module
-from exceptions import LimitExceededError
+from exceptions import GeminiIncompleteResponseError, LimitExceededError
 from services import (
     check_quota,
     get_file_with_retry,
@@ -187,18 +187,18 @@ def test_resolve_mime_type_fallback_when_mimetypes_returns_none(mocker):
 
 
 def test_upload_and_wait_for_file_name_none(mocker):
-    """upload_and_wait_for_file raises AttributeError when upload returns no name."""
+    """upload_and_wait_for_file raises when upload returns no name."""
     mock_client = mocker.patch("services.gemini_client")
     mock_file = mocker.MagicMock()
     mock_file.name = None
     mock_client.files.upload.return_value = mock_file
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(GeminiIncompleteResponseError):
         upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
 def test_upload_and_wait_for_file_missing_uri(mocker):
-    """upload_and_wait_for_file raises AttributeError when uri or mime_type is None."""
+    """upload_and_wait_for_file raises when uri or mime_type is None."""
     mock_client = mocker.patch("services.gemini_client")
     mock_file = mocker.MagicMock()
     mock_file.name = "name"
@@ -206,7 +206,7 @@ def test_upload_and_wait_for_file_missing_uri(mocker):
     mock_file.uri = None
     mock_client.files.upload.return_value = mock_file
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(GeminiIncompleteResponseError):
         upload_and_wait_for_file("path", "audio/ogg", 1)
 
 

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,7 +1,10 @@
+import importlib.util
 from types import SimpleNamespace
 
 import httpx
 import pytest
+from google.genai import errors as genai_errors
+from google.genai import interactions as genai_interactions
 from google.genai._gaos.lib.compat_errors import APIError as InteractionsAPIError
 from telebot.types import File
 from tenacity import RetryError
@@ -887,3 +890,22 @@ def test_summarize_with_telegram_file(mocker):
 
     assert result == "Telegram file summary"
     mock_download_tg.assert_called_once_with(mock_tg_file, ext=".ogg")
+
+
+def test_interactions_error_hierarchy_has_no_public_import_path():
+    """Canary for the private error import in ``summary.py``.
+
+    ``summary.py`` imports ``APIError`` from
+    ``google.genai._gaos.lib.compat_errors`` because google-genai 2.10.0
+    exposes no public path for the Interactions error hierarchy. A public
+    surface is unlikely to be announced in release notes, so this test fails
+    the suite the moment an SDK bump adds one. When it fails: switch the
+    import in ``summary.py`` (and the one at the top of this file) to the new
+    public path and delete this test.
+    """
+    # The surface the SDK's own docstrings reference but don't ship yet.
+    assert importlib.util.find_spec("google.genai._interactions") is None
+    # The two public modules where the hierarchy would plausibly appear.
+    for name in ("APIStatusError", "RateLimitError", "InternalServerError"):
+        assert not hasattr(genai_errors, name)
+        assert not hasattr(genai_interactions, name)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,7 +1,8 @@
 from types import SimpleNamespace
 
+import httpx
 import pytest
-from google.genai.errors import ClientError
+from google.genai._gaos.lib.compat_errors import APIError as InteractionsAPIError
 from telebot.types import File
 from tenacity import RetryError
 
@@ -29,8 +30,10 @@ def test_summarize_with_file_upload_and_genai_call(mocker):
         state="ACTIVE",
     )
     mock_client.files.upload.return_value = mock_uploaded_file
-    mock_response = mocker.MagicMock(text="This is a mocked summary of the file.")
-    mock_client.models.generate_content.return_value = mock_response
+    mock_response = mocker.MagicMock(
+        output_text="This is a mocked summary of the file.",
+    )
+    mock_client.interactions.create.return_value = mock_response
 
     result = summarize_with_file(
         file="test_audio.ogg",
@@ -62,7 +65,7 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
     mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mock_client = mocker.patch("summary.gemini_client")
     mocker.patch("services.gemini_client", mock_client)
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text="")
 
     with pytest.raises(RetryError):
         summarize_with_file(
@@ -99,8 +102,8 @@ def test_summarize_with_transcript(mocker):
     """Test summarize_with_transcript functionality."""
     mocker.patch("summary.check_quota", return_value=True)
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(
-        text="Transcript summary.",
+    mock_client.interactions.create.return_value = mocker.MagicMock(
+        output_text="Transcript summary.",
     )
 
     result = summarize_with_transcript(
@@ -125,8 +128,8 @@ def test_summarize_webpage(mocker):
     """Test summarize_webpage feeds pre-parsed content to Gemini."""
     mocker.patch("summary.check_quota", return_value=True)
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(
-        text="Webpage summary.",
+    mock_client.interactions.create.return_value = mocker.MagicMock(
+        output_text="Webpage summary.",
     )
 
     result = summarize_webpage(
@@ -140,11 +143,10 @@ def test_summarize_webpage(mocker):
     )
 
     assert result == "Webpage summary."
-    call_kwargs = mock_client.models.generate_content.call_args.kwargs
-    assert "Parsed page content." in call_kwargs["contents"]
-    config = call_kwargs["config"]
-    assert config.tools is None
-    assert "UrlContext" not in (config.system_instruction or "")
+    call_kwargs = mock_client.interactions.create.call_args.kwargs
+    assert "Parsed page content." in call_kwargs["input"]
+    assert call_kwargs["store"] is False
+    assert "tools" not in call_kwargs
 
 
 def test_summarize_with_file_upload_failure(mocker):
@@ -166,19 +168,14 @@ def test_summarize_with_file_upload_failure(mocker):
 
 
 def test_summarize_genai_exception(mocker):
-    """Test summarize_with_transcript raises RetryError when Gemini crashes."""
+    """Test summarize_with_transcript raises RetryError when the interactions API crashes."""
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.side_effect = ClientError(
-        400,
-        {
-            "error": {
-                "code": 400,
-                "status": "INVALID_ARGUMENT",
-                "message": "GenAI unavailable",
-            },
-        },
+    mock_client.interactions.create.side_effect = InteractionsAPIError(
+        "GenAI unavailable",
+        httpx.Request("POST", "https://example.com"),
+        body=None,
     )
 
     with pytest.raises(RetryError):
@@ -210,8 +207,8 @@ def test_summarize_with_document_polling(mocker):
     )
     mock_client.files.upload.return_value = mock_file_proc
     mock_client.files.get.return_value = mock_file_active
-    mock_client.models.generate_content.return_value = mocker.MagicMock(
-        text="Document summary",
+    mock_client.interactions.create.return_value = mocker.MagicMock(
+        output_text="Document summary",
     )
     mock_tg_file = mocker.MagicMock()
 
@@ -600,8 +597,8 @@ def test_summarize_with_file_logs_warning_on_delete_failure(mocker):
     )
     mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(
-        text="summary text",
+    mock_client.interactions.create.return_value = mocker.MagicMock(
+        output_text="summary text",
     )
     mock_client.files.delete.side_effect = Exception("delete failed")
     mock_logger = mocker.patch("summary.logger")
@@ -626,7 +623,7 @@ def test_summarize_with_transcript_raises_on_empty_response(mocker):
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text="")
 
     with pytest.raises(RetryError):
         summarize_with_transcript(
@@ -728,6 +725,73 @@ def test_summarize_with_document_raises_when_mime_type_none(mocker):
         )
 
 
+def test_summarize_with_document_raises_when_upload_returns_none_uri(mocker):
+    """Test summarize_with_document raises RetryError when upload_and_wait_for_file returns uri=None.
+
+    Bypasses the service-layer AttributeError so the inline guard in
+    summarize_with_document itself is exercised, before interactions.create
+    is called.
+    """
+    mocker.patch("summary.check_quota", return_value=True)
+    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
+    mocker.patch("summary.clean_up")
+    mocker.patch("tenacity.nap.time.sleep")
+    mock_client = mocker.patch("summary.gemini_client")
+    mock_file = SimpleNamespace(
+        name="files/doc123",
+        uri=None,
+        mime_type="application/pdf",
+    )
+    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_file)
+
+    with pytest.raises(RetryError):
+        summarize_with_document(
+            file=mocker.MagicMock(),
+            model="test-model",
+            prompt_key="basic_prompt_for_transcript",
+            target_language="English",
+            mime_type="application/pdf",
+            user_id=123,
+            daily_limit=10,
+            thinking_level="MINIMAL",
+        )
+
+    mock_client.interactions.create.assert_not_called()
+
+
+def test_summarize_with_document_raises_when_upload_returns_none_mime_type(mocker):
+    """Test summarize_with_document raises RetryError when upload_and_wait_for_file returns mime_type=None.
+
+    Exercises the inline guard in summarize_with_document itself, before
+    interactions.create is called.
+    """
+    mocker.patch("summary.check_quota", return_value=True)
+    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
+    mocker.patch("summary.clean_up")
+    mocker.patch("tenacity.nap.time.sleep")
+    mock_client = mocker.patch("summary.gemini_client")
+    mock_file = SimpleNamespace(
+        name="files/doc123",
+        uri="https://mock.uri",
+        mime_type=None,
+    )
+    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_file)
+
+    with pytest.raises(RetryError):
+        summarize_with_document(
+            file=mocker.MagicMock(),
+            model="test-model",
+            prompt_key="basic_prompt_for_transcript",
+            target_language="English",
+            mime_type="application/pdf",
+            user_id=123,
+            daily_limit=10,
+            thinking_level="MINIMAL",
+        )
+
+    mock_client.interactions.create.assert_not_called()
+
+
 def test_summarize_with_document_raises_on_empty_response(mocker):
     """Test summarize_with_document raises RetryError when Gemini returns empty response."""
     mocker.patch("summary.check_quota", return_value=True)
@@ -744,7 +808,7 @@ def test_summarize_with_document_raises_on_empty_response(mocker):
         mime_type="application/pdf",
     )
     mock_client.files.upload.return_value = mock_file
-    mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
+    mock_client.interactions.create.return_value = mocker.MagicMock(output_text="")
 
     with pytest.raises(RetryError):
         summarize_with_document(
@@ -774,8 +838,8 @@ def test_summarize_with_document_logs_warning_on_delete_failure(mocker):
         mime_type="application/pdf",
     )
     mock_client.files.upload.return_value = mock_file
-    mock_client.models.generate_content.return_value = mocker.MagicMock(
-        text="document summary",
+    mock_client.interactions.create.return_value = mocker.MagicMock(
+        output_text="document summary",
     )
     mock_client.files.delete.side_effect = Exception("delete failed")
     mock_logger = mocker.patch("summary.logger")

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -731,7 +731,7 @@ def test_summarize_with_document_raises_when_mime_type_none(mocker):
 def test_summarize_with_document_raises_when_upload_returns_none_uri(mocker):
     """Test summarize_with_document raises RetryError when upload_and_wait_for_file returns uri=None.
 
-    Bypasses the service-layer AttributeError so the inline guard in
+    Bypasses the service-layer GeminiIncompleteResponseError so the inline guard in
     summarize_with_document itself is exercised, before interactions.create
     is called.
     """


### PR DESCRIPTION
## Summary

* Migrate all Gemini text-generation calls in `src/summary.py` from `client.models.generate_content` to `client.interactions.create` (the recommended surface in `google-genai` 2.10.0), per vasiliadi/ai-summarizer-telegram-bot#884.
* Drop `SAFETY_SETTINGS`/`GEMINI_CONFIG` from `src/config.py` — the Interactions API rejects `safety_settings` (confirmed against the live API, see issue comments); safety is now handled by the model's built-in filtering.
* Rename `get_gemini_config` → `get_gemini_kwargs` in `src/services.py`: returns a plain `GeminiKwargs` dict (`system_instruction`, `generation_config`, `store=False`) for `**`-unpacking into `interactions.create`, with `thinking_level` lowercased to match the new lowercase literal contract.
* Add a private-path import of the Interactions error hierarchy (`google.genai._gaos.lib.compat_errors.APIError`, aliased `InteractionsAPIError`) into the retry tuples, since 2.10.0 exposes no public path for it. A canary test (`test_interactions_error_hierarchy_has_no_public_import_path`) fails the suite the moment an SDK bump adds a public path, so this doesn't need a manual per-release check.
* Consolidate the three call sites onto one shared `_generate_text` helper (generalized to accept `str | list[Any]`) instead of duplicating the `cast` + `interactions.create` + `output_text` guard three times.

## Why

Staying on `generate_content` means a forced, time-pressured migration once Google removes the legacy surface. See vasiliadi/ai-summarizer-telegram-bot#884 for the full rationale and the `safety_settings` investigation.

## Test plan

- [X] `uvx ruff format .` / `uvx ruff check .` / `uvx ty check .` — all clean
- [X] `uv run pytest --cov` — 235 passed, 100% coverage (1049/1049 statements), no new uncovered lines
- [X] Live smoke test against the real Gemini API (`gemini-3.5-flash`, `store=False`) — confirmed `interaction.output_text` returns as expected
- [X] `/code-review` (high effort, 8 finder angles) run on the branch diff — 1 duplication finding applied (this branch's 3rd commit), 1 commit-message-format finding intentionally left as-is per explicit request

Closes vasiliadi/ai-summarizer-telegram-bot#884.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI summarization reliability by switching Gemini generation to the interactions-based flow for text/audio/document inputs.
  * Strengthened retry handling when Gemini returns empty or incomplete output.
  * Added stricter validation for uploaded document metadata (missing URI/MIME) to stop processing invalid inputs earlier.
* **Refactor**
  * Standardized Gemini generation settings into a kwargs-based interface and aligned summarization codepaths and error handling accordingly.