### PR TITLE
docs: retire the decision-record template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,12 @@ Before your first edit to a tracked file, branch off `main` (`git checkout -b <s
 
 ## Where Things Live
 
-- `docs/summaries/` — session outputs: handoffs (work log) and Rule 3 overflow files. **(gitignored)**
+- `docs/summaries/` — session outputs: handoffs (`handoff-*.md`, work log) and Rule 3 overflow analyses (`analysis-*.md`). **(gitignored)**
 - `docs/context/` — reusable domain knowledge, loaded only when relevant. **(tracked)**
   - `architecture.md` — component map and data flow; update only on architectural change
   - `style-guide.md` — coding conventions Ruff does not enforce
   - `git-guide.md` — commit format, pre-commit hooks, coverage
   - `uv-guide.md` — running the project and managing dependencies
-  - `agent-templates.md` — handoff and Rule 3 overflow templates (read on demand)
+  - `agent-templates.md` — handoff and analysis (Rule 3 overflow) templates (read on demand)
 - `docs/archive/` — processed raw files. Do not read unless explicitly told. **(gitignored)**
 - `.claude/commands/handoff.md` — the `/handoff` routine; agents without slash commands follow its steps directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Before your first edit to a tracked file, branch off `main` (`git checkout -b <s
 
 ## Rules
 
-1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, by following `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly). Decision records and analyses are separate outputs, written when the user asks or when Rule 3 requires one — templates in `docs/context/agent-templates.md`.
+1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, by following `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly). Rule 3 overflow files are a separate output — template in `docs/context/agent-templates.md`.
 2. **Surface every open question.** Mark unresolved items OPEN or ASSUMED in the final answer, and in the handoff when one is written. Before delivering output, verify exact numbers are preserved and claims are backed by specific data.
 3. Sub-agent returns must be structured — exact numbers, file paths, decisions with rationale, open items — not free-form prose. Target 1,000–2,000 tokens per return; write anything longer to `docs/summaries/analysis-<topic>.md` and return the path.
 4. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.
@@ -22,12 +22,12 @@ Before your first edit to a tracked file, branch off `main` (`git checkout -b <s
 
 ## Where Things Live
 
-- `docs/summaries/` — session outputs: handoffs (work log), decision records, analyses. **(gitignored)**
+- `docs/summaries/` — session outputs: handoffs (work log) and Rule 3 overflow files. **(gitignored)**
 - `docs/context/` — reusable domain knowledge, loaded only when relevant. **(tracked)**
   - `architecture.md` — component map and data flow; update only on architectural change
   - `style-guide.md` — coding conventions Ruff does not enforce
   - `git-guide.md` — commit format, pre-commit hooks, coverage
   - `uv-guide.md` — running the project and managing dependencies
-  - `agent-templates.md` — handoff, decision-record, and analysis templates (read on demand)
+  - `agent-templates.md` — handoff and Rule 3 overflow templates (read on demand)
 - `docs/archive/` — processed raw files. Do not read unless explicitly told. **(gitignored)**
 - `.claude/commands/handoff.md` — the `/handoff` routine; agents without slash commands follow its steps directly.

--- a/docs/context/agent-templates.md
+++ b/docs/context/agent-templates.md
@@ -1,6 +1,6 @@
 # Agent Templates — On-Demand Reference
 
-> **Do NOT read this file at session start.** Read it only when writing a handoff, a decision record, or an analysis summary.
+> **Do NOT read this file at session start.** Read it only when writing a handoff or a Rule 3 overflow file.
 
 ---
 
@@ -45,68 +45,22 @@ Under What NOT to Re-Read list the handoffs, plans, and analyses this session ac
 
 ---
 
-## Template 2: Decision Record
+## Template 2: Sub-Agent Overflow
 
-**Use when:** A significant decision is made during a session (library choice, architecture, migration strategy, error-handling approach). These persist in `docs/summaries/` as the project's ADRs.
-
-**Write to:** `docs/summaries/decision-[number]-[topic].md`
-
-```markdown
-# Decision [N]: [Short Title] ([ticket if any])
-**Date:** [YYYY-MM-DD]  **Branch:** [branch]  **Issue:** [link/id, if any]
-
-## Problem
-[2-3 sentences: what situation prompted this decision]
-
-## Decision
-[One clear statement of what was decided]
-- CHOSE [option] BECAUSE [specific reason] — STATUS: [confirmed (user) / provisional]
-- REJECTED [alternative] BECAUSE [specific reason]
-
-## Files Modified
-| File | Change |
-|------|--------|
-| `[path]` | [what changed] |
-
-## Verification
-- pre-commit hooks at commit time — [result]
-- pytest hook — [exact pass count, e.g. **207 passed**; no new uncovered lines]
-
-## Open Items
-- [next step / unresolved item] or None
-```
-
----
-
-## Template 3: Analysis / Research Summary
-
-**Use when:** Completing a technical evaluation, feasibility check, incident investigation, or refactor scoping. Keep only the latest version per topic (archive the old one if re-run).
+**Use when:** A sub-agent return exceeds the Rule 3 budget and goes to a file instead of into the reply. Keep only the latest version per topic (archive the old one if re-run).
 
 **Write to:** `docs/summaries/analysis-[topic].md`
 
 ```markdown
-# Analysis Summary: [Topic]
-**Completed:** [YYYY-MM-DD]
-**Analysis Type:** [technical / feasibility / incident / refactor]
-**Sources Used:** [file paths or URLs]
-**Confidence:** [high / medium / low — and WHY]
+# Analysis: [Topic]
+**Date:** [YYYY-MM-DD]  **Scope:** [what was investigated]
 
-## Core Finding (One Sentence)
-[Single sentence: the most important conclusion]
+## Core Finding
+[one sentence]
 
-## Evidence Base
-<!-- Specific data points. Exact values only — do not round. -->
-| Data Point | Value | Source | Date of Data |
-|-----------|-------|--------|-------------|
-| [metric]  | [exact value] | [source] | [date] |
+## Findings
+- WHAT: [finding] — EVIDENCE: [`file:line`, exact numbers — do not round] — SO WHAT: [why it matters here]
 
-## Detailed Findings
-### Finding 1: [Name]
-- WHAT: [the finding]
-- SO WHAT: [why it matters for this project]
-- EVIDENCE: [specific supporting data, file:line]
-- CONFIDENCE: [high/medium/low]
-
-## Recommended Next Steps
-1. [action] — priority [high/medium/low], depends on [what]
+## Open Items
+- [OPEN/ASSUMED item, or next step] or None
 ```

--- a/docs/context/agent-templates.md
+++ b/docs/context/agent-templates.md
@@ -47,7 +47,7 @@ Under What NOT to Re-Read list the handoffs, plans, and analyses this session ac
 
 ## Template 2: Analysis (Rule 3 Overflow)
 
-**Use when:** A sub-agent return exceeds the Rule 3 budget and goes to a file instead of into the reply. Keep only the latest version per topic (archive the old one if re-run).
+**Use when:** A sub-agent return exceeds the Rule 3 budget and goes to a file instead of into the reply. Keep only the latest version per topic — on a re-run, move the existing `docs/summaries/analysis-[topic].md` to `docs/archive/summaries/` before writing the new one.
 
 **Write to:** `docs/summaries/analysis-[topic].md`
 

--- a/docs/context/agent-templates.md
+++ b/docs/context/agent-templates.md
@@ -45,7 +45,7 @@ Under What NOT to Re-Read list the handoffs, plans, and analyses this session ac
 
 ---
 
-## Template 2: Sub-Agent Overflow
+## Template 2: Analysis (Rule 3 Overflow)
 
 **Use when:** A sub-agent return exceeds the Rule 3 budget and goes to a file instead of into the reply. Keep only the latest version per topic (archive the old one if re-run).
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -2,7 +2,8 @@
 
 High-level component map and data flow for orientation at session start. **Stable** —
 update only on a real architectural change (new component, new flow, routing/fallback
-rewrite), not every handoff. Not a source mirror: read the source for function
+rewrite) or a durable external-service gotcha (→ Cross-cutting patterns), not every
+handoff. Not a source mirror: read the source for function
 signatures, dependencies, and env vars.
 
 - Stack → `pyproject.toml` + `README.md`

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -6,7 +6,6 @@ rewrite), not every handoff. Not a source mirror: read the source for function
 signatures, dependencies, and env vars.
 
 - Stack → `pyproject.toml` + `README.md`
-- Per-feature decisions and external-service gotchas → `docs/summaries/decision-*.md`
 
 ---
 


### PR DESCRIPTION
## What changed

- **Deleted Template 2 (Decision Record)** from `docs/context/agent-templates.md`.
- **Renumbered Template 3 → Template 2**, retitled it *Analysis (Rule 3 Overflow)*, and trimmed it from 32 lines to 13 — dropped `Analysis Type`, `Sources Used`, `Confidence`, the evidence table, and `Recommended Next Steps`.
- **`AGENTS.md`** — Rule 1's tail, the `docs/summaries/` bullet, and the `agent-templates.md` bullet no longer mention decision records.
- **`docs/context/architecture.md`** — removed the `docs/summaries/decision-*.md` pointer; added external-service gotchas to the stability header's update triggers.
- Archived all 11 existing `decision-*.md` files to `docs/archive/summaries/` (untracked move — that path is gitignored).

Net: 3 files, +19/−65.

## Why

Nothing triggered the decision-record template automatically. Its only pointer was an `architecture.md` bullet into gitignored `docs/summaries/`, so a fresh clone got a dangling reference. The handoff template's `Decisions Made` section already carries the same `[decision] BECAUSE [rationale] — STATUS:` shape, and Rule 7 forces the durable part into tracked `docs/context/` regardless — a decision record was that content a second and third time.

Template 3 stayed because Rule 3 gained a live, non-user trigger in #1002 (sub-agent returns over ~2,000 tokens land in `docs/summaries/analysis-<topic>.md`). But its evaluation-report framing fit a job it no longer does, so it now matches what Rule 3 actually asks for: exact numbers, file paths, open items.

## Reviewer notes

Two follow-up findings from `/code-review` are fixed in the second commit (6cae8b2), kept separate rather than amended:

1. **Gotchas lost their home.** Retiring the decision record left non-architectural external-service gotchas with no destination — Rule 7 mandates `docs/context/` updates only for architectural change, and `architecture.md`'s own header repeated that limit, so such a gotcha could only land in a gitignored handoff that AGENTS.md:5 tells agents never to load on their own. The header now names `Cross-cutting patterns` as its home, where `Gemini bills failed calls` and the OOP-unwind rejection already live.
2. **Naming drift.** The overflow artifact had three names (*Rule 3 overflow files*, *Sub-Agent Overflow*, `analysis-*.md`), none matching the file on disk, so the "Where Things Live" lookup table couldn't resolve "check the analysis for X". Unified on *analysis*, and the bullet now carries both `handoff-*.md` and `analysis-*.md` prefixes.

Docs-only, so the ruff/ty/pytest hooks skipped at commit time as expected. The 11 archived decision records remain readable in `docs/archive/summaries/`; nothing was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Refined project rules to better direct where “Rule 3 overflow” outputs should be created and documented.
  - Updated agent template guidance to prevent template reading during normal sessions and replaced the decision record template with a streamlined “Rule 3 overflow” analysis template.
  - Revised architecture documentation to clarify when high-level component/data-flow guidance should be updated and removed outdated links to per-feature decision materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->