### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,8 @@
 name: Linting
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/4](https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/linting.yml` at the workflow root level (top-level, alongside `name` and `on`) so it applies to all jobs unless overridden. For this lint-only workflow, the minimal required permission is:

- `contents: read`

This preserves existing functionality (checkout and read-only linting) while preventing unintended broader token access. No imports, methods, or dependencies are needed—only YAML configuration update in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the repository’s automation settings to use more restricted access for workflow runs, improving security with no expected user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->