### PR TITLE
config: trim sentry init to error capture and logs

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -122,4 +122,5 @@ to Gemini — return the raw model text with **no** prefix.
   `main.handle_message`) wraps each Telegram message in one root span attributed to
   the user and tagged with the content type, so all Gemini calls for a message nest
   under a single trace. `langfuse_client.shutdown()` flushes on exit. Independent
-  of Sentry, which is used for error capture only; a no-op when disabled.
+  of Sentry, which handles error capture and logs; the Langfuse tracing is a
+  no-op when disabled.

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -121,5 +121,5 @@ to Gemini — return the raw model text with **no** prefix.
   `generate_content` call, and `services.observe_message` (used in
   `main.handle_message`) wraps each Telegram message in one root span attributed to
   the user and tagged with the content type, so all Gemini calls for a message nest
-  under a single trace. `langfuse_client.shutdown()` flushes on exit. Coexists with
-  Sentry tracing; a no-op when disabled.
+  under a single trace. `langfuse_client.shutdown()` flushes on exit. Independent
+  of Sentry, which is used for error capture only; a no-op when disabled.

--- a/src/config.py
+++ b/src/config.py
@@ -25,10 +25,6 @@ if os.environ.get("ENV") != "PROD":
 # Sentry.io config
 sentry_sdk.init(
     dsn=os.environ["SENTRY_DSN"],
-    send_default_pii=True,  # capture input and output of your AI model
-    traces_sample_rate=1.0,
-    profiles_sample_rate=1.0,
-    enable_tracing=True,
     enable_logs=True,
 )
 


### PR DESCRIPTION
## Summary
- Removed `send_default_pii`, `traces_sample_rate`, `profiles_sample_rate`, and `enable_tracing` from `sentry_sdk.init` in `src/config.py` — tracing/profiling weren't used, and `send_default_pii` was only there to capture Gemini input/output, which Langfuse now handles instead.
- Updated `docs/context/architecture.md` to drop the now-stale "Coexists with Sentry tracing" note.

Error capture (`capture_exception` in `src/main.py`) and Sentry Logs (`enable_logs=True`) are unaffected.

## Test plan
- [x] `uv run pytest` — 240 passed, 100% coverage maintained
- [x] Sanity import: `uv run python -c "import src.config"` succeeds
- [ ] After deploy, confirm exceptions still arrive in Sentry with no traces/profiles and no PII on error events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Langfuse tracing runs independently from Sentry, which is focused on error capture and logging.
  * Documented that tracing is optional, flushes on exit, and becomes a no-op when disabled.

* **Bug Fixes**
  * Updated Sentry initialization to stop automatically enabling default PII capture and performance/tracing sampling settings, while keeping logging enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->