### PR TITLE
docs: refresh style-guide after OOP rewrite

### DIFF
--- a/docs/context/style-guide.md
+++ b/docs/context/style-guide.md
@@ -32,8 +32,8 @@ Use `# noqa` sparingly and always specify the exact rule code.
 
 ## Error Handling & Logging
 
-- **Custom exceptions** for domain-specific errors (e.g. `MessageTooLongError`,
-  `SummarizationError`); inherit from `ValueError` or `Exception`.
+- **Custom exceptions** for domain-specific errors (e.g. `LimitExceededError`,
+  `WebParseError`); inherit from `ValueError` or `Exception`.
 - Only catch exceptions you can handle gracefully; let unexpected programming errors propagate.
   Never use a bare `except:`.
 - **PEP 758 (Python 3.14+):** for a tuple of exception types with no `as` binding, `ruff format`
@@ -54,6 +54,17 @@ Use `# noqa` sparingly and always specify the exact rule code.
 - Modern syntax: `|` over `Union`, `Type | None` over `Optional[Type]`, built-in generics
   (`dict[str, Any]`, `list[int]`).
 - For circular-import types, use `from __future__ import annotations` and `if TYPE_CHECKING:` blocks.
+
+## Classes
+
+Service modules follow the class → module-singleton → method-alias pattern documented in
+`docs/context/architecture.md` (Cross-cutting patterns); don't restate it here. Beyond that:
+
+- `@staticmethod` is reserved for **private** helpers (`_name`) that need no instance state.
+  Public methods keep `self` even when they don't use it — they form the aliased singleton
+  surface (`check_quota = quota_manager.check_quota`), so they must stay bound methods.
+- Annotate class-level constants with `ClassVar`, e.g.
+  `_EXT_MIME_FALLBACK: ClassVar[dict[str, str]]`.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Replace fictional exception examples (`MessageTooLongError`, `SummarizationError`) in the Error Handling section with real ones from `src/exceptions.py` (`LimitExceededError`, `WebParseError`)
- Add a new **Classes** section documenting the Ruff-unenforced OOP conventions the code already follows: `@staticmethod` reserved for private helpers, `ClassVar` for class-level constants — cross-referencing the singleton/alias pattern already documented in `architecture.md` rather than duplicating it

## Why
Investigated whether `docs/context/style-guide.md` went stale after the OOP rewrite (#863). It didn't — the doc predates and already anticipated the rewrite — but the check surfaced two accuracy gaps: nonexistent exception names as examples, and an undocumented-but-consistently-followed class convention.

The `@staticmethod` wording went through one self-review round: an initial draft said "@staticmethod for methods that don't use self," which a scan of `src/` showed was backwards (17 public methods intentionally keep an unused `self` to support the singleton+alias pattern; all 7 actual `@staticmethod`s are private helpers). Corrected before committing.

## Test plan
- [x] `grep -n "MessageTooLongError\|SummarizationError" docs/context/style-guide.md` → no hits
- [x] Verified `@staticmethod`/`ClassVar` claims against `src/*.py` via AST scan (7 static methods, all private; 17 unused-`self` public methods, all part of the alias surface)
- [x] Pre-commit hooks passed (docs-only change, no code/test impact)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the style guide examples for error handling and logging with revised exception names.
  * Added clearer guidance on class organization, including module structure and method patterns.
  * Clarified when to use `@staticmethod`.
  * Added a requirement to type class-level constants with `ClassVar`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->