### PR TITLE
docs(architecture): inline core stack rationale, drop dangling decision-10 pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Parsing runs a fixed two-stage flow: [Exa.ai](https://exa.ai) is tried first, an
 
 #### Remote functions
 
-To avoid multiple docker images, I use a [Modal](https://modal.com/) for cron jobs to reset the Gemini rate limit. [Modal Secrets](https://modal.com/docs/guide/secrets) should include `REDIS_URL`.
+To avoid multiple docker images, I use a [Modal](https://modal.com/) for cron jobs to reset the bot's own daily request counters. [Modal Secrets](https://modal.com/docs/guide/secrets) should include `REDIS_URL`.
 
 Modal Image Builder Version required to be `2025.06`. Set in Settings -> Image Builder Version.
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -20,13 +20,14 @@ polling-based (`bot.infinity_polling`); no webhooks, no async framework.
 ## Why this stack
 
 Rationale for the standing infrastructure choices — mostly not derivable from
-`pyproject.toml` or `README.md`. Treat each as settled; reverse one only as a
-deliberate decision, not incidental cleanup.
+`pyproject.toml` or `README.md`. Treat each as settled unless its bullet says
+otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 
 - **Synchronous polling** (see above) — no webhooks or async framework are needed
   for this workload.
-- **Valkey over Redis** — Redis-protocol compatible and BSD-3-Clause, after Redis
-  relicensed away from BSD-3-Clause in 2024.
+- **Valkey over Redis** — Aiven offers a free managed Valkey instance (linked in
+  `README.md`); that is the whole reason. **Not** a settled constraint: the client
+  speaks the Redis protocol, so either server works and swapping is fair game.
 - **Gemini primary, Replicate fallback** — Replicate (WhisperX) is the transcription
   rescue path taken when Gemini file processing exhausts its retries, not a swappable
   summarization model.

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -25,13 +25,16 @@ deliberate decision, not incidental cleanup.
 
 - **Synchronous polling** (see above) — no webhooks or async framework are needed
   for this workload.
-- **Valkey over Redis** — Redis-protocol compatible, and avoids Redis's licensing terms.
-- **Gemini primary, Replicate fallback** — Replicate gives model flexibility without
-  code changes.
+- **Valkey over Redis** — Redis-protocol compatible and BSD-3-Clause, after Redis
+  relicensed away from BSD-3-Clause in 2024.
+- **Gemini primary, Replicate fallback** — Replicate (WhisperX) is the transcription
+  rescue path taken when Gemini file processing exhausts its retries, not a swappable
+  summarization model.
 - **PostgreSQL for persistent user data, Valkey for ephemeral rate-limit counters** —
   the two have different durability needs.
-- **Modal for serverless cron** — resets Gemini daily rate limits without running a
-  second container. Also stated in `README.md`; keep the two in step.
+- **Modal for serverless cron** — clears the bot's own per-user daily counters in
+  Valkey, in step with Gemini's quota window, without running a second container.
+  Also stated in `README.md`; keep the two in step.
 
 ## Component map (`src/`)
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -6,7 +6,6 @@ rewrite), not every handoff. Not a source mirror: read the source for function
 signatures, dependencies, and env vars.
 
 - Stack → `pyproject.toml` + `README.md`
-- *Why* the core infra was chosen → `docs/summaries/decision-10-architecture-rationale.md`
 - Per-feature decisions and external-service gotchas → `docs/summaries/decision-*.md`
 
 ---
@@ -17,6 +16,22 @@ A private Telegram bot that summarizes content — webpages, YouTube/Castro
 links, audio, voice, video, video notes, and documents — with Gemini, and
 replies with the summary in the user's chosen language. Synchronous,
 polling-based (`bot.infinity_polling`); no webhooks, no async framework.
+
+## Why this stack
+
+Rationale for the standing infrastructure choices — the part not derivable from
+`pyproject.toml` or `README.md`. Treat each as settled; reverse one only as a
+deliberate decision, not incidental cleanup.
+
+- **Synchronous, polling-based bot** (pyTelegramBotAPI) — no webhooks or async
+  framework are needed for this workload.
+- **Valkey over Redis** — Redis-protocol compatible, and avoids Redis's licensing terms.
+- **Gemini primary, Replicate fallback** — Replicate gives model flexibility without
+  code changes.
+- **PostgreSQL for persistent user data, Valkey for ephemeral rate-limit counters** —
+  the two have different durability needs.
+- **Modal for serverless cron** — resets Gemini daily rate limits without running a
+  second container.
 
 ## Component map (`src/`)
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -19,19 +19,19 @@ polling-based (`bot.infinity_polling`); no webhooks, no async framework.
 
 ## Why this stack
 
-Rationale for the standing infrastructure choices — the part not derivable from
+Rationale for the standing infrastructure choices — mostly not derivable from
 `pyproject.toml` or `README.md`. Treat each as settled; reverse one only as a
 deliberate decision, not incidental cleanup.
 
-- **Synchronous, polling-based bot** (pyTelegramBotAPI) — no webhooks or async
-  framework are needed for this workload.
+- **Synchronous polling** (see above) — no webhooks or async framework are needed
+  for this workload.
 - **Valkey over Redis** — Redis-protocol compatible, and avoids Redis's licensing terms.
 - **Gemini primary, Replicate fallback** — Replicate gives model flexibility without
   code changes.
 - **PostgreSQL for persistent user data, Valkey for ephemeral rate-limit counters** —
   the two have different durability needs.
 - **Modal for serverless cron** — resets Gemini daily rate limits without running a
-  second container.
+  second container. Also stated in `README.md`; keep the two in step.
 
 ## Component map (`src/`)
 


### PR DESCRIPTION
## What changed

`docs/context/architecture.md` gains a new **"Why this stack"** section listing the five standing infrastructure rationale bullets (sync/polling, Valkey over Redis, Gemini/Replicate fallback, Postgres+Valkey split, Modal cron), and drops its pointer to `docs/summaries/decision-10-architecture-rationale.md`.

`docs/summaries/decision-10-architecture-rationale.md` (gitignored, not part of this PR's diff but changed locally) is marked `SUPERSEDED`, pointing back at `architecture.md` — kept only as history of the original `tech-stack.md` removal, no longer the live source.

## Why

`docs/summaries/` is gitignored. `architecture.md` — tracked, and mandatory reading before touching code per `AGENTS.md` — pointed at decision-10 for the *why* behind the core stack. That means a fresh clone, another contributor, or a cloud agent hit a dangling reference: the pointer existed, the file it named didn't. Inlining the rationale makes it reachable everywhere the tracked file is.

## Reviewer notes

- Two commits: the first inlines the rationale, the second is a self-review fix-up (`a3c822d`) for two duplication issues caught in `/code-review`:
  - The new "Modal for serverless cron" bullet restated a rationale already public in `README.md:187`; the framing claim ("not derivable from README.md") was softened to "mostly," and the bullet now cross-references README so the two don't silently drift.
  - The new "Synchronous, polling-based bot" bullet duplicated the `## What it is` paragraph eight lines above; trimmed to keep only the non-redundant rationale clause ("no webhooks or async framework needed for this workload").
- `docs/context/architecture.md:9` still points at `docs/summaries/decision-*.md` for **per-feature** decisions — that pointer remains gitignored-only and out of scope here.
- Docs-only change; ruff/ty/pytest pre-commit hooks skipped by design, rest passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Why this stack” section to the architecture documentation.
  * Documented key infrastructure decisions, including polling strategy, cache choice, AI provider fallback, data storage approach, and scheduled daily counter resets.
  * Updated the README guidance on what the scheduled job resets and removed the separate architecture rationale reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->