### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,6 +2,9 @@ name: Run tests and upload coverage
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests and collect coverage


### PR DESCRIPTION
Potential fix for [https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/1](https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.

Best fix here: add a root-level permission block immediately after `on: push`:

- `permissions:`
  - `contents: read`

This is sufficient for the shown steps and follows CodeQL’s minimal recommendation. It does not change workflow behavior except to constrain token scope.

File to edit:
- `.github/workflows/codecov.yml`
- Insert the block between current lines 3 and 5 (after `on: push`, before `jobs:`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to allow read access to repository contents for the Codecov automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->