### PR TITLE
docs: move handoff template to agent-templates.md

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -4,6 +4,5 @@ Steps:
 
 1. Use the Session Handoff template in `docs/context/agent-templates.md`, filling every section including the forward-looking tail (Unfinished Work / Files to Load Next Session / What NOT to Re-Read).
 2. Fill in every field based on what was accomplished in this session. Be specific — include exact file paths for every output, exact numbers discovered, and conditional logic established.
-3. Write the handoff to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`.
-4. If a previous handoff file exists in `docs/summaries/`, move it to `docs/archive/handoffs/`.
-5. Tell me the file path of the new handoff and summarize what it contains.
+3. Write the handoff to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`, then archive the previous one as the template says.
+4. Tell me the file path of the new handoff and summarize what it contains.

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -4,5 +4,6 @@ Steps:
 
 1. Use the Session Handoff template in `docs/context/agent-templates.md`, filling every section including the forward-looking tail (Unfinished Work / Files to Load Next Session / What NOT to Re-Read).
 2. Fill in every field based on what was accomplished in this session. Be specific — include exact file paths for every output, exact numbers discovered, and conditional logic established.
-3. Write the handoff to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`, then archive the previous one as the template says.
-4. Tell me the file path of the new handoff and summarize what it contains.
+3. Write the handoff to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`.
+4. If a previous handoff file exists in `docs/summaries/`, move it to `docs/archive/handoffs/`.
+5. Tell me the file path of the new handoff and summarize what it contains.

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -2,7 +2,7 @@ Write a session handoff file for the current session.
 
 Steps:
 
-1. Use the Handoff template in `AGENTS.md`, filling every section including the forward-looking tail (Unfinished Work / Files to Load Next Session / What NOT to Re-Read).
+1. Use the Session Handoff template in `docs/context/agent-templates.md`, filling every section including the forward-looking tail (Unfinished Work / Files to Load Next Session / What NOT to Re-Read).
 2. Fill in every field based on what was accomplished in this session. Be specific — include exact file paths for every output, exact numbers discovered, and conditional logic established.
 3. Write the handoff to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`.
 4. If a previous handoff file exists in `docs/summaries/`, move it to `docs/archive/handoffs/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,50 +12,13 @@ Before your first edit to a tracked file, branch off `main` (`git checkout -b <s
 
 ## Rules
 
-1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, via `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly), to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md` using the template below. Decision records and analyses are separate on-demand outputs — templates in `docs/context/agent-templates.md`.
+1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, via `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly), to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`. Decision records and analyses are separate on-demand outputs. Templates for all three: `docs/context/agent-templates.md`.
 2. **Surface every open question.** Mark unresolved items OPEN or ASSUMED in the final answer, and in the handoff when one is written. Before delivering output, verify exact numbers are preserved and claims are backed by specific data.
 3. Sub-agent returns must be structured — exact numbers, file paths, decisions with rationale, open items — not free-form prose. Target 1,000–2,000 tokens.
 4. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.
 5. Commit per `docs/context/git-guide.md`, which also covers the pre-commit hooks and the coverage report. Never bypass hooks with `--no-verify`. Follow-up fixes go into new commits — never amend, rebase, or otherwise rewrite an existing commit unless the user asks for that directly. Under `docs/`, stage only `docs/context/` — the rest is gitignored.
 6. **Never `git push` on your own — a push happens only via the user invoking `/create-pr` or pushing it themselves.**
 7. A code change updates its tests **and** any `docs/context/` doc it invalidates (`architecture.md` for architecture, `style-guide.md` for conventions) in the same PR. Treat both as mandatory — skipping either is equivalent to bypassing the pre-commit hooks.
-
-## Handoff Template
-
-After writing the new handoff, move the previous one to `docs/archive/handoffs/`.
-
-Under What NOT to Re-Read list the handoffs, plans, and analyses this session actually opened that a later reader should skip, naming what replaces each — a reason to *read* something belongs in Files to Load instead.
-
-```markdown
-# Handoff: [Topic]
-**Date:** [YYYY-MM-DD]  **Branch:** [branch]  **Focus:** [one sentence]
-
-## What Was Accomplished
-- [task] → `[file:line]`
-
-## Decisions Made
-- [decision] BECAUSE [rationale] — STATUS: [confirmed/provisional]
-
-## Key Numbers
-- [exact test counts, timings, values — do not round]
-
-## Files Modified
-| File | Action | Description |
-|------|--------|-------------|
-| `[path]` | Created/Modified | [what and why] |
-
-## Open Questions
-- [OPEN/ASSUMED item] or None
-
-## Unfinished Work
-- [ordered, specific action with paths] or None
-
-## Files to Load Next Session
-- `[path]` — [what it holds and when it matters; add `~L[start]-[end]` if only one region does]
-
-## What NOT to Re-Read
-- `[path]` — superseded by / already summarized in / unrelated to `[path]`
-```
 
 ## Where Things Live
 
@@ -65,6 +28,6 @@ Under What NOT to Re-Read list the handoffs, plans, and analyses this session ac
   - `style-guide.md` — coding conventions Ruff does not enforce
   - `git-guide.md` — commit format, pre-commit hooks, coverage
   - `uv-guide.md` — running the project and managing dependencies
-  - `agent-templates.md` — decision-record and analysis templates (read on demand)
+  - `agent-templates.md` — handoff, decision-record, and analysis templates (read on demand)
 - `docs/archive/` — processed raw files. Do not read unless explicitly told. **(gitignored)**
 - `.claude/commands/handoff.md` — the `/handoff` routine; agents without slash commands follow its steps directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Before your first edit to a tracked file, branch off `main` (`git checkout -b <s
 
 ## Rules
 
-1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, via `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly), to `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`. Decision records and analyses are separate on-demand outputs. Templates for all three: `docs/context/agent-templates.md`.
+1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, by following `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly). Decision records and analyses are separate on-demand outputs — templates in `docs/context/agent-templates.md`.
 2. **Surface every open question.** Mark unresolved items OPEN or ASSUMED in the final answer, and in the handoff when one is written. Before delivering output, verify exact numbers are preserved and claims are backed by specific data.
 3. Sub-agent returns must be structured — exact numbers, file paths, decisions with rationale, open items — not free-form prose. Target 1,000–2,000 tokens.
 4. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.

--- a/docs/context/agent-templates.md
+++ b/docs/context/agent-templates.md
@@ -1,10 +1,51 @@
 # Agent Templates — On-Demand Reference
 
-> **Do NOT read this file at session start.** Read it only when writing a decision record or an analysis summary. The session handoff template lives inline in `AGENTS.md`.
+> **Do NOT read this file at session start.** Read it only when writing a handoff, a decision record, or an analysis summary.
 
 ---
 
-## Template 1: Decision Record
+## Template 1: Session Handoff
+
+**Use when:** The user asks for one (`/handoff`). It is a history log — never created or updated while work is in progress.
+
+**Write to:** `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`
+
+Under What NOT to Re-Read list the handoffs, plans, and analyses this session actually opened that a later reader should skip, naming what replaces each — a reason to *read* something belongs in Files to Load instead.
+
+```markdown
+# Handoff: [Topic]
+**Date:** [YYYY-MM-DD]  **Branch:** [branch]  **Focus:** [one sentence]
+
+## What Was Accomplished
+- [task] → `[file:line]`
+
+## Decisions Made
+- [decision] BECAUSE [rationale] — STATUS: [confirmed/provisional]
+
+## Key Numbers
+- [exact test counts, timings, values — do not round]
+
+## Files Modified
+| File | Action | Description |
+|------|--------|-------------|
+| `[path]` | Created/Modified | [what and why] |
+
+## Open Questions
+- [OPEN/ASSUMED item] or None
+
+## Unfinished Work
+- [ordered, specific action with paths] or None
+
+## Files to Load Next Session
+- `[path]` — [what it holds and when it matters; add `~L[start]-[end]` if only one region does]
+
+## What NOT to Re-Read
+- `[path]` — superseded by / already summarized in / unrelated to `[path]`
+```
+
+---
+
+## Template 2: Decision Record
 
 **Use when:** A significant decision is made during a session (library choice, architecture, migration strategy, error-handling approach). These persist in `docs/summaries/` as the project's ADRs.
 
@@ -37,7 +78,7 @@
 
 ---
 
-## Template 2: Analysis / Research Summary
+## Template 3: Analysis / Research Summary
 
 **Use when:** Completing a technical evaluation, feasibility check, incident investigation, or refactor scoping. Keep only the latest version per topic (archive the old one if re-run).
 

--- a/docs/context/agent-templates.md
+++ b/docs/context/agent-templates.md
@@ -6,9 +6,9 @@
 
 ## Template 1: Session Handoff
 
-**Use when:** The user asks for one (`/handoff`). It is a history log — never created or updated while work is in progress.
+**Use when:** The user asks for a handoff. The steps around it — where to write, what to archive — are in `.claude/commands/handoff.md`.
 
-**Write to:** `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md` — then move the previous handoff, if one is there, to `docs/archive/handoffs/`.
+**Write to:** `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`
 
 Under What NOT to Re-Read list the handoffs, plans, and analyses this session actually opened that a later reader should skip, naming what replaces each — a reason to *read* something belongs in Files to Load instead.
 

--- a/docs/context/agent-templates.md
+++ b/docs/context/agent-templates.md
@@ -8,7 +8,7 @@
 
 **Use when:** The user asks for one (`/handoff`). It is a history log — never created or updated while work is in progress.
 
-**Write to:** `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md`
+**Write to:** `docs/summaries/handoff-[YYYY-MM-DD]-[topic].md` — then move the previous handoff, if one is there, to `docs/archive/handoffs/`.
 
 Under What NOT to Re-Read list the handoffs, plans, and analyses this session actually opened that a later reader should skip, naming what replaces each — a reason to *read* something belongs in Files to Load instead.
 


### PR DESCRIPTION
## What changed

Moved the Handoff template out of `AGENTS.md` into `docs/context/agent-templates.md`, alongside the decision-record and analysis templates it belongs with, and tightened the pointers around it.

| File | Change |
|---|---|
| `AGENTS.md` | Deleted the `## Handoff Template` section; Rule 1 now points only at the procedure; `Where Things Live` entry updated |
| `docs/context/agent-templates.md` | Added `Template 1: Session Handoff`; Decision Record → 2, Analysis → 3; header trigger now covers handoffs |
| `.claude/commands/handoff.md` | Step 1 points at `docs/context/agent-templates.md` |

## Why

`AGENTS.md` loads every session via `CLAUDE.md`, but the handoff template is only needed when the user runs `/handoff`. It was 1,131 of 4,456 bytes — 25% of the always-loaded contract serving a rare path. This is the same read-on-demand gating already applied to `architecture.md` and `style-guide.md` in #1000, and it puts all three on-demand session outputs in one file instead of splitting one off arbitrarily.

**AGENTS.md: 4,456 → 3,272 bytes (−26.6%).**

## Notes for review

- **The template block is byte-identical to `main`.** 152 of 166 archived handoffs grep on the exact section headings, so the move had to preserve them exactly — verified with a diff against `main`.
- **Separation of concerns across the three files.** `AGENTS.md` owns the policy (handoff is on-demand only), `.claude/commands/handoff.md` owns the procedure, `agent-templates.md` owns the shape of the output. Rule 1 deliberately does *not* inline the output path or the template path: doing so let an agent satisfy the rule without ever opening the procedure file, which is what pushed a procedural step (archive the previous handoff) into the template file in the first place.
- **The archive-move instruction exists in exactly one place** — `handoff.md` step 4 — and both entry paths reach it. Previously it was duplicated between `AGENTS.md` and `handoff.md`.
- **Nothing else references the removed heading or the template numbers.** Checked `.claude/`, `docs/context/`, and the live ADRs in `docs/summaries/`; `decision-11` mentions the old heading only as a dated record of a past change.
- Commits 2 and 3 are follow-ups from `/code-review` on this branch, kept as separate commits rather than amended.

Docs-only; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated session handoff guidance to use a centralized template.
  * Added a comprehensive handoff template covering accomplishments, decisions, open questions, unfinished work, and next-session context.
  * Clarified documentation references and updated template numbering.
  * Removed the outdated handoff template from the general guidance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->