### PR TITLE
docs: trim restated docstrings and comments

### DIFF
--- a/docs/context/style-guide.md
+++ b/docs/context/style-guide.md
@@ -20,8 +20,11 @@ Use `# noqa` sparingly and always specify the exact rule code.
 
 ## Docstrings & Comments
 
-- Public functions, classes, and methods use **Google-style** docstrings — define `Args:`,
-  `Returns:`, and `Raises:` where applicable; keep descriptions concise.
+- Public functions, classes, and methods use **Google-style** docstrings led by a one-line summary.
+  Skip `Args:` — annotations are complete, so a param block only restates the signature; fold
+  anything non-obvious into the summary instead. Keep `Raises:` (the `RetryError` contracts the
+  `@retry` decorators create are not derivable from the body), and `Returns:` only where it says
+  something the return type does not.
 - Docstrings for private (`_method`) members are optional when behavior is obvious.
 - Use inline `#` comments sparingly, and only to explain *why* non-obvious logic exists — not *what*
   the code does. Code should be self-documenting through naming.

--- a/src/database.py
+++ b/src/database.py
@@ -34,7 +34,12 @@ class UserRepository:
         prompt_key_for_summary: str = DEFAULT_PROMPT_KEY,
         thinking_level: str = DEFAULT_THINKING_LEVEL,
     ) -> bool:
-        """Register a new user; False if that user id is already present."""
+        """Register a new user; False on any IntegrityError.
+
+        The primary key is this table's only constraint, so in practice that means
+        a duplicate user id — which is why `handle_start` reads False as "already
+        registered". A schema change adding constraints would break that reading.
+        """
         with Session() as session:
             try:
                 stmt = UsersOrm(

--- a/src/database.py
+++ b/src/database.py
@@ -36,9 +36,9 @@ class UserRepository:
     ) -> bool:
         """Register a new user; False on any IntegrityError.
 
-        The primary key is this table's only constraint, so in practice that means
-        a duplicate user id — which is why `handle_start` reads False as "already
-        registered". A schema change adding constraints would break that reading.
+        For `handle_start`'s input that means a duplicate user id, which is why it
+        reads False as "already registered". Any other violation — a NOT NULL
+        column passed None, or constraints added later — reports identically.
         """
         with Session() as session:
             try:

--- a/src/database.py
+++ b/src/database.py
@@ -34,12 +34,7 @@ class UserRepository:
         prompt_key_for_summary: str = DEFAULT_PROMPT_KEY,
         thinking_level: str = DEFAULT_THINKING_LEVEL,
     ) -> bool:
-        """Register a new user in the database.
-
-        Returns:
-            bool: True if registration is successful, False if already registered.
-
-        """
+        """Register a new user; False if that user id is already present."""
         with Session() as session:
             try:
                 stmt = UsersOrm(
@@ -91,65 +86,39 @@ class UserRepository:
             return True
 
     def set_target_language(self, user_id: int, target_language: str) -> bool:
-        """Set the target language for a user.
-
-        Returns:
-            bool: True on success, False if language unsupported or user not found.
-
-        """
+        """Set the user's target language; False if unsupported or user unknown."""
         normalized = target_language.title()
         if normalized not in SUPPORTED_LANGUAGES:
             return False
         return self._update_field(user_id, "target_language", normalized)
 
     def set_summarizing_model(self, user_id: int, summarizing_model: str) -> bool:
-        """Set the summarizing model for a user.
-
-        Returns:
-            bool: True on success, False if model unsupported or user not found.
-
-        """
+        """Set the user's summarizing model; False if unsupported or user unknown."""
         normalized = summarizing_model.lower()
         if normalized not in ALLOWED_MODELS_FOR_SUMMARY:
             return False
         return self._update_field(user_id, "summarizing_model", normalized)
 
     def set_thinking_level(self, user_id: int, thinking_level: str) -> bool:
-        """Set the AI thinking level for a user.
-
-        Returns:
-            bool: True on success, False if level unsupported or user not found.
-
-        """
+        """Set the user's thinking level; False if unsupported or user unknown."""
         normalized = thinking_level.upper()
         if normalized not in ALLOWED_THINKING_LEVELS:
             return False
         return self._update_field(user_id, "thinking_level", normalized)
 
     def set_prompt_strategy(self, user_id: int, prompt_key_for_summary: str) -> bool:
-        """Set the prompt strategy for a user.
-
-        Returns:
-            bool: True on success, False if key unsupported or user not found.
-
-        """
+        """Set the user's prompt strategy; False if unsupported or user unknown."""
         normalized = prompt_key_for_summary.lower()
         if normalized not in ALLOWED_PROMPT_KEYS:
             return False
         return self._update_field(user_id, "prompt_key_for_summary", normalized)
 
 
-# ---------------------------------------------------------------------------
 # Module-level singleton
-# ---------------------------------------------------------------------------
-
 user_repo = UserRepository()
 
 
-# ---------------------------------------------------------------------------
 # Module-level aliases — preserve the existing public API
-# ---------------------------------------------------------------------------
-
 register_user = user_repo.register_user
 select_user = user_repo.select_user
 check_auth = user_repo.check_auth

--- a/src/download.py
+++ b/src/download.py
@@ -105,13 +105,7 @@ class Downloader:
         reraise=False,
     )
     def download_yt(self, url: str) -> str:
-        """Download audio from a YouTube video and convert it to MP3 format.
-
-        Args:
-            url (str): The YouTube video URL to download from.
-
-        Returns:
-            str: Path to the downloaded temporary MP3 file.
+        """Download a YouTube video's audio as MP3, returning the temp file path.
 
         Raises:
             RetryError: If the download fails after 2 retry attempts.
@@ -159,13 +153,7 @@ class Downloader:
         reraise=False,
     )
     def download_castro(self, url: str) -> str:
-        """Download audio from a Castro podcast URL and save it as an MP3 file.
-
-        Args:
-            url (str): The Castro podcast URL to download from.
-
-        Returns:
-            str: Path to the downloaded temporary MP3 file.
+        """Scrape a Castro episode page for its audio and save it as an MP3.
 
         Raises:
             ValueError: If the audio source tag or URL is missing on the page.
@@ -203,14 +191,7 @@ class Downloader:
         return temporary_file_name
 
     def download_tg(self, file_id: File, ext: str = "") -> str:
-        """Download a file from Telegram and save it locally.
-
-        Args:
-            file_id (File): The Telegram File object containing file information.
-            ext (str, optional): File extension for the output file.
-
-        Returns:
-            str: Path to the downloaded temporary file.
+        """Fetch a Telegram file, returning the local temp path.
 
         Raises:
             ValueError: If the Telegram file path is missing.
@@ -227,17 +208,11 @@ class Downloader:
         return temporary_file_name
 
 
-# ---------------------------------------------------------------------------
 # Module-level singleton
-# ---------------------------------------------------------------------------
-
 downloader = Downloader()
 
 
-# ---------------------------------------------------------------------------
 # Module-level aliases — preserve the existing public API
-# ---------------------------------------------------------------------------
-
 download_yt = downloader.download_yt
 download_castro = downloader.download_castro
 download_tg = downloader.download_tg

--- a/src/download.py
+++ b/src/download.py
@@ -153,10 +153,14 @@ class Downloader:
         reraise=False,
     )
     def download_castro(self, url: str) -> str:
-        """Scrape a Castro episode page for its audio and save it as an MP3.
+        """Scrape a Castro episode page for its audio URL and stream it to a file.
+
+        The bytes are stored as fetched, with no transcoding; the `.mp3` temp name
+        reflects the common case, not a verified container.
 
         Raises:
             ValueError: If the audio source tag or URL is missing on the page.
+            TypeError: If the page's source `src` is not a string.
             HTTPError: If the HTTP request fails.
             RetryError: If SSL/connection failures persist after retries.
 

--- a/src/llm.py
+++ b/src/llm.py
@@ -40,15 +40,7 @@ class LLMClient:
     """Provider-agnostic entry point for every summarization model call."""
 
     def build_model(self, model_id: str) -> Model:
-        """Return the provider model for a registered model id.
-
-        Args:
-            model_id (str): A key of `config.MODEL_SPECS`.
-
-        Returns:
-            Model: The pydantic-ai model, shared across calls for that id.
-
-        """
+        """Return the pydantic-ai model for a registered id, shared across calls."""
         return _build_model(model_id)
 
     def build_settings(self, model_id: str, thinking_level: str) -> ModelSettings:
@@ -59,14 +51,6 @@ class LLMClient:
         Gemini would generate thought summaries that `run` discards. Passing the
         level straight through keeps the request shape and stays lenient about
         an unrecognized level, which the provider decides on rather than us.
-
-        Args:
-            model_id (str): A key of `config.MODEL_SPECS`.
-            thinking_level (str): One of `config.ALLOWED_THINKING_LEVELS`.
-
-        Returns:
-            ModelSettings: Settings carrying the thinking level.
-
         """
         if MODEL_SPECS[model_id].provider == "google":
             return GoogleModelSettings(
@@ -80,11 +64,6 @@ class LLMClient:
 
     def build_uploaded_file(self, model_id: str, file: types.File) -> UploadedFile:
         """Reference a file already uploaded to the provider's file API.
-
-        Args:
-            model_id (str): A key of `config.MODEL_SPECS`.
-            file (types.File): The processed file returned by
-                `services.upload_and_wait_for_file`.
 
         Returns:
             UploadedFile: A message part pointing at the stored file. For Google
@@ -119,15 +98,8 @@ class LLMClient:
     ) -> str:
         """Run one summarization request and return the model's text output.
 
-        Args:
-            content (str | Sequence[UserContent]): The prompt, either on its own
-                or followed by the file parts it refers to.
-            model_id (str): A key of `config.MODEL_SPECS`.
-            target_language (str): The language to write the summary in.
-            thinking_level (str): One of `config.ALLOWED_THINKING_LEVELS`.
-
-        Returns:
-            str: The generated text.
+        `content` is the prompt on its own, or the prompt followed by the file
+        parts it refers to.
 
         Raises:
             AttributeError: If the model returns an empty response.
@@ -150,17 +122,11 @@ class LLMClient:
         return result.output
 
 
-# ---------------------------------------------------------------------------
 # Module-level singleton
-# ---------------------------------------------------------------------------
-
 llm_client = LLMClient()
 
 
-# ---------------------------------------------------------------------------
 # Module-level aliases — preserve the existing public API
-# ---------------------------------------------------------------------------
-
 build_model = llm_client.build_model
 build_settings = llm_client.build_settings
 build_uploaded_file = llm_client.build_uploaded_file

--- a/src/main.py
+++ b/src/main.py
@@ -55,20 +55,7 @@ if TYPE_CHECKING:
 # /start
 @bot.message_handler(commands=["start"])
 def handle_start(message: Message) -> None:
-    """Handle the /start command for the bot.
-
-    This function registers new users and sends a welcome message. If the user is
-    registering for the first time, they receive an initial greeting. Otherwise,
-    they receive a confirmation message.
-
-    Args:
-        message (Message): The message object from Telegram containing user information
-                           and chat details.
-
-    Returns:
-        None
-
-    """
+    """Handle /start: register a new user, or welcome back an existing one."""
     if message.from_user is None:
         bot.reply_to(message, "User information is missing.")
         return
@@ -92,18 +79,7 @@ def handle_start(message: Message) -> None:
 # /info
 @bot.message_handler(commands=["info"])
 def handle_info(message: Message) -> None:
-    """Handle the /info command for the bot.
-
-    This function sends back the user's Telegram ID when they use the /info command.
-
-    Args:
-        message (Message): The message object from Telegram containing user information
-                           and chat details.
-
-    Returns:
-        None
-
-    """
+    """Handle /info: reply with the sender's Telegram user ID."""
     if message.from_user is None:
         bot.reply_to(message, "User information is missing.")
         return
@@ -118,21 +94,7 @@ def handle_info(message: Message) -> None:
     ),
 )
 def handle_myinfo(message: Message) -> None:
-    """Handle the /myinfo command for the bot.
-
-    This function retrieves and sends detailed information about the user.
-    It checks if the user is authenticated and then fetches their information
-    from the database, including their user ID, approval status, translation
-    settings, target language, and parsing strategy.
-
-    Args:
-        message (Message): The message object from Telegram containing user information
-                           and chat details.
-
-    Returns:
-        None
-
-    """
+    """Handle /myinfo: reply with the user's settings, limit, and remaining quota."""
     if message.from_user is None:
         bot.reply_to(message, "User information is missing.")
         return
@@ -181,23 +143,7 @@ def handle_set_target_language(message: Message) -> None:
 
 
 def proceed_set_target_language(message: Message) -> None:
-    """Process the target language selection and update user settings.
-
-    This function is called after the user selects a language from the keyboard markup.
-    It attempts to set the user's target language preference and sends a confirmation
-    message. If the selected language is not supported, it raises a ValueError.
-
-    Args:
-        message (Message): The message object from Telegram containing the selected
-                          language and user information.
-
-    Raises:
-        ValueError: If the selected language is not supported.
-
-    Returns:
-        None
-
-    """
+    """Apply the language picked from the keyboard, or report it as unknown."""
     if message.from_user is None or message.text is None:
         bot.reply_to(message, "User information or language is missing.")
         return
@@ -232,20 +178,7 @@ def handle_set_summarizing_model(message: Message) -> None:
 
 
 def proceed_set_summarizing_model(message: Message) -> None:
-    """Process the summarizing model selection and update user settings.
-
-    This function is called after the user selects a model from the keyboard markup.
-    It attempts to set the user's summarizing model preference and sends a confirmation
-    message. If the selected model is not supported, it sends an error message.
-
-    Args:
-        message (Message): The message object from Telegram containing the selected
-                          model and user information.
-
-    Returns:
-        None
-
-    """
+    """Apply the model picked from the keyboard, or report it as unknown."""
     if message.from_user is None or message.text is None:
         bot.reply_to(message, "User information or model is missing.")
         return
@@ -282,20 +215,7 @@ def handle_set_prompt_strategy(message: Message) -> None:
 
 
 def proceed_set_prompt_strategy(message: Message) -> None:
-    """Process the prompt strategy selection and update user settings.
-
-    This function is called after the user selects a strategy from the keyboard markup.
-    It attempts to set the user's prompt strategy preference and sends a confirmation
-    message. If the selected strategy is not supported, it sends an error message.
-
-    Args:
-        message (Message): The message object from Telegram containing the selected
-                           strategy and user information.
-
-    Returns:
-        None
-
-    """
+    """Apply the strategy picked from the keyboard, or report it as unknown."""
     if message.from_user is None or message.text is None:
         bot.reply_to(message, "User information or strategy is missing.")
         return
@@ -332,21 +252,7 @@ def handle_set_thinking_level(message: Message) -> None:
 
 
 def proceed_set_thinking_level(message: Message) -> None:
-    """Process the thinking level selection and update user settings.
-
-    This function is called after the user selects a level from the keyboard markup.
-    It attempts to set the user's thinking level preference and sends a
-    confirmation message. If the selected level is not supported, it sends an
-    error message.
-
-    Args:
-        message (Message): The message object from Telegram containing the selected
-                           level and user information.
-
-    Returns:
-        None
-
-    """
+    """Apply the thinking level picked from the keyboard, or report it as unknown."""
     if message.from_user is None or message.text is None:
         bot.reply_to(message, "User information or level is missing.")
         return
@@ -366,16 +272,7 @@ def proceed_set_thinking_level(message: Message) -> None:
 
 
 def process_message_content(message: Message, user: UsersOrm) -> None:
-    """Process the content of a validated message.
-
-    Args:
-        message (Message): The message object from Telegram
-        user (UsersOrm): The authenticated user object
-
-    Returns:
-        None
-
-    """
+    """Route a validated message to the handler for its content type."""
     if message.content_type == "audio":
         handle_audio(message, user)
     elif (
@@ -403,24 +300,10 @@ def process_message_content(message: Message, user: UsersOrm) -> None:
     content_types=["text", "audio", "document", "video_note", "voice", "video"],
 )
 def handle_message(message: Message) -> None:
-    """Universal message handler for the bot.
+    """Universal entry point: authorize the sender, then route and trace the message.
 
-    This function processes various types of content:
-    - YouTube and Castro.fm URLs
-    - Other webpage URLs
-    - Audio files
-    - General text messages
-
-    Catches and maps the pipeline's failure modes to user-facing replies:
-    LimitExceededError, WebParseError, RetryError, and any other Exception are
-    reported to Sentry and answered with an appropriate message.
-
-    Args:
-        message (Message): The message object from Telegram
-
-    Returns:
-        None
-
+    Every failure mode of the pipeline terminates here — each is reported to
+    Sentry and answered with a user-facing message.
     """
     try:
         if message.from_user is None:

--- a/src/main.py
+++ b/src/main.py
@@ -302,8 +302,9 @@ def process_message_content(message: Message, user: UsersOrm) -> None:
 def handle_message(message: Message) -> None:
     """Universal entry point: authorize the sender, then route and trace the message.
 
-    Every failure mode of the pipeline terminates here — each is reported to
-    Sentry and answered with a user-facing message.
+    Every failure the summarization pipeline raises terminates here — reported to
+    Sentry, answered with a user-facing message. The command and settings handlers
+    are separate entry points and are not covered by this guard.
     """
     try:
         if message.from_user is None:

--- a/src/models.py
+++ b/src/models.py
@@ -7,23 +7,10 @@ class Base(DeclarativeBase):
 
 
 class UsersOrm(Base):
-    """SQLAlchemy ORM model representing users in the database.
+    """The `users` table: identity, approval, per-user settings, and daily cap.
 
-    This class defines the structure of the 'users' table, storing user preferences
-    and settings for various features of the application.
-
-    Attributes:
-        user_id (int): Primary key identifier for the user.
-        first_name (str | None): User's first name, optional.
-        last_name (str | None): User's last name, optional.
-        username (str | None): User's username, optional.
-        approved (bool): Flag indicating if the user is approved, defaults to False.
-        target_language (str): Language for translations, defaults to "English".
-        summarizing_model (str): Model for summary.
-        prompt_key_for_summary (str): Prompt key for summarization strategy.
-        daily_limit (int): Max requests per day for this user, defaults to 0 (blocked).
-        thinking_level (str): AI thinking level
-
+    Server defaults must stay in step with the matching constants in `config.py`.
+    A `daily_limit` of 0 blocks the user.
     """
 
     __tablename__ = "users"

--- a/src/services.py
+++ b/src/services.py
@@ -152,11 +152,6 @@ class GeminiHelper:
         return uploaded
 
 
-# ---------------------------------------------------------------------------
-# Langfuse tracing
-# ---------------------------------------------------------------------------
-
-
 @contextmanager
 def observe_message(user_id: int, content_type: str) -> Generator[None]:
     """Group all model calls for one Telegram message into a single trace.
@@ -164,14 +159,6 @@ def observe_message(user_id: int, content_type: str) -> Generator[None]:
     Opens a Langfuse root span attributed to the user and tagged with the
     message content type, so the generation spans emitted by pydantic-ai nest
     under one trace. A no-op when Langfuse is not configured.
-
-    Args:
-        user_id (int): Telegram user ID, recorded as the trace's user id.
-        content_type (str): Telegram message content type, recorded as a tag.
-
-    Yields:
-        None
-
     """
     if langfuse_client is None:
         yield
@@ -183,20 +170,14 @@ def observe_message(user_id: int, content_type: str) -> Generator[None]:
         yield
 
 
-# ---------------------------------------------------------------------------
 # Module-level singletons
-# ---------------------------------------------------------------------------
-
 messenger = Messenger()
 quota_manager = QuotaManager()
 gemini_helper = GeminiHelper()
 
 
-# ---------------------------------------------------------------------------
 # Module-level aliases — keep the existing public API intact so that
 # all importers and mocker.patch("services.*") calls continue to work.
-# ---------------------------------------------------------------------------
-
 get_file_with_retry = messenger.get_file_with_retry
 send_answer = messenger.send_answer
 

--- a/src/summary.py
+++ b/src/summary.py
@@ -64,19 +64,6 @@ class Summarizer:
     ) -> str:
         """Summarize audio content by uploading it to the provider's file API.
 
-        Args:
-            file (str): Path to the audio file to be summarized.
-            model (str): The summarizing model identifier.
-            prompt_key (str): Key to retrieve the prompt template from PROMPTS.
-            target_language (str): The language to translate the summary into.
-            user_id (int): Telegram user ID for per-user quota enforcement.
-            daily_limit (int): The user's configured daily request cap.
-            thinking_level (str): AI thinking level.
-            sleep_time (int, optional): Time between processing checks. Defaults to 10.
-
-        Returns:
-            str: Generated summary text from the audio content.
-
         Raises:
             AttributeError: If the model returns an empty response, or the upload
                 helper reports incomplete file metadata.
@@ -135,18 +122,6 @@ class Summarizer:
     ) -> str:
         """Summarize already-extracted text (a transcript or webpage content).
 
-        Args:
-            text (str): The text to summarize (transcript or pre-parsed webpage).
-            model (str): The summarizing model identifier.
-            prompt_key (str): Key to retrieve the prompt template from PROMPTS.
-            target_language (str): The language to translate the summary into.
-            user_id (int): Telegram user ID for per-user quota enforcement.
-            daily_limit (int): The user's configured daily request cap.
-            thinking_level (str): AI thinking level.
-
-        Returns:
-            str: Generated summary text.
-
         Raises:
             AttributeError: If the model returns an empty response.
             RetryError: If transient model or network errors persist after retries.
@@ -193,20 +168,6 @@ class Summarizer:
 
         Audio documents sent to a model that cannot read audio take the Replicate
         transcription path instead, and so carry the 📝 prefix.
-
-        Args:
-            file (File): Telegram File object for the document to be summarized.
-            model (str): The summarizing model identifier.
-            prompt_key (str): Key to retrieve the prompt template from PROMPTS.
-            target_language (str): The language to translate the summary into.
-            mime_type (str): MIME type of the document being uploaded.
-            user_id (int): Telegram user ID for per-user quota enforcement.
-            daily_limit (int): The user's configured daily request cap.
-            thinking_level (str): AI thinking level.
-            sleep_time (int, optional): Time between processing checks. Defaults to 10.
-
-        Returns:
-            str: Generated summary text from the document content.
 
         Raises:
             AttributeError: If the provider returns incomplete file metadata, or
@@ -276,22 +237,11 @@ class Summarizer:
         daily_limit: int,
         thinking_level: str,
     ) -> str:
-        """Generate a summary from various input sources.
-
-        Args:
-            data (str | File): Input data to summarize. Can be:
-                - YouTube URL
-                - Castro.fm episode URL
-                - Telegram File object
-            model (str): The summarizing model identifier.
-            prompt_key (str): Key to retrieve the prompt template from PROMPTS.
-            target_language (str): The language to translate the summary into.
-            user_id (int): Telegram user ID for per-user quota enforcement.
-            daily_limit (int): The user's configured daily request cap.
-            thinking_level (str): AI thinking level.
+        """Generate a summary from a YouTube/Castro URL, a Telegram file, or a path.
 
         Returns:
-            str: Generated summary of the content, prefixed with the source emoji.
+            str: The summary, carrying a source-provenance prefix on the
+                transcript and Replicate-transcription paths only.
 
         Raises:
             RetryError: If all summarization attempts fail after retries.
@@ -400,17 +350,11 @@ class Summarizer:
             clean_up(file=new_file)
 
 
-# ---------------------------------------------------------------------------
 # Module-level singleton
-# ---------------------------------------------------------------------------
-
 summarizer = Summarizer()
 
 
-# ---------------------------------------------------------------------------
 # Module-level aliases — preserve the existing public API
-# ---------------------------------------------------------------------------
-
 summarize_with_file = summarizer.summarize_with_file
 summarize_text = summarizer.summarize_text
 summarize_with_document = summarizer.summarize_with_document

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -172,7 +172,10 @@ class YtDlpBackend(TranscriptBackend):
 
     @staticmethod
     def _vtt_to_text(vtt_path: Path) -> str:
-        """Convert a VTT subtitle file to deduplicated plain text."""
+        """Convert a VTT subtitle file to plain text, collapsing consecutive repeats.
+
+        Only adjacent duplicates are dropped; a line recurring later is kept.
+        """
         lines = vtt_path.read_text(encoding="utf-8").splitlines()
         out: list[str] = []
         prev = ""

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -64,14 +64,7 @@ class AudioTranscriber:
         reraise=False,
     )
     def transcribe(self, file: str, sleep_time: int = 10) -> str:
-        """Transcribe an audio file using WhisperX model.
-
-        Args:
-            file (str): Path to the audio file to transcribe.
-            sleep_time (int, optional): Time in seconds to wait between status checks.
-
-        Returns:
-            str: The transcribed text from the audio file.
+        """Transcribe an audio file with the WhisperX model on Replicate.
 
         Raises:
             ModelError: If the transcription fails, is canceled, or output is invalid.
@@ -140,12 +133,6 @@ class ApiBackend(TranscriptBackend):
     def fetch_via_api(self, video_id: str) -> str:
         """Retrieve and format a YouTube transcript via youtube_transcript_api.
 
-        Args:
-            video_id (str): The YouTube video ID.
-
-        Returns:
-            str: The formatted transcript text.
-
         Raises:
             NoTranscriptFound: If no transcript is found in any language.
             CouldNotRetrieveTranscript: Subclasses propagate to the caller.
@@ -185,15 +172,7 @@ class YtDlpBackend(TranscriptBackend):
 
     @staticmethod
     def _vtt_to_text(vtt_path: Path) -> str:
-        """Convert a VTT subtitle file to deduplicated plain text.
-
-        Args:
-            vtt_path (Path): Path to the .vtt file.
-
-        Returns:
-            str: Clean transcript text with duplicate lines removed.
-
-        """
+        """Convert a VTT subtitle file to deduplicated plain text."""
         lines = vtt_path.read_text(encoding="utf-8").splitlines()
         out: list[str] = []
         prev = ""
@@ -237,12 +216,6 @@ class YtDlpBackend(TranscriptBackend):
         Probes available tracks first, preferring genuine manual subtitles (English
         when present) and otherwise the video's original-language automatic captions,
         then converts to vtt via ffmpeg.
-
-        Args:
-            url (str): The YouTube video URL.
-
-        Returns:
-            str: The transcript as plain text.
 
         Raises:
             DownloadError: If no subtitles are available or vtt conversion fails.
@@ -437,12 +410,9 @@ class YouTubeTranscriber:
         failure (including an empty result). With the default wiring this means
         the API first, then yt-dlp.
 
-        Args:
-            url (str): The YouTube video URL.
-
         Returns:
-            PrefixedText: The transcript text and display prefix. 📺 =
-                youtube_transcript_api; 📹 = yt-dlp.
+            PrefixedText: The transcript and its display prefix — 📺 for
+                youtube_transcript_api, 📹 for yt-dlp.
 
         Raises:
             ValueError: If the URL format is not recognized.
@@ -479,19 +449,13 @@ class YouTubeTranscriber:
         return PrefixedText(text=text, prefix=self._primary.prefix)
 
 
-# ---------------------------------------------------------------------------
 # Module-level singletons
-# ---------------------------------------------------------------------------
-
 audio_transcriber = AudioTranscriber(replicate_client)
 api_backend = ApiBackend()
 ytdlp_backend = YtDlpBackend()
 yt_transcriber = YouTubeTranscriber(api_backend, ytdlp_backend)
 
 
-# ---------------------------------------------------------------------------
 # Module-level aliases — preserve the existing public API
-# ---------------------------------------------------------------------------
-
 transcribe = audio_transcriber.transcribe
 get_yt_transcript = yt_transcriber.get_transcript

--- a/src/utils.py
+++ b/src/utils.py
@@ -82,10 +82,11 @@ def compress_audio(input_file: str, output_file: str) -> None:
 
 
 def clean_up(file: str | None = None, all_downloads: bool = False) -> None:
-    """Remove `file`, or every download when `all_downloads` is set.
+    """Remove `file`, or sweep the working directory when `all_downloads` is set.
 
-    Both paths skip anything in `config.PROTECTED_FILES`, the startup snapshot of
-    the working directory.
+    The sweep unlinks every regular file in the CWD, not only downloads. Both paths
+    skip `config.PROTECTED_FILES`, the startup snapshot — in PROD the container's
+    CWD is `src/`, so that snapshot covers the source tree.
     """
     if all_downloads:
         for file_name in Path.cwd().iterdir():

--- a/src/utils.py
+++ b/src/utils.py
@@ -62,7 +62,7 @@ def compress_audio(input_file: str, output_file: str) -> None:
     """
     subprocess.run(
         [
-            "ffmpeg",
+            "ffmpeg",  # /usr/bin/ffmpeg
             "-y",
             "-i",
             input_file,

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,9 +19,6 @@ def classify_url(url: str) -> str | None:
     the summarize path, and `summary.summarize` uses it to pick the download path.
     Both must agree, so neither may re-derive the kind on its own.
 
-    Args:
-        url (str): The URL to classify.
-
     Returns:
         str | None: "youtube" or "castro" for https media URLs, "web" for any
             other http(s) URL, None when the URL has no usable scheme or host.
@@ -50,50 +47,22 @@ def classify_url(url: str) -> str | None:
 
 
 def generate_temporary_name(ext: str = "") -> str:
-    """Generate a unique temporary filename with an optional extension.
-
-    Args:
-        ext (str, optional): File extension to append to the generated name.
-
-    Returns:
-        str: A unique filename string consisting of a UUID with the optional extension.
-
-    Example:
-        >>> generate_temporary_name(".mp3")
-        '123e4567-e89b-12d3-a456-426614174000.mp3'
-        >>> generate_temporary_name()
-        '123e4567-e89b-12d3-a456-426614174000'
-
-    """
+    """Generate a UUID filename, with `ext` appended when given."""
     return f"{uuid4()!s}{ext}"
 
 
 def compress_audio(input_file: str, output_file: str) -> None:
-    """Compress an audio file using FFmpeg with Opus codec.
+    """Compress an audio file to mono 16 kbps Opus, stripping any video stream.
 
-    This function compresses the input file using FFmpeg with the following settings:
-    - Single audio channel (mono)
-    - Opus codec
-    - 16kbps bitrate
-    - Strips any video streams
-
-    Args:
-        input_file (str): Path to the input audio file to be compressed.
-        output_file (str): Path where the compressed audio file will be saved.
+    Requires ffmpeg on PATH.
 
     Raises:
         subprocess.CalledProcessError: If the ffmpeg command fails.
 
-    Requirements:
-        - ffmpeg must be installed and available in system PATH
-
-    Example:
-        >>> compress_audio("input.mp3", "output.ogg")
-
     """
     subprocess.run(
         [
-            "ffmpeg",  # /usr/bin/ffmpeg
+            "ffmpeg",
             "-y",
             "-i",
             input_file,
@@ -113,20 +82,10 @@ def compress_audio(input_file: str, output_file: str) -> None:
 
 
 def clean_up(file: str | None = None, all_downloads: bool = False) -> None:
-    """Remove temporary files from the current working directory.
+    """Remove `file`, or every download when `all_downloads` is set.
 
-    This function can either remove a single specified file or all non-protected files
-    in the current working directory.
-
-    Args:
-        file (str | None, optional): Path to a specific file to remove.
-        all_downloads (bool): If True, removes all non-protected files in the
-                              current working directory.
-
-    Example:
-        >>> clean_up("temp.mp3")  # Remove a single file
-        >>> clean_up(all_downloads=True)  # Remove all non-protected files
-
+    Both paths skip anything in `config.PROTECTED_FILES`, the startup snapshot of
+    the working directory.
     """
     if all_downloads:
         for file_name in Path.cwd().iterdir():


### PR DESCRIPTION
## **User description**
Removes the docstring and comment text that only restates what the code already
says, keeping every line that carries context a reader cannot derive.

`src/` + `scripts/` goes from 3,121 to 2,749 lines: **-372** (331 docstring,
27 comment, plus the follow-up fixes). Docstrings drop from 21% to 12% of the
tree.

## What was removed

* **`Args:` blocks** (~81 lines). Annotation coverage is 100% and enforced by
  `ANN`, so a param block restates the signature. `model_id (str): A key of
  config.MODEL_SPECS.` appeared 4x in `llm.py`; `summary.py`'s four methods
  repeated the same 7 params. Anything non-obvious moved into the summary line.
* **`Returns: None`** on void functions (8x in `main.py`).
* **`Example:` doctest blocks** that showed the obvious call. `--doctest-modules`
  is not enabled, so these were never executed — no verification is lost.
* **`UsersOrm`'s `Attributes:` block**, which mirrored the column definitions and
  had already drifted (it stated defaults in prose next to `server_default=`, and
  omitted `thinking_level`'s). Deleting it removes a standing drift risk.
* **Repeated prose** — `main.py`'s "This function is called after the user selects
  X from the keyboard markup..." appeared 4x near-verbatim.
* **Banner comments** (`# ---- Module-level singleton ----`, 4 lines to 1) across
  6 files. The pattern itself is documented in `architecture.md`.

## What was kept

Every `Raises:` section — the `RetryError` contracts the `@retry` decorators
create are not derivable from the body — and every *why* comment: the 60-second
YouTube cooldown with its issue link, `classify_url`'s single-source-of-truth
note, the `Cast, not types.ThinkingLevel` rationale, `live_chat` filtering, the
nested-`try` in `summarize`, the re-check on the polled Gemini object, the IDNA
`UnicodeError`, the yt-dlp fragment cleanup, both `also change it in models.py`
cross-refs. `config.py`'s section headers stay — real navigation in a flat
226-line module.

`style-guide.md` records the sharpened rule so the verbose form does not creep
back. It was the only doc prescribing docstring format.

## Corrections found along the way

Three docstrings asserted things the code does not do:

* `proceed_set_target_language` promised `ValueError` on an unsupported language.
  It replies with a message and returns.
* `download_castro` said it saves the audio "as an MP3". It streams the remote
  bytes through untouched — only the temp *filename* is `.mp3` — unlike
  `download_yt`, which really does transcode via `FFmpegExtractAudio`. Its
  `Raises:` block was also missing the `TypeError` guard on a non-string `src`.
* `handle_message` claimed "every failure mode of the pipeline" terminates there.
  The command and settings handlers are separate entry points with no
  `try`/`except`, so the boundary is now named rather than implied.

## Reviewer notes

**No executable code changed** — and that is verifiable rather than assumed. With
docstring nodes stripped from the AST, all 18 files in `src/` and `scripts/` are
byte-identical to `main`. Every hunk is docstring or comment.

Nothing consumes the removed text at runtime: no `__doc__` / `inspect.getdoc`
references, no Sphinx/mkdocs/pdoc, no test asserts on docstrings.

Every substantive new claim was checked against the code — `UsersOrm`'s four
server defaults match their `config.py` constants; the prefixed return paths in
`summarize` are exactly the transcript and Replicate branches while
`summarize_with_file` returns raw; the backend prefixes are the ones documented;
both `clean_up` branches guard `PROTECTED_FILES`.

`ruff check`, `ruff format --check`, and 268 tests pass; coverage stays at 100%.
The 18 remaining `D` hits under an explicit `--select D` are all `D100`/`D401`,
both in the project's `ignore` list, so pre-existing and deliberate.

`tests/` was left alone by design — its docstrings are mostly one-liners already,
so the payoff is small and the diff would roughly triple.

**Out of scope, worth a separate look:** `download_castro` naming a possibly-`.m4a`
payload `.mp3` feeds `resolve_mime_type`'s extension-based `guess_type`, which can
hand Gemini `audio/mpeg` for non-MPEG bytes. Pre-existing behavior; this PR only
stops the docstring from claiming otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Trim repetitive documentation while preserving behavior-critical guidance

### What Changed
- Removed docstring sections that duplicate typed parameters, obvious return values, example calls, and database field definitions across the application.
- Replaced verbose descriptions with concise summaries that clarify observable behavior, including user commands, summarization inputs, transcript prefixes, and cleanup rules.
- Corrected documentation for Castro downloads: fetched audio is stored without transcoding, and invalid source URLs can raise a type error.
- Corrected the message-handler documentation to limit its error-handling claim to message processing, excluding separate command and settings handlers.
- Added documentation rules requiring concise summaries, retaining non-obvious return and error details, and limiting comments to rationale.
- Removed decorative section banners without changing the public behavior or available interfaces.

### Impact
`✅ Fewer misleading documentation claims`
`✅ Clearer error and output expectations`
`✅ Lower documentation maintenance overhead`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized public documentation with concise, consistent guidance.
  * Clarified behavior, error conditions, transcript handling, user limits, and source attribution.
  * Removed redundant argument and return-value details from API documentation.
  * Simplified internal comments and documentation around shared components.
* **Refactor**
  * Documentation-only cleanup; application behavior and public interfaces remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->