### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,5 +1,4 @@
 import logging
-from urllib.parse import urlparse
 
 import pytest
 from tavily.errors import TimeoutError as TavilyTimeoutError
@@ -432,15 +431,10 @@ def test_resolve_blocks_non_public_initial_url(mocker, caplog):
 
 def test_resolve_blocks_redirect_to_private_host(mocker, caplog):
     """Test resolve returns the original URL when a redirect lands on a private host."""
-
-    def _is_example_host(u):
-        host = urlparse(u).hostname
-        return bool(host) and (host == "example.com" or host.endswith(".example.com"))
-
     mocker.patch.object(
         parsing.UrlResolver,
         "_is_public",
-        side_effect=_is_example_host,
+        side_effect=[True, False],  # public initial URL, private redirect
     )
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="http://169.254.169.254/latest/meta-data/")

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlparse
 
 import pytest
 from tavily.errors import TimeoutError as TavilyTimeoutError
@@ -431,10 +432,15 @@ def test_resolve_blocks_non_public_initial_url(mocker, caplog):
 
 def test_resolve_blocks_redirect_to_private_host(mocker, caplog):
     """Test resolve returns the original URL when a redirect lands on a private host."""
+
+    def _is_example_host(u):
+        host = urlparse(u).hostname
+        return bool(host) and (host == "example.com" or host.endswith(".example.com"))
+
     mocker.patch.object(
         parsing.UrlResolver,
         "_is_public",
-        side_effect=lambda u: "example.com" in u,
+        side_effect=_is_example_host,
     )
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="http://169.254.169.254/latest/meta-data/")


### PR DESCRIPTION
Potential fix for [https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/5](https://github.com/vasiliadi/ai-summarizer-telegram-bot/security/code-scanning/5)

To fix this safely, parse the URL and check the hostname explicitly instead of checking whether a trusted domain appears as a substring anywhere in the URL string.

Best minimal fix in `tests/test_parsing.py`:
- Add `urlparse` import from `urllib.parse`.
- In `test_resolve_blocks_redirect_to_private_host`, replace the lambda `side_effect=lambda u: "example.com" in u` with a helper that:
  - parses `u` via `urlparse(u).hostname`
  - returns `True` only for `example.com` and its subdomains (e.g., `*.example.com`)
  - returns `False` when hostname is missing.

This preserves test intent (initial `https://example.com/start` is public, redirect to link-local IP is blocked) while removing incomplete substring sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for redirect handling by making the “public vs. private host” check deterministic across multiple evaluations, ensuring redirects to private hosts are reliably detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->