### PR TITLE
Fix duplicated URL classification; drop dead code

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -35,7 +35,7 @@ polling-based (`bot.infinity_polling`); no webhooks, no async framework.
 | `config.py` | All clients/singletons + labels, defaults, limits, constants. Side-effectful import (Sentry, logging, env). |
 | `prompts.py` | `PROMPTS` (strategy templates) + `SYSTEM_INSTRUCTION`. |
 | `domain.py` | `PrefixedText` + `format_prefixed_summary` — source-provenance prefixing. |
-| `utils.py` | Proxy pick, temp-name gen, `compress_audio` (ffmpeg Opus 16k mono), `clean_up`. |
+| `utils.py` | Proxy pick, temp-name gen, `classify_url` (shared URL routing), `compress_audio` (ffmpeg Opus 16k mono), `clean_up`. |
 | `scripts/cron.py` | Modal serverless cron — clears the bot's per-user daily request-limit counters (`RPD`) in Valkey at midnight PT, so daily budgets reset in step with Gemini's free-tier quota. |
 | `scripts/db.py` | Standalone bootstrap script — creates the `users` table via its own `Base`/engine (separate from `src/models.py`); runs `create_all` at import. |
 
@@ -51,11 +51,17 @@ Telegram update
     audio / voice ───────────────► summarize(File)
     video / video_note ──────────► download_tg(.mp4) → compress_audio(.ogg) → summarize(path)
     document ────────────────────► summarize_with_document(File, mime)
-    text (treated as URL) ── _classify_url ──┬─ "media" (YT/Castro) ► summarize(url)
-                                             └─ "web"  ► parse_url → summarize_text
+    text (treated as URL) ── classify_url ──┬─ "youtube" / "castro" ► summarize(url)
+                                            └─ "web"  ► parse_url → summarize_text
 ```
 
 ### Summarizer input branching (`summary.py:summarize`)
+
+`utils.classify_url` is the **single** source of URL routing: `handlers.handle_url`
+calls it to pick the summarize path and `summarize` calls it again to pick the
+download path. Neither may re-derive the kind on its own — a second, narrower
+classifier here previously let www-prefixed and uppercase-host media URLs reach
+the Gemini file upload with the URL string as their file path.
 
 - **YouTube URL** → try transcript (`get_yt_transcript`); on success summarize
   the transcript. On failure → `download_yt` audio, then the file path below.

--- a/docs/context/style-guide.md
+++ b/docs/context/style-guide.md
@@ -59,8 +59,8 @@ Service modules follow the class → module-singleton → method-alias pattern d
 - `@staticmethod` is reserved for **private** helpers (`_name`) that need no instance state.
   Public methods keep `self` even when they don't use it — they form the aliased singleton
   surface (`check_quota = quota_manager.check_quota`), so they must stay bound methods.
-- Annotate class-level constants with `ClassVar`, e.g.
-  `_EXT_MIME_FALLBACK: ClassVar[dict[str, str]]`.
+- Annotate class-level constants with `ClassVar`, e.g. `_DEFAULTS: ClassVar[dict[str, str]]` —
+  without it Ruff (`RUF012`) reads a mutable class attribute as an un-annotated instance field.
 
 ## Testing
 

--- a/src/database.py
+++ b/src/database.py
@@ -80,6 +80,16 @@ class UserRepository:
         user = self.select_user(user_id)
         return user.approved
 
+    def _update_field(self, user_id: int, field: str, value: str) -> bool:
+        """Persist a single validated settings field; False if the user is unknown."""
+        with Session() as session:
+            user = session.get(UsersOrm, user_id)
+            if user is None:
+                return False
+            setattr(user, field, value)
+            session.commit()
+            return True
+
     def set_target_language(self, user_id: int, target_language: str) -> bool:
         """Set the target language for a user.
 
@@ -89,13 +99,7 @@ class UserRepository:
         """
         if target_language.title() not in SUPPORTED_LANGUAGES:
             return False
-        with Session() as session:
-            user = session.get(UsersOrm, user_id)
-            if user is not None:
-                user.target_language = target_language
-                session.commit()
-                return True
-            return False
+        return self._update_field(user_id, "target_language", target_language)
 
     def set_summarizing_model(self, user_id: int, summarizing_model: str) -> bool:
         """Set the summarizing model for a user.
@@ -106,13 +110,7 @@ class UserRepository:
         """
         if summarizing_model.lower() not in ALLOWED_MODELS_FOR_SUMMARY:
             return False
-        with Session() as session:
-            user = session.get(UsersOrm, user_id)
-            if user is not None:
-                user.summarizing_model = summarizing_model
-                session.commit()
-                return True
-            return False
+        return self._update_field(user_id, "summarizing_model", summarizing_model)
 
     def set_thinking_level(self, user_id: int, thinking_level: str) -> bool:
         """Set the AI thinking level for a user.
@@ -124,13 +122,7 @@ class UserRepository:
         normalized = thinking_level.upper()
         if normalized not in ALLOWED_THINKING_LEVELS:
             return False
-        with Session() as session:
-            user = session.get(UsersOrm, user_id)
-            if user is not None:
-                user.thinking_level = normalized
-                session.commit()
-                return True
-            return False
+        return self._update_field(user_id, "thinking_level", normalized)
 
     def set_prompt_strategy(self, user_id: int, prompt_key_for_summary: str) -> bool:
         """Set the prompt strategy for a user.
@@ -141,13 +133,11 @@ class UserRepository:
         """
         if prompt_key_for_summary.lower() not in ALLOWED_PROMPT_KEYS:
             return False
-        with Session() as session:
-            user = session.get(UsersOrm, user_id)
-            if user is not None:
-                user.prompt_key_for_summary = prompt_key_for_summary
-                session.commit()
-                return True
-            return False
+        return self._update_field(
+            user_id,
+            "prompt_key_for_summary",
+            prompt_key_for_summary,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/database.py
+++ b/src/database.py
@@ -97,9 +97,10 @@ class UserRepository:
             bool: True on success, False if language unsupported or user not found.
 
         """
-        if target_language.title() not in SUPPORTED_LANGUAGES:
+        normalized = target_language.title()
+        if normalized not in SUPPORTED_LANGUAGES:
             return False
-        return self._update_field(user_id, "target_language", target_language)
+        return self._update_field(user_id, "target_language", normalized)
 
     def set_summarizing_model(self, user_id: int, summarizing_model: str) -> bool:
         """Set the summarizing model for a user.
@@ -108,9 +109,10 @@ class UserRepository:
             bool: True on success, False if model unsupported or user not found.
 
         """
-        if summarizing_model.lower() not in ALLOWED_MODELS_FOR_SUMMARY:
+        normalized = summarizing_model.lower()
+        if normalized not in ALLOWED_MODELS_FOR_SUMMARY:
             return False
-        return self._update_field(user_id, "summarizing_model", summarizing_model)
+        return self._update_field(user_id, "summarizing_model", normalized)
 
     def set_thinking_level(self, user_id: int, thinking_level: str) -> bool:
         """Set the AI thinking level for a user.
@@ -131,13 +133,10 @@ class UserRepository:
             bool: True on success, False if key unsupported or user not found.
 
         """
-        if prompt_key_for_summary.lower() not in ALLOWED_PROMPT_KEYS:
+        normalized = prompt_key_for_summary.lower()
+        if normalized not in ALLOWED_PROMPT_KEYS:
             return False
-        return self._update_field(
-            user_id,
-            "prompt_key_for_summary",
-            prompt_key_for_summary,
-        )
+        return self._update_field(user_id, "prompt_key_for_summary", normalized)
 
 
 # ---------------------------------------------------------------------------

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypedDict
-from urllib.parse import urlsplit
 
-from config import CASTRO_HOST, TG_MAX_FILE_SIZE, YT_HOSTS, bot
+from config import TG_MAX_FILE_SIZE, bot
 from domain import format_prefixed_summary
 from download import download_tg
 from parsing import parse_url
@@ -13,7 +12,7 @@ from services import (
     send_answer,
 )
 from summary import summarize, summarize_text, summarize_with_document
-from utils import clean_up, compress_audio, generate_temporary_name
+from utils import classify_url, clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
     from telebot.types import Audio, Document, File, Message, Video, VideoNote, Voice
@@ -136,29 +135,10 @@ def handle_document(message: Message, user: UsersOrm) -> None:
     send_answer(message, answer)
 
 
-def _classify_url(url: str) -> str | None:
-    """Return 'media' for https YT/Castro URLs, 'web' for any http(s) URL, else None."""
-    parts = urlsplit(url)
-    if parts.scheme not in ("http", "https"):
-        return None
-    host = (parts.hostname or "").lower().removeprefix("www.")
-    if not host:
-        return None
-    if parts.scheme == "https" and host in YT_HOSTS:
-        return "media"
-    if (
-        parts.scheme == "https"
-        and host == CASTRO_HOST
-        and parts.path.startswith("/episode/")
-    ):
-        return "media"
-    return "web"
-
-
 def handle_url(message: Message, user: UsersOrm, url: str) -> None:
     """Handle URL processing."""
-    kind = _classify_url(url)
-    if kind == "media":
+    kind = classify_url(url)
+    if kind in ("youtube", "castro"):
         answer = summarize(
             data=url,
             **_summary_kwargs(user),

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
@@ -51,8 +50,6 @@ if TYPE_CHECKING:
     from telebot.types import Message
 
     from models import UsersOrm
-
-logger = logging.getLogger(__name__)
 
 
 # /start
@@ -388,7 +385,6 @@ def process_message_content(message: Message, user: UsersOrm) -> None:
     ):
         handle_document(message, user)
     elif message.content_type == "video_note":
-        logger.debug("video_note found. Starting video_note handle...")
         handle_video_note(message, user)
     elif message.content_type == "voice":
         handle_voice(message, user)

--- a/src/services.py
+++ b/src/services.py
@@ -5,7 +5,7 @@ import mimetypes
 import time
 from contextlib import contextmanager
 from textwrap import dedent
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, cast
 
 from google.genai import types
 from langfuse import propagate_attributes
@@ -125,14 +125,6 @@ class QuotaManager:
 class GeminiHelper:
     """Utilities for Gemini model configuration and file management."""
 
-    _EXT_MIME_FALLBACK: ClassVar[dict[str, str]] = {
-        ".ogg": "audio/ogg",
-        ".opus": "audio/ogg",
-        ".mp3": "audio/mpeg",
-        ".wav": "audio/wav",
-        ".mp4": "video/mp4",
-    }
-
     def get_gemini_config(
         self,
         target_language: str,
@@ -152,14 +144,8 @@ class GeminiHelper:
         )
 
     def resolve_mime_type(self, file: str) -> str:
-        """Resolve the MIME type for a file path, with fallbacks."""
-        mime_type = mimetypes.guess_type(file)[0]
-        if mime_type is not None:
-            return mime_type
-        for ext, mt in self._EXT_MIME_FALLBACK.items():
-            if file.endswith(ext):
-                return mt
-        return "application/octet-stream"
+        """Resolve the MIME type for a file path, defaulting to octet-stream."""
+        return mimetypes.guess_type(file)[0] or "application/octet-stream"
 
     def upload_and_wait_for_file(
         self,
@@ -239,16 +225,3 @@ get_remaining_quota = quota_manager.get_remaining_quota
 get_gemini_config = gemini_helper.get_gemini_config
 resolve_mime_type = gemini_helper.resolve_mime_type
 upload_and_wait_for_file = gemini_helper.upload_and_wait_for_file
-
-
-__all__ = [
-    "check_quota",
-    "get_file_with_retry",
-    "get_gemini_config",
-    "get_remaining_quota",
-    "messenger",
-    "observe_message",
-    "resolve_mime_type",
-    "send_answer",
-    "upload_and_wait_for_file",
-]

--- a/src/services.py
+++ b/src/services.py
@@ -166,7 +166,9 @@ class GeminiHelper:
             uploaded = gemini_client.files.get(name=file_name)
         if uploaded.state == "FAILED":
             raise ValueError(uploaded.state)
-        if uploaded.uri is None or uploaded.mime_type is None:
+        # Re-check name on the polled object, not just the upload response:
+        # callers rely on name/uri/mime_type all being set on what is returned.
+        if uploaded.name is None or uploaded.uri is None or uploaded.mime_type is None:
             raise AttributeError
         return uploaded
 

--- a/src/summary.py
+++ b/src/summary.py
@@ -31,7 +31,7 @@ from services import (
     upload_and_wait_for_file,
 )
 from transcription import get_yt_transcript, transcribe
-from utils import clean_up, compress_audio, generate_temporary_name
+from utils import classify_url, clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
     from tenacity import _utils as tenacity_utils
@@ -79,7 +79,8 @@ class Summarizer:
             str: Generated summary text from the audio content.
 
         Raises:
-            AttributeError: If Gemini returns incomplete file or response metadata.
+            AttributeError: If Gemini returns an empty response, or the upload
+                helper reports incomplete file metadata.
             ValueError: If Gemini reports a failed processing state.
             RetryError: If transient Gemini or network errors persist after retries.
 
@@ -92,10 +93,8 @@ class Summarizer:
             mime_type=mime_type,
             sleep_time=sleep_time,
         )
-        audio_file_name = audio_file.name
+        audio_file_name = cast("str", audio_file.name)
         try:
-            if audio_file.uri is None or audio_file.mime_type is None:
-                raise AttributeError
             check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
             response = gemini_client.models.generate_content(
                 model=model,
@@ -105,8 +104,8 @@ class Summarizer:
                         parts=[
                             types.Part.from_text(text=prompt),
                             types.Part.from_uri(
-                                file_uri=audio_file.uri,
-                                mime_type=audio_file.mime_type,
+                                file_uri=cast("str", audio_file.uri),
+                                mime_type=cast("str", audio_file.mime_type),
                             ),
                         ],
                     ),
@@ -120,15 +119,14 @@ class Summarizer:
                 raise AttributeError
             return response.text
         finally:
-            if audio_file_name is not None:
-                try:
-                    gemini_client.files.delete(name=audio_file_name)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to delete Gemini file %s: %s",
-                        audio_file_name,
-                        e,
-                    )
+            try:
+                gemini_client.files.delete(name=audio_file_name)
+            except Exception as e:
+                logger.warning(
+                    "Failed to delete Gemini file %s: %s",
+                    audio_file_name,
+                    e,
+                )
 
     @retry(
         stop=stop_after_attempt(2),
@@ -311,15 +309,10 @@ class Summarizer:
         """
         check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
         if isinstance(data, str):
-            if data.startswith("https://castro.fm/episode/"):
+            kind = classify_url(data)
+            if kind == "castro":
                 data = download_castro(data)
-            if data.startswith(
-                (
-                    "https://youtu.be/",
-                    "https://www.youtube.com/",
-                    "https://youtube.com/",
-                ),
-            ):
+            elif kind == "youtube":
                 try:
                     transcript_result = get_yt_transcript(data)
                 except (FetchTranscriptError, ValueError) as e:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,14 +1,47 @@
 import random
 import subprocess
 from pathlib import Path
+from urllib.parse import urlsplit
 from uuid import uuid4
 
-from config import PROTECTED_FILES, PROXIES
+from config import CASTRO_HOST, PROTECTED_FILES, PROXIES, YT_HOSTS
 
 
 def get_proxy() -> str:
     """Return a random proxy URL from PROXIES, or '' if none configured."""
     return random.choice(PROXIES) if PROXIES else ""  # noqa: S311
+
+
+def classify_url(url: str) -> str | None:
+    """Classify a URL by the pipeline that can summarize it.
+
+    Single source of truth for URL routing: `handlers.handle_url` uses it to pick
+    the summarize path, and `summary.summarize` uses it to pick the download path.
+    Both must agree, so neither may re-derive the kind on its own.
+
+    Args:
+        url (str): The URL to classify.
+
+    Returns:
+        str | None: "youtube" or "castro" for https media URLs, "web" for any
+            other http(s) URL, None when the URL has no usable scheme or host.
+
+    """
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        return None
+    host = (parts.hostname or "").lower().removeprefix("www.")
+    if not host:
+        return None
+    if parts.scheme == "https" and host in YT_HOSTS:
+        return "youtube"
+    if (
+        parts.scheme == "https"
+        and host == CASTRO_HOST
+        and parts.path.startswith("/episode/")
+    ):
+        return "castro"
+    return "web"
 
 
 def generate_temporary_name(ext: str = "") -> str:

--- a/src/utils.py
+++ b/src/utils.py
@@ -27,7 +27,12 @@ def classify_url(url: str) -> str | None:
             other http(s) URL, None when the URL has no usable scheme or host.
 
     """
-    parts = urlsplit(url)
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        # urlsplit rejects bracket-malformed authorities ("https://[") outright,
+        # so treat them as unusable rather than letting the error reach the user.
+        return None
     if parts.scheme not in ("http", "https"):
         return None
     host = (parts.hostname or "").lower().removeprefix("www.")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -170,6 +170,48 @@ def test_set_setting_rejects_unsupported(
     assert setter(123, bad_value) is False
 
 
+@pytest.mark.parametrize(
+    ("setter", "value", "orm_attr", "stored_value"),
+    [
+        (set_target_language, "english", "target_language", "English"),
+        (
+            set_summarizing_model,
+            "GEMINI-3.5-FLASH",
+            "summarizing_model",
+            "gemini-3.5-flash",
+        ),
+        (
+            set_prompt_strategy,
+            "Key_Points_For_Transcript",
+            "prompt_key_for_summary",
+            "key_points_for_transcript",
+        ),
+    ],
+)
+def test_set_setting_stores_normalized_value(
+    monkeypatch,
+    sqlite_session_factory,
+    setter,
+    value,
+    orm_attr,
+    stored_value,
+):
+    """Test setters persist the canonical form, not the caller's casing.
+
+    Validation already normalizes before checking the allow-list, so storing the
+    raw input would let a non-canonical value through: PROMPTS[...] would raise
+    KeyError and a mis-cased model id would be rejected by the Gemini API.
+    """
+    monkeypatch.setattr("database.Session", sqlite_session_factory)
+    register_user(123, "First", "Last", "user")
+
+    assert setter(123, value) is True
+    with sqlite_session_factory() as session:
+        user = session.get(UsersOrm, 123)
+        assert user is not None
+        assert getattr(user, orm_attr) == stored_value
+
+
 def test_set_thinking_level_rejects_unknown_value(monkeypatch, sqlite_session_factory):
     """Test set_thinking_level returns False and leaves the stored level unchanged."""
     monkeypatch.setattr("database.Session", sqlite_session_factory)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -3,8 +3,8 @@ from tenacity import RetryError
 
 from domain import PrefixedText
 from exceptions import LimitExceededError, WebParseError
-from handlers import _classify_url
 from main import handle_message, process_message_content
+from utils import classify_url
 
 
 def test_unauthorized_user(message_factory, mocker):
@@ -151,14 +151,41 @@ def test_handle_url_unsupported_pattern(message_factory, mocker):
 
 
 def test_classify_url_uppercase_youtube_host():
-    """Test _classify_url normalises uppercase YouTube hostnames to 'media'."""
-    assert _classify_url("https://YOUTU.BE/dQw4w9WgXcQ") == "media"
-    assert _classify_url("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "media"
+    """Test classify_url normalises uppercase YouTube hostnames to 'youtube'."""
+    assert classify_url("https://YOUTU.BE/dQw4w9WgXcQ") == "youtube"
+    assert classify_url("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "youtube"
+
+
+def test_classify_url_strips_www_prefix():
+    """Test classify_url routes www-prefixed media hosts to their media kind.
+
+    Regression: routing used to be duplicated, and the second classifier matched
+    three literal lowercase prefixes. A www-prefixed Castro or youtu.be link was
+    classified as media here, then failed the second check and reached the
+    Gemini file upload with the URL string as its file path.
+    """
+    assert classify_url("https://www.castro.fm/episode/123") == "castro"
+    assert classify_url("https://www.youtu.be/dQw4w9WgXcQ") == "youtube"
+
+
+def test_classify_url_castro_non_episode_path_is_web():
+    """Test classify_url only treats Castro /episode/ paths as media."""
+    assert classify_url("https://castro.fm/about") == "web"
 
 
 def test_classify_url_malformed_no_host():
-    """Test _classify_url returns None for URLs with no parseable hostname."""
-    assert _classify_url("https://") is None
+    """Test classify_url returns None for URLs with no parseable hostname."""
+    assert classify_url("https://") is None
+
+
+def test_classify_url_rejects_non_http_scheme():
+    """Test classify_url returns None for non-http(s) schemes."""
+    assert classify_url("ftp://example.com/file.txt") is None
+
+
+def test_classify_url_http_youtube_is_web():
+    """Test classify_url only treats https media hosts as media."""
+    assert classify_url("http://youtube.com/watch?v=dQw4w9WgXcQ") == "web"
 
 
 def test_handle_url_youtube_pattern(message_factory, mocker):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -183,6 +183,17 @@ def test_classify_url_rejects_non_http_scheme():
     assert classify_url("ftp://example.com/file.txt") is None
 
 
+def test_classify_url_returns_none_for_unparseable_authority():
+    """Test classify_url returns None when urlsplit rejects the authority.
+
+    urlsplit raises ValueError on bracket-malformed hosts. Left uncaught it
+    escapes handle_url's kind check and reaches handle_message's catch-all, so
+    the user sees "Unexpected: ValueError" instead of "No data to proceed.".
+    """
+    assert classify_url("https://[") is None
+    assert classify_url("http://[::1") is None
+
+
 def test_classify_url_http_youtube_is_web():
     """Test classify_url only treats https media hosts as media."""
     assert classify_url("http://youtube.com/watch?v=dQw4w9WgXcQ") == "web"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -185,6 +185,32 @@ def test_upload_and_wait_for_file_name_none(mocker):
         upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
+def test_upload_and_wait_for_file_name_none_after_polling(mocker):
+    """upload_and_wait_for_file raises AttributeError when the polled file has no name.
+
+    The pre-loop check only sees the upload response; callers cast .name on the
+    returned object, so the polled result must be validated too.
+    """
+    mock_client = mocker.patch("services.gemini_client")
+    mocker.patch("services.time.sleep")
+
+    mock_file_proc = mocker.MagicMock()
+    mock_file_proc.name = "name"
+    mock_file_proc.state = "PROCESSING"
+
+    mock_file_done = mocker.MagicMock()
+    mock_file_done.name = None
+    mock_file_done.state = "ACTIVE"
+    mock_file_done.uri = "uri"
+    mock_file_done.mime_type = "audio/ogg"
+
+    mock_client.files.upload.return_value = mock_file_proc
+    mock_client.files.get.return_value = mock_file_done
+
+    with pytest.raises(AttributeError):
+        upload_and_wait_for_file("path", "audio/ogg", 1)
+
+
 def test_upload_and_wait_for_file_missing_uri(mocker):
     """upload_and_wait_for_file raises AttributeError when uri or mime_type is None."""
     mock_client = mocker.patch("services.gemini_client")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -159,21 +159,19 @@ def test_resolve_mime_type_uses_mimetypes_guess():
     assert resolve_mime_type("data.csv") == "text/csv"
     assert resolve_mime_type("text.rtf") == "application/rtf"
     assert resolve_mime_type("audio.ogg") == "audio/ogg"
-    assert resolve_mime_type("audio.mp3") == "audio/mpeg"
-    assert resolve_mime_type("video.mp4") == "video/mp4"
-    assert resolve_mime_type("unknown.bin") == "application/octet-stream"
-
-
-def test_resolve_mime_type_fallback_when_mimetypes_returns_none(mocker):
-    """resolve_mime_type falls back to extension matching when mimetypes returns None."""
-    mocker.patch("services.mimetypes.guess_type", return_value=(None, None))
-
-    assert resolve_mime_type("audio.ogg") == "audio/ogg"
     assert resolve_mime_type("audio.opus") == "audio/ogg"
     assert resolve_mime_type("audio.mp3") == "audio/mpeg"
-    assert resolve_mime_type("audio.wav") == "audio/wav"
     assert resolve_mime_type("video.mp4") == "video/mp4"
-    assert resolve_mime_type("unknown.bin") == "application/octet-stream"
+
+
+def test_resolve_mime_type_defaults_for_unknown_extension():
+    """resolve_mime_type falls back to octet-stream for extensions mimetypes cannot map.
+
+    Uses .zzz rather than .bin: mimetypes resolves .bin to application/octet-stream
+    itself, so it never reaches the default and leaves that branch uncovered.
+    """
+    assert resolve_mime_type("mystery.zzz") == "application/octet-stream"
+    assert resolve_mime_type("no_extension") == "application/octet-stream"
 
 
 def test_upload_and_wait_for_file_name_none(mocker):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -6,6 +6,7 @@ from telebot.types import File
 from tenacity import RetryError
 
 import summary as summary_module
+from domain import PrefixedText
 from exceptions import FetchTranscriptError, LimitExceededError
 from summary import (
     format_prefixed_summary,
@@ -62,25 +63,6 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
     mock_client = mocker.patch("summary.gemini_client")
     mocker.patch("services.gemini_client", mock_client)
     mock_client.models.generate_content.return_value = mocker.MagicMock(text=None)
-
-    with pytest.raises(RetryError):
-        summarize_with_file(
-            file="test_audio.ogg",
-            model="test-model",
-            prompt_key="basic_prompt_for_transcript",
-            target_language="English",
-            user_id=123,
-            daily_limit=10,
-            thinking_level="MINIMAL",
-        )
-
-
-def test_summarize_with_file_retries_on_missing_upload_metadata(mocker):
-    """Test summarize_with_file raises RetryError on repeated missing upload metadata."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("tenacity.nap.time.sleep")
-    mock_audio_file = SimpleNamespace(name=None, uri=None, mime_type="audio/ogg")
-    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
 
     with pytest.raises(RetryError):
         summarize_with_file(
@@ -514,6 +496,74 @@ def test_summarize_castro(mocker):
     )
 
     assert result == "Castro summary"
+
+
+def test_summarize_castro_www_host(mocker):
+    """Test summarize() downloads a www-prefixed Castro URL instead of uploading it.
+
+    Regression: the URL used to be re-classified with a literal
+    "https://castro.fm/episode/" prefix check, so a www-prefixed link skipped
+    download_castro and was passed to summarize_with_file as a file path.
+    """
+    mocker.patch("summary.check_quota", return_value=True)
+    mock_download = mocker.patch("summary.download_castro", return_value="dl.mp3")
+    mock_with_file = mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_file",
+        return_value="Castro summary",
+    )
+    mocker.patch("summary.clean_up")
+
+    result = summarize(
+        data="https://www.castro.fm/episode/123",
+        model="test-model",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        user_id=123,
+        daily_limit=10,
+        thinking_level="MINIMAL",
+    )
+
+    assert result == "Castro summary"
+    mock_download.assert_called_once_with("https://www.castro.fm/episode/123")
+    assert mock_with_file.call_args.kwargs["file"] == "dl.mp3"
+
+
+def test_summarize_youtube_uppercase_host_uses_transcript(mocker):
+    """Test summarize() routes an uppercase-host YouTube URL to the transcript path.
+
+    Regression: the old literal prefix check was case-sensitive, so an
+    uppercase host bypassed the transcript path entirely.
+    """
+    url = "https://YouTube.com/watch?v=dQw4w9WgXcQ"
+    mocker.patch("summary.check_quota", return_value=True)
+    mock_transcript = mocker.patch(
+        "summary.get_yt_transcript",
+        return_value=PrefixedText(text="transcript text", prefix="📺"),
+    )
+    mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_text",
+        return_value="YT summary",
+    )
+    mock_with_file = mocker.patch.object(
+        summary_module.summarizer,
+        "summarize_with_file",
+    )
+
+    result = summarize(
+        data=url,
+        model="test-model",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        user_id=123,
+        daily_limit=10,
+        thinking_level="MINIMAL",
+    )
+
+    assert result == "📺\n\nYT summary"
+    mock_transcript.assert_called_once_with(url)
+    mock_with_file.assert_not_called()
 
 
 def test_summarize_preflight_blocks_before_download(mocker):


### PR DESCRIPTION
## Summary
- Fixes a routing bug: URLs were classified twice — once in `handlers._classify_url` and again in `summary.summarize` via three hardcoded, case-sensitive `startswith` prefixes. The second check was strictly narrower, so `https://www.castro.fm/episode/x`, `https://www.youtu.be/x`, and any uppercase-host YouTube URL passed the first check, failed the second, and were handed to Gemini's file-upload path as if the URL string were a local file path.
- Unifies routing into a single `utils.classify_url`, used by both `handlers.handle_url` and `summary.summarize` — neither re-derives the kind independently anymore.
- Adds a guard for `urlsplit` raising `ValueError` on bracket-malformed authorities (e.g. `https://[`), so `classify_url` returns `None` per its documented contract instead of letting the exception reach the user as `Unexpected: ValueError`.
- Removes dead code found in review: unreachable `uri`/`mime_type`/`name` guards in `summarize_with_file` (already enforced by `upload_and_wait_for_file`), an unreachable MIME fallback dict in `GeminiHelper` (all its extensions resolve via the stdlib `mimetypes` map, and one entry — `.wav` — was wrong), a stale/unused `services.__all__`, and a vestigial debug log line.
- Collapses `UserRepository`'s four `set_*` methods' duplicated session boilerplate into a shared `_update_field` helper.
- Updates `docs/context/architecture.md` and `docs/context/style-guide.md` to match.

## Test plan
- [x] `uv run pytest --cov` — 247 passed, 100% line coverage maintained across all `src/` modules
- [x] `ruff check` / `ruff format --check` — clean
- [x] `ty check` — 0 diagnostics in `src/`, unchanged from `main`'s pre-existing baseline elsewhere
- [x] Regression reproduced against real code before the fix and re-verified after: `summarize(data="https://www.castro.fm/episode/123")` now calls `download_castro` and passes its output to `summarize_with_file`, instead of passing the raw URL
- [x] New tests cover the previously-broken inputs (www-prefixed Castro/youtu.be, uppercase YouTube host) and the malformed-authority edge case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved URL recognition and routing for YouTube, Castro, and standard web links, including support for uppercase hosts.
* **Bug Fixes**
  * More reliable upload MIME handling with a safe default for unknown types.
  * Improved robustness when polled upload metadata is incomplete.
  * Standardized persistence of user preference updates and ensured Gemini file cleanup runs reliably.
* **Documentation**
  * Updated architecture and style guidance to match the revised URL routing approach and constant typing conventions.
* **Tests**
  * Expanded coverage for URL classification, MIME defaults, and routing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->