### PR TITLE
docs: give Rule 3 sub-agent returns an overflow destination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Before your first edit to a tracked file, branch off `main` (`git checkout -b <s
 
 ## Rules
 
-1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, by following `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly). Decision records and analyses are separate on-demand outputs — templates in `docs/context/agent-templates.md`.
+1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, by following `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly). Decision records and analyses are separate outputs, written when the user asks or when Rule 3 requires one — templates in `docs/context/agent-templates.md`.
 2. **Surface every open question.** Mark unresolved items OPEN or ASSUMED in the final answer, and in the handoff when one is written. Before delivering output, verify exact numbers are preserved and claims are backed by specific data.
 3. Sub-agent returns must be structured — exact numbers, file paths, decisions with rationale, open items — not free-form prose. Target 1,000–2,000 tokens per return; write anything longer to `docs/summaries/analysis-<topic>.md` and return the path.
 4. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Before your first edit to a tracked file, branch off `main` (`git checkout -b <s
 
 1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, by following `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly). Decision records and analyses are separate on-demand outputs — templates in `docs/context/agent-templates.md`.
 2. **Surface every open question.** Mark unresolved items OPEN or ASSUMED in the final answer, and in the handoff when one is written. Before delivering output, verify exact numbers are preserved and claims are backed by specific data.
-3. Sub-agent returns must be structured — exact numbers, file paths, decisions with rationale, open items — not free-form prose. Target 1,000–2,000 tokens.
+3. Sub-agent returns must be structured — exact numbers, file paths, decisions with rationale, open items — not free-form prose. Target 1,000–2,000 tokens per return; write anything longer to `docs/summaries/analysis-<topic>.md` and return the path.
 4. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.
 5. Commit per `docs/context/git-guide.md`, which also covers the pre-commit hooks and the coverage report. Never bypass hooks with `--no-verify`. Follow-up fixes go into new commits — never amend, rebase, or otherwise rewrite an existing commit unless the user asks for that directly. Under `docs/`, stage only `docs/context/` — the rest is gitignored.
 6. **Never `git push` on your own — a push happens only via the user invoking `/create-pr` or pushing it themselves.**


### PR DESCRIPTION
## What changed

Two one-line edits to `AGENTS.md`:

1. **Rule 3** — the 1,000–2,000 token guidance now says *per return* and names where longer output goes: `docs/summaries/analysis-<topic>.md`, with the sub-agent returning the path.
2. **Rule 1** — its closing sentence no longer labels analyses flatly as "on-demand outputs"; it now reads "written when the user asks or when Rule 3 requires one."

## Why

Rule 3 set a token target but never said where detail beyond it should go. A sub-agent handed a large research task (say, comparing several libraries) saw only two options: blow the target, or drop findings. Dropping findings conflicts with Rule 2, which requires exact numbers preserved and claims backed by data.

Naming the analysis file resolves that — depth lands in a file the parent reads on demand, instead of being forced into the orchestrator's context window. Raising the token number was considered and rejected: a large return defeats the purpose of delegating to a sub-agent at all, since you pay the sub-agent's cost and still fill the parent's window.

The second commit follows from the first. Once Rule 3 *requires* writing an analysis file in some cases, Rule 1's unqualified "on-demand" label contradicts it — one agent would write the file, another would truncate its return to honor Rule 1. Rule 1 was edited rather than Rule 3 so the ambiguity is fixed at its source.

## Reviewer notes

- The path matches Template 3's `**Write to:**` line in `docs/context/agent-templates.md`, so the two documents agree on the convention. Bracket style differs cosmetically (`[topic]` there, `<topic>` here).
- Rule 1's first two sentences still bind *the handoff* to explicit user request only — that scoping was already correct and is untouched.
- Docs-only, so the ruff/ty/pytest pre-commit hooks skipped by design; the rest passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when handoffs and decision records should be created.
  * Added guidance for storing lengthy analysis in documentation summaries and returning a reference instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->