### PR TITLE
docker: disable modal build validation in builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS builder
 ENV ENV=BUILD \
-    PATH="/app/.venv/bin:$PATH"
+    PATH="/app/.venv/bin:$PATH" \
+    MODAL_BUILD_VALIDATION=ignore
 ARG DSN
 ARG MODAL_TOKEN_ID
 ARG MODAL_TOKEN_SECRET


### PR DESCRIPTION
## What

Set `MODAL_BUILD_VALIDATION=ignore` in the builder stage's `ENV` block (`Dockerfile:3`).

## Why

The deploy build failed at `[builder 6/6]`:

```
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ /app/scripts/cron.py was modified during build process.                      │
╰──────────────────────────────────────────────────────────────────────────────╯
Build Failed: ... exit code: 1
```

`modal deploy` mounts the local `.py` files and, for each one, compares `st_mtime` against the moment the deploy started (`modal/mount.py:524-531`; baseline taken from a tempfile mtime in `modal/_resolver.py:23-26`). The check exists to catch a user editing sources locally while a build is in flight. Inside an immutable Docker layer that cannot happen, so any hit is a false positive from clock skew between the uploaded build context and the builder.

The log supports that: context unpacked at `04:13:37.6`, `alembic upgrade head` finished `04:13:46.8`, modal errored `04:13:49.6` — so the flagged mtime was ~10s ahead of the builder's clock. The setting defaults to `error` (`modal/config.py:298`, accepts `error|warn|ignore`), hence the hard failure.

## Reviewer notes

- Scoped to the `builder` stage only; the runtime stage installs with `--no-group modal` and never runs modal.
- Not verified locally — building requires the `DSN`, `MODAL_TOKEN_ID`, and `MODAL_TOKEN_SECRET` build args. Verification is the next deploy getting past `[builder 6/6]`.
- Root cause of the skew (fly.io context snapshot vs. Metal builder clock) is inferred from log timestamps, not proven. The fix holds either way.
- No tests or `docs/context/` updates: Dockerfile-only change, no architecture or convention impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build configuration to support the latest build validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->