### PR TITLE
docs: consolidate handoff rules and drop dead guardrail sections in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,17 +12,15 @@ Before your first file edit, ensure you are not on `main`. If you are, create a 
 
 ## Rules
 
-1. Write state to disk, not conversation. After completing meaningful work, record it in the session handoff at `docs/summaries/handoff-[date]-[topic].md` using the Handoff template below — create it on first write, update it as work progresses. Include decisions with rationale, exact numbers, file paths, and open items.
-2. Before compaction or session end, update the active handoff from Rule 1 with every number, every decision with rationale, every open question, every file path, and the exact next action. Do not create a separate recovery or checkpoint artifact.
-3. When switching work types (research → writing → review) or ending the session, finalize the handoff using `.claude/commands/handoff.md` (or follow that file's steps directly if slash commands are unavailable).
-4. Do not silently resolve open questions. Mark unresolved items as OPEN or ASSUMED in the handoff and in the final answer when relevant.
-5. Use `docs/context/processing-protocol.md` for multiple documents, large files, docs dumps, broad research, big diffs, incident traces, or broad codebase exploration. Targeted lookup in a few short files does not require source-summary overhead.
-6. When sub-agents are used, their returns must be structured with exact numbers, file paths, decisions with rationale, and open items — not free-form prose. See `docs/context/subagent-rules.md`.
-7. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.
-8. Pre-commit hooks enforce format/lint/type/test checks at commit time — do not run them manually before committing, and never bypass them with `--no-verify`. When the pytest hook runs, review its coverage output — no new uncovered lines.
-9. When you want to commit, see `docs/context/git-guide.md`. Follow-up fixes go into new commits — never amend, rebase, or otherwise rewrite an existing commit unless the user asks for that directly. Never stage `docs/summaries/` or `docs/archive/` (gitignored); under `docs/`, only `docs/context/` is tracked.
-10. **Never `git push` on your own — a push happens only via the user invoking `/create-pr` or pushing it themselves.**
-11. When changing code, update or add tests in the same PR. Treat test maintenance as mandatory — skipping it is equivalent to bypassing the pre-commit hooks in Rule 8.
+1. **Write state to disk, not conversation.** Record work in the session handoff at `docs/summaries/handoff-[date]-[topic].md` using the Handoff template below — create it on first meaningful write and update it as work progresses, capturing decisions with rationale, exact numbers, file paths, and open items. Before compaction, before switching work types (research → writing → review), and at session end, do a full update: every number, every decision with rationale, every open question, every file path, and the exact next action — finalizing with `.claude/commands/handoff.md` (the `/handoff` command, or follow its steps directly if slash commands are unavailable). Do not create a separate recovery or checkpoint artifact.
+2. **Do not silently resolve open questions.** Mark unresolved items as OPEN or ASSUMED in the handoff and in the final answer when relevant. Before delivering output, verify that exact numbers are preserved and that claims are backed by specific data.
+3. Use `docs/context/processing-protocol.md` for multiple documents, large files, docs dumps, broad research, big diffs, incident traces, or broad codebase exploration. Targeted lookup in a few short files does not require source-summary overhead.
+4. When sub-agents are used, their returns must be structured with exact numbers, file paths, decisions with rationale, and open items — not free-form prose. See `docs/context/subagent-rules.md`.
+5. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.
+6. Pre-commit hooks enforce format/lint/type/test checks at commit time — do not run them manually before committing, and never bypass them with `--no-verify`. When the pytest hook runs, review its coverage output — no new uncovered lines.
+7. When you want to commit, see `docs/context/git-guide.md`. Follow-up fixes go into new commits — never amend, rebase, or otherwise rewrite an existing commit unless the user asks for that directly. Never stage `docs/summaries/` or `docs/archive/` (gitignored); under `docs/`, only `docs/context/` is tracked.
+8. **Never `git push` on your own — a push happens only via the user invoking `/create-pr` or pushing it themselves.**
+9. When changing code, update or add tests in the same PR. Treat test maintenance as mandatory — skipping it is equivalent to bypassing the pre-commit hooks in Rule 6.
 
 ## Handoff Template
 
@@ -74,11 +72,3 @@ Write to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`. Create it after the f
   - `subagent-rules.md` — rules for sub-agent usage and outputs
 - `docs/archive/` — processed raw files. Do not read unless explicitly told. **(gitignored — not committed)**
 - `.claude/commands/` — step-by-step routine for **handoff** (`handoff.md`). Claude Code exposes it as the `/handoff` slash command; agents without slash-command support should read that file and follow the steps directly.
-
-## Error Recovery
-
-If context degrades or auto-compact fires unexpectedly: re-read the active handoff in `docs/summaries/` and verify it against `git status` and `git log`. Do not invent a recovery handoff from degraded context. If disk state is stale or unreliable, say so and suggest a fresh session.
-
-## Before Delivering Output
-
-Before responding, verify that exact numbers are preserved, unresolved questions are marked OPEN or ASSUMED, the output matches the request, claims are backed by specific data, and the handoff status is correct for this session's work.


### PR DESCRIPTION
## Summary
- Collapse the three overlapping handoff-lifecycle rules (old Rules 1-3) into a single Rule 1 covering create-on-first-write, update-as-you-go, and full update before compaction / work-type switch / session end.
- Fold `## Before Delivering Output` into Rule 2 (kept OPEN/ASSUMED discipline + "exact numbers preserved / claims backed by data"); delete the standalone section.
- Delete `## Error Recovery` — its "if context degrades" trigger is effectively dead since an agent can't self-detect context degradation; its durable instruction ("don't invent a recovery artifact") is preserved in Rule 1.
- Renumber remaining rules (old 5-11 -> new 3-9) and fix the one internal cross-reference (tests rule's "Rule 8" -> "Rule 6").
- Net: 11 rules -> 9; two dead/redundant sections removed. Verified no dangling `Rule N` or section-name references remain in `docs/context/` or `.claude/commands/`.

## Test plan
- [x] Docs-only change to `AGENTS.md` — no code, hooks, or dependencies touched, so no test run required.
- [x] `grep -nE "^[0-9]+\." AGENTS.md` confirms rules 1-9, no gaps or duplicates.
- [x] `grep -rn "Before Delivering\|Error Recovery" .` returns no matches repo-wide.
- [x] `/handoff` command pointer still present (2 references: consolidated Rule 1 + Where Things Live).
- [x] `git diff --check` clean; pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project guidance to better define when session handoffs should be created and finalized.
  * Clarified how to handle unresolved items by marking them clearly and verifying exact figures and supporting details.
  * Removed some end-of-document guidance sections, simplifying the overall instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->