### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sentry_release.yml
+++ b/.github/workflows/sentry_release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   push_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/2](https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted instead of inheriting repository/org defaults. The safest minimal fix that preserves behavior is to set `contents: read` at the workflow root (applies to all jobs unless overridden). This satisfies CodeQL’s recommendation and keeps checkout/release metadata access working without granting write privileges.

Change only `.github/workflows/sentry_release.yml`, near the top-level keys: insert `permissions:` between `on:` and `jobs:` (or before `jobs:`) with `contents: read`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow’s repository access to use a more limited permission scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->