### PR TITLE
tests: cover dotenv-skip branch in PROD

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,11 +50,19 @@ def test_dotenv_skipped_in_prod(monkeypatch, mocker):
     so it would trigger the opposite branch. Patch dotenv.load_dotenv at the
     source — the name is only bound into config's namespace when the import
     inside the skipped block runs, so config.load_dotenv does not exist here.
+
+    Reloading mutates the process-global config module, so a finally block
+    restores ENV and reloads it back to the TEST baseline even if the
+    assertion fails, preventing later tests from observing PROD settings.
     """
     monkeypatch.setenv("ENV", "PROD")
     mock_load_dotenv = mocker.patch("dotenv.load_dotenv")
-    importlib.reload(config)
-    mock_load_dotenv.assert_not_called()
+    try:
+        importlib.reload(config)
+        mock_load_dotenv.assert_not_called()
+    finally:
+        monkeypatch.setenv("ENV", "TEST")
+        importlib.reload(config)
 
 
 def test_langfuse_disabled_when_keys_blank(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,22 @@ def test_proxy_env_parsing_empty_string(monkeypatch):
     assert config.PROXIES == []
 
 
+def test_dotenv_skipped_in_prod(monkeypatch, mocker):
+    """Test load_dotenv is not invoked when ENV=PROD (production).
+
+    Every other test runs with ENV=TEST, so the dotenv-skip branch
+    (ENV=PROD, as in the real container) is otherwise never exercised.
+    Set the literal "PROD" rather than delenv: an absent ENV is not "PROD",
+    so it would trigger the opposite branch. Patch dotenv.load_dotenv at the
+    source — the name is only bound into config's namespace when the import
+    inside the skipped block runs, so config.load_dotenv does not exist here.
+    """
+    monkeypatch.setenv("ENV", "PROD")
+    mock_load_dotenv = mocker.patch("dotenv.load_dotenv")
+    importlib.reload(config)
+    mock_load_dotenv.assert_not_called()
+
+
 def test_langfuse_disabled_when_keys_blank(monkeypatch):
     """Test langfuse_client stays None when either Langfuse key is blank.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,6 +93,15 @@ def test_clean_up_single_file_protected(mocker):
     mock_unlink.assert_not_called()
 
 
+def test_clean_up_no_args_is_noop(mocker):
+    """Test that clean_up() with no arguments does nothing."""
+    mock_unlink = mocker.patch("utils.Path.unlink")
+
+    clean_up()
+
+    mock_unlink.assert_not_called()
+
+
 def test_clean_up_all_downloads(mocker):
     """Test that clean_up(all_downloads=True) only deletes unprotected files."""
     # Create mock paths


### PR DESCRIPTION
## Summary
- Closes a pre-existing branch-coverage gap in `src/config.py` flagged by Codecov (`19->26` partial branch on `if os.environ.get("ENV") != "PROD":`), not part of PR #980's diff (code dates to 2024-10-02).
- Adds `test_dotenv_skipped_in_prod`, following the existing `importlib.reload(config)` pattern in `tests/test_config.py`, asserting `load_dotenv` is not called when `ENV=PROD`.

## Test plan
- [x] `uvx ruff format tests/test_config.py && uvx ruff check tests/test_config.py` — clean
- [x] `uv run ty check tests/test_config.py` — clean
- [x] `uv run pytest --cov --cov-branch --cov-report=term-missing -q` — `src/config.py` now 100%, no missing branches
- [x] `uv run pytest -q` — 239 passed (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming environment files are not loaded in production mode.
  * Added coverage confirming cleanup performs no deletions when no files are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->