### PR TITLE
summary: collapse text-summarize wrappers and drop dead surface

### DIFF
--- a/src/handlers.py
+++ b/src/handlers.py
@@ -12,7 +12,7 @@ from services import (
     get_file_with_retry,
     send_answer,
 )
-from summary import summarize, summarize_webpage, summarize_with_document
+from summary import summarize, summarize_text, summarize_with_document
 from utils import clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
@@ -169,7 +169,7 @@ def handle_url(message: Message, user: UsersOrm, url: str) -> None:
         parsed = parse_url(url)
         answer = format_prefixed_summary(
             parsed.prefix,
-            summarize_webpage(content=parsed.text, **_summary_kwargs(user)),
+            summarize_text(text=parsed.text, **_summary_kwargs(user)),
         )
         send_answer(message, answer)
     else:

--- a/src/main.py
+++ b/src/main.py
@@ -414,14 +414,12 @@ def handle_message(message: Message) -> None:
     - Audio files
     - General text messages
 
+    Catches and maps the pipeline's failure modes to user-facing replies:
+    LimitExceededError, WebParseError, RetryError, and any other Exception are
+    reported to Sentry and answered with an appropriate message.
+
     Args:
         message (Message): The message object from Telegram
-
-    Raises:
-        LimitExceededError: When user exceeds daily limit
-        RetryError: When multiple processing attempts fail
-        WebParseError: When a webpage URL cannot be parsed
-        Exception: For any other unexpected errors
 
     Returns:
         None

--- a/src/services.py
+++ b/src/services.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import logging
 import mimetypes
 import time
-from functools import lru_cache
 from textwrap import dedent
 from typing import TYPE_CHECKING, ClassVar, cast
 
 from google.genai import types
-from limits import parse as _parse_rate_limit
+from limits import parse as parse_rate_limit
 from requests.exceptions import ReadTimeout
 from telebot.apihelper import ApiTelegramException
 from telegramify_markdown import convert, split_entities
@@ -39,7 +38,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
-parse_rate_limit = lru_cache(maxsize=64)(_parse_rate_limit)
 
 
 class Messenger:
@@ -215,12 +213,10 @@ upload_and_wait_for_file = gemini_helper.upload_and_wait_for_file
 __all__ = [
     "PrefixedText",
     "check_quota",
-    "gemini_helper",
     "get_file_with_retry",
     "get_gemini_config",
     "get_remaining_quota",
     "messenger",
-    "quota_manager",
     "resolve_mime_type",
     "send_answer",
     "upload_and_wait_for_file",

--- a/src/summary.py
+++ b/src/summary.py
@@ -139,15 +139,6 @@ class Summarizer:
         before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
         reraise=False,
     )
-    @retry(
-        stop=stop_after_attempt(2),
-        wait=wait_fixed(30),
-        retry=retry_if_exception_type(
-            (ServerError, AttributeError, ClientError),
-        ),
-        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
-        reraise=False,
-    )
     def summarize_text(
         self,
         text: str,

--- a/src/summary.py
+++ b/src/summary.py
@@ -43,24 +43,6 @@ tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 class Summarizer:
     """Generates Gemini-powered summaries from audio, video, documents, and URLs."""
 
-    @staticmethod
-    def _generate_text(
-        prompt: str,
-        model: str,
-        target_language: str,
-        thinking_level: str,
-    ) -> str:
-        """Run a single Gemini text-prompt generation with the standard config."""
-        config = get_gemini_config(target_language, thinking_level=thinking_level)
-        response = gemini_client.models.generate_content(
-            model=model,
-            contents=prompt,
-            config=config,
-        )
-        if response.text is None:
-            raise AttributeError
-        return response.text
-
     @retry(
         stop=stop_after_attempt(2),
         wait=wait_fixed(30),
@@ -157,7 +139,16 @@ class Summarizer:
         before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
         reraise=False,
     )
-    def _summarize_text(
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(30),
+        retry=retry_if_exception_type(
+            (ServerError, AttributeError, ClientError),
+        ),
+        before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
+        reraise=False,
+    )
+    def summarize_text(
         self,
         text: str,
         model: str,
@@ -188,57 +179,15 @@ class Summarizer:
         """
         prompt = (f"{dedent(PROMPTS[prompt_key])} {text}").strip()
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-        return self._generate_text(prompt, model, target_language, thinking_level)
-
-    def summarize_with_transcript(
-        self,
-        transcript: str,
-        model: str,
-        prompt_key: str,
-        target_language: str,
-        user_id: int,
-        daily_limit: int,
-        thinking_level: str,
-    ) -> str:
-        """Generate a summary from a transcript using Gemini API.
-
-        Thin wrapper over :meth:`_summarize_text`; see it for the full contract.
-
-        """
-        return self._summarize_text(
-            transcript,
-            model,
-            prompt_key,
-            target_language,
-            user_id,
-            daily_limit,
-            thinking_level,
+        config = get_gemini_config(target_language, thinking_level=thinking_level)
+        response = gemini_client.models.generate_content(
+            model=model,
+            contents=prompt,
+            config=config,
         )
-
-    def summarize_webpage(
-        self,
-        content: str,
-        model: str,
-        prompt_key: str,
-        target_language: str,
-        user_id: int,
-        daily_limit: int,
-        thinking_level: str,
-    ) -> str:
-        """Generate a summary from pre-parsed webpage content using Gemini API.
-
-        Thin wrapper over :meth:`_summarize_text`; see it for the full contract.
-
-        """
-        return self._summarize_text(
-            content,
-            model,
-            prompt_key,
-            target_language,
-            user_id,
-            daily_limit,
-            thinking_level,
-        )
+        if response.text is None:
+            raise AttributeError
+        return response.text
 
     @retry(
         stop=stop_after_attempt(2),
@@ -390,8 +339,8 @@ class Summarizer:
                 else:
                     return format_prefixed_summary(
                         transcript_result.prefix,
-                        self.summarize_with_transcript(
-                            transcript=transcript_result.text,
+                        self.summarize_text(
+                            text=transcript_result.text,
                             model=model,
                             prompt_key=prompt_key,
                             target_language=target_language,
@@ -422,8 +371,8 @@ class Summarizer:
                 transcription = transcribe(new_file)
                 return format_prefixed_summary(
                     "📝",
-                    self.summarize_with_transcript(
-                        transcript=transcription,
+                    self.summarize_text(
+                        text=transcription,
                         model=model,
                         prompt_key=prompt_key,
                         target_language=target_language,
@@ -450,7 +399,6 @@ summarizer = Summarizer()
 # ---------------------------------------------------------------------------
 
 summarize_with_file = summarizer.summarize_with_file
-summarize_with_transcript = summarizer.summarize_with_transcript
-summarize_webpage = summarizer.summarize_webpage
+summarize_text = summarizer.summarize_text
 summarize_with_document = summarizer.summarize_with_document
 summarize = summarizer.summarize

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -494,6 +494,4 @@ yt_transcriber = YouTubeTranscriber(api_backend, ytdlp_backend)
 # ---------------------------------------------------------------------------
 
 transcribe = audio_transcriber.transcribe
-fetch_transcript_via_api = api_backend.fetch_via_api
-fetch_transcript_via_ytdlp = ytdlp_backend.fetch_via_ytdlp
 get_yt_transcript = yt_transcriber.get_transcript

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -142,12 +142,12 @@ def test_handle_url_unsupported_pattern(message_factory, mocker):
     msg = message_factory(content_type="text", text="This is not a url.")
     mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
     mock_send_message = mocker.patch("main.bot.send_message")
-    mock_summarize_webpage = mocker.patch("handlers.summarize_webpage")
+    mock_summarize_text = mocker.patch("handlers.summarize_text")
 
     handle_message(msg)
 
     mock_send_message.assert_called_once_with(msg.chat.id, "No data to proceed.")
-    mock_summarize_webpage.assert_not_called()
+    mock_summarize_text.assert_not_called()
 
 
 def test_classify_url_uppercase_youtube_host():
@@ -197,8 +197,8 @@ def test_handle_url_other_http_pattern(message_factory, mocker):
         "handlers.parse_url",
         return_value=PrefixedText(text="Parsed page content.", prefix="🌐"),
     )
-    mock_summarize_webpage = mocker.patch(
-        "handlers.summarize_webpage",
+    mock_summarize_text = mocker.patch(
+        "handlers.summarize_text",
         return_value="Summary text.",
     )
     mock_send_answer = mocker.patch("handlers.send_answer")
@@ -206,7 +206,7 @@ def test_handle_url_other_http_pattern(message_factory, mocker):
     handle_message(msg)
 
     mock_parse_url.assert_called_once_with(url)
-    assert mock_summarize_webpage.call_args.kwargs["content"] == "Parsed page content."
+    assert mock_summarize_text.call_args.kwargs["text"] == "Parsed page content."
     answer = mock_send_answer.call_args.args[1]
     assert answer.startswith("🌐")
     assert "Summary text." in answer
@@ -219,7 +219,7 @@ def test_handle_url_web_preflight_blocks_before_parse_url(message_factory, mocke
     mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
     mocker.patch("handlers.check_quota", side_effect=LimitExceededError)
     mock_parse_url = mocker.patch("handlers.parse_url")
-    mock_summarize_webpage = mocker.patch("handlers.summarize_webpage")
+    mock_summarize_text = mocker.patch("handlers.summarize_text")
     mocker.patch("handlers.send_answer")
     mocker.patch("main.bot.reply_to")
     mocker.patch("main.capture_exception")
@@ -227,24 +227,24 @@ def test_handle_url_web_preflight_blocks_before_parse_url(message_factory, mocke
     handle_message(msg)
 
     mock_parse_url.assert_not_called()
-    mock_summarize_webpage.assert_not_called()
+    mock_summarize_text.assert_not_called()
 
 
 def test_handle_url_web_parse_error_skips_summarize(message_factory, mocker):
-    """Test that WebParseError from parse_url short-circuits before summarize_webpage."""
+    """Test that WebParseError from parse_url short-circuits before summarize_text."""
     url = "https://example.com/article"
     msg = message_factory(content_type="text", text=url)
     mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
     mocker.patch("handlers.check_quota", return_value=True)
     mocker.patch("handlers.parse_url", side_effect=WebParseError("boom"))
-    mock_summarize_webpage = mocker.patch("handlers.summarize_webpage")
+    mock_summarize_text = mocker.patch("handlers.summarize_text")
     mocker.patch("handlers.send_answer")
     mocker.patch("main.bot.reply_to")
     mocker.patch("main.capture_exception")
 
     handle_message(msg)
 
-    mock_summarize_webpage.assert_not_called()
+    mock_summarize_text.assert_not_called()
 
 
 def test_handle_voice_happy_path(message_factory, mocker):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -10,10 +10,9 @@ from exceptions import FetchTranscriptError, LimitExceededError
 from summary import (
     format_prefixed_summary,
     summarize,
-    summarize_webpage,
+    summarize_text,
     summarize_with_document,
     summarize_with_file,
-    summarize_with_transcript,
 )
 
 
@@ -95,16 +94,16 @@ def test_summarize_with_file_retries_on_missing_upload_metadata(mocker):
         )
 
 
-def test_summarize_with_transcript(mocker):
-    """Test summarize_with_transcript functionality."""
+def test_summarize_text_from_transcript(mocker):
+    """Test summarize_text feeds a transcript to Gemini."""
     mocker.patch("summary.check_quota", return_value=True)
     mock_client = mocker.patch("summary.gemini_client")
     mock_client.models.generate_content.return_value = mocker.MagicMock(
         text="Transcript summary.",
     )
 
-    result = summarize_with_transcript(
-        transcript="Hello world. This is a transcript.",
+    result = summarize_text(
+        text="Hello world. This is a transcript.",
         model="test-model",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
@@ -121,16 +120,16 @@ def test_format_prefixed_summary_preserves_blank_line():
     assert format_prefixed_summary("📹", "\n- one\n- two\n") == "📹\n\n- one\n- two"
 
 
-def test_summarize_webpage(mocker):
-    """Test summarize_webpage feeds pre-parsed content to Gemini."""
+def test_summarize_text_from_webpage(mocker):
+    """Test summarize_text feeds pre-parsed webpage content to Gemini."""
     mocker.patch("summary.check_quota", return_value=True)
     mock_client = mocker.patch("summary.gemini_client")
     mock_client.models.generate_content.return_value = mocker.MagicMock(
         text="Webpage summary.",
     )
 
-    result = summarize_webpage(
-        content="Parsed page content.",
+    result = summarize_text(
+        text="Parsed page content.",
         model="test-model",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
@@ -166,7 +165,7 @@ def test_summarize_with_file_upload_failure(mocker):
 
 
 def test_summarize_genai_exception(mocker):
-    """Test summarize_with_transcript raises RetryError when Gemini crashes."""
+    """Test summarize_text raises RetryError when Gemini crashes."""
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
@@ -182,8 +181,8 @@ def test_summarize_genai_exception(mocker):
     )
 
     with pytest.raises(RetryError):
-        summarize_with_transcript(
-            transcript="Hello",
+        summarize_text(
+            text="Hello",
             model="test-model",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
@@ -267,7 +266,7 @@ def test_summarize_youtube_always_attempts_transcript(mocker):
     )
     mocker.patch.object(
         summary_module.summarizer,
-        "summarize_with_transcript",
+        "summarize_text",
         return_value="Summary",
     )
 
@@ -294,7 +293,7 @@ def test_summarize_youtube_direct_transcript(mocker):
     )
     mock_sum_transcript = mocker.patch.object(
         summary_module.summarizer,
-        "summarize_with_transcript",
+        "summarize_text",
         return_value="- first point\n- second point",
     )
 
@@ -311,7 +310,7 @@ def test_summarize_youtube_direct_transcript(mocker):
     assert result.startswith("📹")
     assert result == "📹\n\n- first point\n- second point"
     mock_sum_transcript.assert_called_once_with(
-        transcript="YT Transcript content",
+        text="YT Transcript content",
         model="test-model",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
@@ -331,7 +330,7 @@ def test_summarize_youtube_fallback_transcript_uses_fallback_prefix(mocker):
     )
     mocker.patch.object(
         summary_module.summarizer,
-        "summarize_with_transcript",
+        "summarize_text",
         return_value="- first point\n- second point",
     )
 
@@ -365,7 +364,7 @@ def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
     mock_transcribe = mocker.patch("summary.transcribe")
     mocker.patch.object(
         summary_module.summarizer,
-        "summarize_with_transcript",
+        "summarize_text",
         side_effect=retry_error,
     )
 
@@ -441,7 +440,7 @@ def test_summarize_fallback_to_transcription(mocker):
     mocker.patch("summary.transcribe", return_value="Transcription text")
     mocker.patch.object(
         summary_module.summarizer,
-        "summarize_with_transcript",
+        "summarize_text",
         return_value="- transcript point\n- follow-up point",
     )
     mock_clean_up = mocker.patch("summary.clean_up")
@@ -621,16 +620,16 @@ def test_summarize_with_file_logs_warning_on_delete_failure(mocker):
     mock_logger.warning.assert_called_once()
 
 
-def test_summarize_with_transcript_raises_on_empty_response(mocker):
-    """Test summarize_with_transcript raises RetryError on repeated empty Gemini responses."""
+def test_summarize_text_raises_on_empty_response(mocker):
+    """Test summarize_text raises RetryError on repeated empty Gemini responses."""
     mocker.patch("summary.check_quota", return_value=True)
     mocker.patch("tenacity.nap.time.sleep")
     mock_client = mocker.patch("summary.gemini_client")
     mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
 
     with pytest.raises(RetryError):
-        summarize_with_transcript(
-            transcript="Hello world",
+        summarize_text(
+            text="Hello world",
             model="test-model",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -24,8 +24,6 @@ from transcription import (
     AudioTranscriber,
     YouTubeTranscriber,
     YtDlpBackend,
-    fetch_transcript_via_api,
-    fetch_transcript_via_ytdlp,
     get_yt_transcript,
 )
 
@@ -194,7 +192,7 @@ def test_fetch_transcript_via_api_falls_back_to_other_languages(mocker):
 
     mock_formatter.return_value.format_transcript.return_value = "Hola"
 
-    result = fetch_transcript_via_api("dQw4w9WgXcQ")
+    result = transcription.api_backend.fetch_via_api("dQw4w9WgXcQ")
 
     assert result == "Hola"
     # Verify it was called twice, once without languages, once with languages
@@ -310,7 +308,7 @@ def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     ).return_value.format_transcript.return_value = "Hello"
     mock_ytt.return_value.fetch.return_value = []
 
-    result = fetch_transcript_via_api("vid")
+    result = transcription.api_backend.fetch_via_api("vid")
 
     assert result == "Hello"
     mock_proxy_cfg.assert_called_once_with(https_url="http://proxy:8080")
@@ -332,7 +330,9 @@ def test_fetch_transcript_via_ytdlp_download_error_logged_and_retried(mocker, tm
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(RetryError):
-        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+        transcription.ytdlp_backend.fetch_via_ytdlp(
+            "https://www.youtube.com/watch?v=test",
+        )
 
     assert ctx.download.call_count == 2
     mock_logger.warning.assert_any_call(
@@ -360,7 +360,9 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_and_retried(
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(RetryError):
-        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+        transcription.ytdlp_backend.fetch_via_ytdlp(
+            "https://www.youtube.com/watch?v=test",
+        )
 
     assert ctx.download.call_count == 2
     mock_logger.warning.assert_any_call(
@@ -385,7 +387,9 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp
     ctx.download.side_effect = original_exc
 
     with pytest.raises(RetryError) as exc_info:
-        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+        transcription.ytdlp_backend.fetch_via_ytdlp(
+            "https://www.youtube.com/watch?v=test",
+        )
 
     last_exc = exc_info.value.last_attempt.exception()
     assert isinstance(last_exc, TranscriptDownloadError)
@@ -406,7 +410,9 @@ def test_fetch_transcript_via_ytdlp_probe_download_error_logged_and_retried(
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(RetryError):
-        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+        transcription.ytdlp_backend.fetch_via_ytdlp(
+            "https://www.youtube.com/watch?v=test",
+        )
 
     assert ctx.extract_info.call_count == 2
     mock_logger.warning.assert_any_call(
@@ -432,7 +438,9 @@ def test_fetch_transcript_via_ytdlp_probe_unexpected_error_wrapped_and_retried(
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(RetryError) as exc_info:
-        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+        transcription.ytdlp_backend.fetch_via_ytdlp(
+            "https://www.youtube.com/watch?v=test",
+        )
 
     last_exc = exc_info.value.last_attempt.exception()
     assert isinstance(last_exc, TranscriptDownloadError)
@@ -480,7 +488,9 @@ def test_fetch_transcript_via_ytdlp_succeeds_on_second_attempt(mocker, tmp_path)
 
     mocker.patch("transcription.YoutubeDL", MockYDL)
 
-    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+        "https://www.youtube.com/watch?v=test",
+    )
 
     assert result == "Hello"
     assert MockYDL.attempt == 2
@@ -493,7 +503,7 @@ def test_fetch_transcript_via_api_propagates_non_retryable_error(mocker):
     mock_ytt.return_value.fetch.side_effect = TranscriptsDisabled("vid")
 
     with pytest.raises(TranscriptsDisabled):
-        fetch_transcript_via_api("vid")
+        transcription.api_backend.fetch_via_api("vid")
 
 
 @pytest.mark.parametrize(
@@ -514,7 +524,7 @@ def test_fetch_transcript_via_api_retries_on_retryable_exception(mocker, exc):
     mock_ytt.return_value.fetch.side_effect = exc
 
     with pytest.raises(RetryError):
-        fetch_transcript_via_api("vid")
+        transcription.api_backend.fetch_via_api("vid")
 
     assert mock_ytt.return_value.fetch.call_count == 2
 
@@ -550,7 +560,9 @@ def test_fetch_transcript_via_ytdlp_non_english_fallback(mocker, tmp_path):
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+        "https://www.youtube.com/watch?v=test",
+    )
 
     assert result == "Bonjour"
     assert download_calls == [["fr"]]
@@ -587,7 +599,9 @@ def test_fetch_transcript_via_ytdlp_prefers_english_when_available(mocker, tmp_p
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+        "https://www.youtube.com/watch?v=test",
+    )
 
     assert result == "Hello"
     assert download_calls == [["en"]]
@@ -637,7 +651,9 @@ def test_fetch_transcript_via_ytdlp_manual_prefers_original_language_over_first_
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+        "https://www.youtube.com/watch?v=test",
+    )
 
     assert result == "Guten Tag"
     assert download_calls == [["de"]]
@@ -686,7 +702,9 @@ def test_fetch_transcript_via_ytdlp_auto_captions_uses_original_language(
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+        "https://www.youtube.com/watch?v=test",
+    )
 
     assert result == "Bonjour"
     assert download_calls == [["fr"]]
@@ -734,7 +752,9 @@ def test_fetch_transcript_via_ytdlp_auto_captions_prefers_orig_key_when_language
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+        "https://www.youtube.com/watch?v=test",
+    )
 
     assert result == "Hallo"
     assert download_calls == [["de-orig"]]
@@ -782,7 +802,9 @@ def test_fetch_transcript_via_ytdlp_auto_captions_falls_back_to_first_key(
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+        "https://www.youtube.com/watch?v=test",
+    )
 
     assert result == "Hola"
     assert download_calls == [["es"]]
@@ -828,7 +850,9 @@ def test_fetch_transcript_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_p
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+        "https://www.youtube.com/watch?v=test",
+    )
 
     assert result == "Bonjour"
     assert download_calls == [["fr"]]
@@ -843,7 +867,9 @@ def test_fetch_transcript_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path
     ctx.extract_info.return_value = {"subtitles": {}, "automatic_captions": {}}
 
     with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
-        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+        transcription.ytdlp_backend.fetch_via_ytdlp(
+            "https://www.youtube.com/watch?v=test",
+        )
 
     ctx.download.assert_not_called()
 
@@ -857,7 +883,9 @@ def test_fetch_transcript_via_ytdlp_extract_info_none_raises(mocker, tmp_path):
     ctx.extract_info.return_value = None
 
     with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
-        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+        transcription.ytdlp_backend.fetch_via_ytdlp(
+            "https://www.youtube.com/watch?v=test",
+        )
 
     ctx.download.assert_not_called()
 
@@ -881,7 +909,9 @@ def test_fetch_transcript_via_ytdlp_vtt_read_error_raises_download_error(
     mocker.patch.object(YtDlpBackend, "_vtt_to_text", side_effect=OSError("disk full"))
 
     with pytest.raises(DownloadError, match="Failed to read downloaded VTT file"):
-        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+        transcription.ytdlp_backend.fetch_via_ytdlp(
+            "https://www.youtube.com/watch?v=test",
+        )
 
 
 def test_fetch_transcript_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_path):
@@ -898,7 +928,9 @@ def test_fetch_transcript_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_pat
     # download() succeeds but writes nothing to tmp_path
 
     with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
-        fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+        transcription.ytdlp_backend.fetch_via_ytdlp(
+            "https://www.youtube.com/watch?v=test",
+        )
 
     ctx.download.assert_called_once()
 
@@ -926,7 +958,7 @@ def test_fetch_transcript_via_ytdlp_pins_proxy_across_probe_and_download(
         "automatic_captions": {},
     }
 
-    fetch_transcript_via_ytdlp("https://www.youtube.com/watch?v=test")
+    transcription.ytdlp_backend.fetch_via_ytdlp("https://www.youtube.com/watch?v=test")
 
     assert mock_ydl_cls.call_count == 2
     probe_opts, download_opts = (call.args[0] for call in mock_ydl_cls.call_args_list)

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -174,8 +174,8 @@ def test_get_yt_transcript_unknown_url(mocker):
     mock_ytdlp.assert_not_called()
 
 
-def test_fetch_transcript_via_api_falls_back_to_other_languages(mocker):
-    """Test fetch_transcript_via_api retries other languages on NoTranscriptFound."""
+def test_fetch_via_api_falls_back_to_other_languages(mocker):
+    """Test fetch_via_api retries other languages on NoTranscriptFound."""
     mocker.patch("transcription.time.sleep")  # don't actually wait 60s
     mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
     mock_formatter = mocker.patch("transcription.TextFormatter")
@@ -298,8 +298,8 @@ def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
     assert result == "Hello\nWorld\nHello"
 
 
-def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
-    """Test fetch_transcript_via_api passes GenericProxyConfig when PROXY is set."""
+def test_fetch_via_api_uses_proxy_when_configured(mocker):
+    """Test fetch_via_api passes GenericProxyConfig when PROXY is set."""
     mocker.patch("transcription.get_proxy", return_value="http://proxy:8080")
     mock_proxy_cfg = mocker.patch("transcription.GenericProxyConfig")
     mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
@@ -315,8 +315,8 @@ def test_fetch_transcript_via_api_uses_proxy_when_configured(mocker):
     mock_ytt.assert_called_once_with(proxy_config=mock_proxy_cfg.return_value)
 
 
-def test_fetch_transcript_via_ytdlp_download_error_logged_and_retried(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp retries DownloadError from yt-dlp twice then raises RetryError."""
+def test_fetch_via_ytdlp_download_error_logged_and_retried(mocker, tmp_path):
+    """Test fetch_via_ytdlp retries DownloadError from yt-dlp twice then raises RetryError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
@@ -342,11 +342,11 @@ def test_fetch_transcript_via_ytdlp_download_error_logged_and_retried(mocker, tm
     )
 
 
-def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_and_retried(
+def test_fetch_via_ytdlp_unexpected_error_wrapped_and_retried(
     mocker,
     tmp_path,
 ):
-    """Test fetch_transcript_via_ytdlp wraps non-DownloadError exceptions and retries."""
+    """Test fetch_via_ytdlp wraps non-DownloadError exceptions and retries."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
@@ -372,8 +372,8 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_wrapped_and_retried(
     )
 
 
-def test_fetch_transcript_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp preserves original cause through RetryError on exhaustion."""
+def test_fetch_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp_path):
+    """Test fetch_via_ytdlp preserves original cause through RetryError on exhaustion."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
@@ -396,11 +396,11 @@ def test_fetch_transcript_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp
     assert last_exc.__cause__ is original_exc
 
 
-def test_fetch_transcript_via_ytdlp_probe_download_error_logged_and_retried(
+def test_fetch_via_ytdlp_probe_download_error_logged_and_retried(
     mocker,
     tmp_path,
 ):
-    """Test fetch_transcript_via_ytdlp retries probe DownloadError twice then raises RetryError."""
+    """Test fetch_via_ytdlp retries probe DownloadError twice then raises RetryError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
@@ -423,11 +423,11 @@ def test_fetch_transcript_via_ytdlp_probe_download_error_logged_and_retried(
     ctx.download.assert_not_called()
 
 
-def test_fetch_transcript_via_ytdlp_probe_unexpected_error_wrapped_and_retried(
+def test_fetch_via_ytdlp_probe_unexpected_error_wrapped_and_retried(
     mocker,
     tmp_path,
 ):
-    """Test fetch_transcript_via_ytdlp wraps and retries unexpected errors from extract_info."""
+    """Test fetch_via_ytdlp wraps and retries unexpected errors from extract_info."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
@@ -454,8 +454,8 @@ def test_fetch_transcript_via_ytdlp_probe_unexpected_error_wrapped_and_retried(
     ctx.download.assert_not_called()
 
 
-def test_fetch_transcript_via_ytdlp_succeeds_on_second_attempt(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp returns transcript when first probe fails but second succeeds."""
+def test_fetch_via_ytdlp_succeeds_on_second_attempt(mocker, tmp_path):
+    """Test fetch_via_ytdlp returns transcript when first probe fails but second succeeds."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.clean_up")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
@@ -496,8 +496,8 @@ def test_fetch_transcript_via_ytdlp_succeeds_on_second_attempt(mocker, tmp_path)
     assert MockYDL.attempt == 2
 
 
-def test_fetch_transcript_via_api_propagates_non_retryable_error(mocker):
-    """Test fetch_transcript_via_api propagates CouldNotRetrieveTranscript subclasses."""
+def test_fetch_via_api_propagates_non_retryable_error(mocker):
+    """Test fetch_via_api propagates CouldNotRetrieveTranscript subclasses."""
     mocker.patch("transcription.get_proxy", return_value="")
     mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
     mock_ytt.return_value.fetch.side_effect = TranscriptsDisabled("vid")
@@ -517,8 +517,8 @@ def test_fetch_transcript_via_api_propagates_non_retryable_error(mocker):
         ChunkedEncodingError(),
     ],
 )
-def test_fetch_transcript_via_api_retries_on_retryable_exception(mocker, exc):
-    """Test fetch_transcript_via_api retries on each retryable exception then raises RetryError."""
+def test_fetch_via_api_retries_on_retryable_exception(mocker, exc):
+    """Test fetch_via_api retries on each retryable exception then raises RetryError."""
     mocker.patch("time.sleep")
     mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
     mock_ytt.return_value.fetch.side_effect = exc
@@ -529,8 +529,8 @@ def test_fetch_transcript_via_api_retries_on_retryable_exception(mocker, exc):
     assert mock_ytt.return_value.fetch.call_count == 2
 
 
-def test_fetch_transcript_via_ytdlp_non_english_fallback(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp requests the available language when no English is offered."""
+def test_fetch_via_ytdlp_non_english_fallback(mocker, tmp_path):
+    """Test fetch_via_ytdlp requests the available language when no English is offered."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.clean_up")
 
@@ -568,8 +568,8 @@ def test_fetch_transcript_via_ytdlp_non_english_fallback(mocker, tmp_path):
     assert download_calls == [["fr"]]
 
 
-def test_fetch_transcript_via_ytdlp_prefers_english_when_available(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp picks English even when other languages are present."""
+def test_fetch_via_ytdlp_prefers_english_when_available(mocker, tmp_path):
+    """Test fetch_via_ytdlp picks English even when other languages are present."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.clean_up")
 
@@ -607,7 +607,7 @@ def test_fetch_transcript_via_ytdlp_prefers_english_when_available(mocker, tmp_p
     assert download_calls == [["en"]]
 
 
-def test_fetch_transcript_via_ytdlp_manual_prefers_original_language_over_first_key(
+def test_fetch_via_ytdlp_manual_prefers_original_language_over_first_key(
     mocker,
     tmp_path,
 ):
@@ -659,11 +659,11 @@ def test_fetch_transcript_via_ytdlp_manual_prefers_original_language_over_first_
     assert download_calls == [["de"]]
 
 
-def test_fetch_transcript_via_ytdlp_auto_captions_uses_original_language(
+def test_fetch_via_ytdlp_auto_captions_uses_original_language(
     mocker,
     tmp_path,
 ):
-    """Test fetch_transcript_via_ytdlp requests the original language, not translated English.
+    """Test fetch_via_ytdlp requests the original language, not translated English.
 
     automatic_captions list machine translations (incl. "en") for ~every language,
     so for a non-English video with no manual subs we must request the original
@@ -710,7 +710,7 @@ def test_fetch_transcript_via_ytdlp_auto_captions_uses_original_language(
     assert download_calls == [["fr"]]
 
 
-def test_fetch_transcript_via_ytdlp_auto_captions_prefers_orig_key_when_language_missing(
+def test_fetch_via_ytdlp_auto_captions_prefers_orig_key_when_language_missing(
     mocker,
     tmp_path,
 ):
@@ -760,7 +760,7 @@ def test_fetch_transcript_via_ytdlp_auto_captions_prefers_orig_key_when_language
     assert download_calls == [["de-orig"]]
 
 
-def test_fetch_transcript_via_ytdlp_auto_captions_falls_back_to_first_key(
+def test_fetch_via_ytdlp_auto_captions_falls_back_to_first_key(
     mocker,
     tmp_path,
 ):
@@ -810,8 +810,8 @@ def test_fetch_transcript_via_ytdlp_auto_captions_falls_back_to_first_key(
     assert download_calls == [["es"]]
 
 
-def test_fetch_transcript_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp skips the "live_chat" subtitles entry.
+def test_fetch_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_path):
+    """Test fetch_via_ytdlp skips the "live_chat" subtitles entry.
 
     yt-dlp lists a "live_chat" key under subtitles for live-stream replays; it is
     not a real subtitle track. It must be ignored so selection falls through to the
@@ -858,8 +858,8 @@ def test_fetch_transcript_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_p
     assert download_calls == [["fr"]]
 
 
-def test_fetch_transcript_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp raises without calling download when no subtitles exist."""
+def test_fetch_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path):
+    """Test fetch_via_ytdlp raises without calling download when no subtitles exist."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
@@ -874,8 +874,8 @@ def test_fetch_transcript_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path
     ctx.download.assert_not_called()
 
 
-def test_fetch_transcript_via_ytdlp_extract_info_none_raises(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp raises when extract_info returns None."""
+def test_fetch_via_ytdlp_extract_info_none_raises(mocker, tmp_path):
+    """Test fetch_via_ytdlp raises when extract_info returns None."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
@@ -890,11 +890,11 @@ def test_fetch_transcript_via_ytdlp_extract_info_none_raises(mocker, tmp_path):
     ctx.download.assert_not_called()
 
 
-def test_fetch_transcript_via_ytdlp_vtt_read_error_raises_download_error(
+def test_fetch_via_ytdlp_vtt_read_error_raises_download_error(
     mocker,
     tmp_path,
 ):
-    """Test fetch_transcript_via_ytdlp converts vtt_to_text OSError into DownloadError."""
+    """Test fetch_via_ytdlp converts vtt_to_text OSError into DownloadError."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("transcription.clean_up")
@@ -914,8 +914,8 @@ def test_fetch_transcript_via_ytdlp_vtt_read_error_raises_download_error(
         )
 
 
-def test_fetch_transcript_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_path):
-    """Test fetch_transcript_via_ytdlp raises when download writes no vtt file."""
+def test_fetch_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_path):
+    """Test fetch_via_ytdlp raises when download writes no vtt file."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("transcription.clean_up")
@@ -935,11 +935,11 @@ def test_fetch_transcript_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_pat
     ctx.download.assert_called_once()
 
 
-def test_fetch_transcript_via_ytdlp_pins_proxy_across_probe_and_download(
+def test_fetch_via_ytdlp_pins_proxy_across_probe_and_download(
     mocker,
     tmp_path,
 ):
-    """Test fetch_transcript_via_ytdlp resolves the proxy once and reuses it for both YoutubeDL instances."""
+    """Test fetch_via_ytdlp resolves the proxy once and reuses it for both YoutubeDL instances."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.clean_up")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)


### PR DESCRIPTION
## Summary
- Collapsed the 4-method text-summarize chain in `summary.py` (`_generate_text` → `_summarize_text` → two byte-identical wrappers `summarize_with_transcript`/`summarize_webpage`) into one public `summarize_text`; updated all callers, the module alias, `handlers.py`, and tests.
- Removed dead surface: `lru_cache` micro-opt on `parse_rate_limit`, unused `quota_manager`/`gemini_helper` entries in `services.__all__`, and test-only `fetch_transcript_via_api`/`fetch_transcript_via_ytdlp` aliases in `transcription.py`.
- Fixed `handle_message`'s docstring, which listed exceptions it catches as exceptions it raises.
- Follow-up commit fixes a duplicate `@retry` decorator left behind on `summarize_text` when `_summarize_text`'s body was inlined (harmless today — the inner `RetryError` doesn't match the outer's retry predicate — but a latent hazard if the retry set ever changes).

Left untouched per author's call: the single-model selection machinery (`MODEL_LABELS` etc.) is intentional — models are added/removed over time — and the `TranscriptBackend.fetch(url, video_id)` uniform two-arg interface, where fixing the unused-arg smell would trade a `# noqa` for real special-casing in the orchestrator.

## Test plan
- [x] `uv run pytest` — 231 passed
- [x] 100% line coverage maintained on all changed modules (`summary.py`, `services.py`, `transcription.py`, `handlers.py`, `main.py`)
- [x] Repo-wide grep confirms no remaining importers of any removed symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text summarization is now consistent across webpage, transcript, and fallback inputs.
* **Bug Fixes**
  * URL-based summaries now run through the updated text-based summarization path, including correct handling for quota blocking and parse failures.
* **Refactor**
  * Consolidated the summarization entry point to `summarize_text`, removing older convenience helpers for transcript/webpage.
  * Removed non-public transcript fetch aliases from module exports.
* **Tests**
  * Updated automated tests to match the new summarization entry point and the revised transcription test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->