### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   typechecking:
     name: Type checking


### PR DESCRIPTION
Potential fix for [https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/3](https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions with `contents: read`, since all shown jobs/steps are read-only (checkout + dependency install + type check). This preserves functionality while making permissions explicit and stable across repo/org defaults.

Edit **`.github/workflows/typechecking.yml`**:
- Insert a root-level `permissions:` block between `on:` and `jobs:`.
- Set:
  - `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to use read-only repository permissions, reducing access scope during workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->