### PR TITLE
ci: drop renovate weekly schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,6 @@
     "helpers:pinGitHubActionDigests",
     "docker:pinDigests"
   ],
-  "schedule": ["on sunday"],
   "minimumReleaseAge": "3 days",
   "rangeStrategy": "widen",
   "prHourlyLimit": 0,


### PR DESCRIPTION
## Summary
- Removes the top-level `"schedule": ["on sunday"]` from `.github/renovate.json`
- With no top-level schedule, Renovate falls back to its default (`at any time`) for PR creation timing

## Why
`minimumReleaseAge: "3 days"` and the per-manager `packageRules` already gate *whether* an update is eligible. The Sunday-only window just delayed PRs that had already passed those gates. Removing it lets eligible PRs open as soon as the rules are met, instead of batching once a week.

## Reviewer notes
- `prHourlyLimit: 0` (unlimited) is unchanged, and `prConcurrentLimit` stays at Renovate's default (10), so PR volume is still bounded.
- `lockFileMaintenance` keeps its own separate schedule (`before 4am on monday`, from `config:recommended`) — unaffected by this change.
- `vulnerabilityAlerts.schedule: ["at any time"]` is now redundant (it matches the new default) but left in place as harmless, self-documenting config.

## Test plan
- [x] Validated `.github/renovate.json` is valid JSON
- [x] Confirmed no other file references the removed schedule (README only has a generic doc link to Renovate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update scheduling to remove the fixed Sunday-only schedule.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->