### PR TITLE
Complete the OOP migration: constructor injection and a composition root

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -54,7 +54,8 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (orchestrator over `ApiBackend` primary → `YtDlpBackend` fallback, mirroring `parsing.py`'s `ParserBackend`). |
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
 | `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
-| `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (MIME, file upload/poll). |
+| `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (MIME, file upload/poll), `Tracer` (Langfuse root span per message). |
+| `container.py` | `Container` + `build_container()` — the composition root; wires `services.py` collaborators to `config`'s clients. |
 | `database.py` | `UserRepository` — users table access (SQLAlchemy + Postgres). |
 | `models.py` | `UsersOrm` — the single `users` table (id, approval, per-user settings, `daily_limit`). |
 | `exceptions.py` | Domain exceptions: `LimitExceededError`, `WebParseError`, `TranscriptDownloadError`, `FetchTranscriptError`. |
@@ -132,13 +133,15 @@ to Gemini — return the raw model text with **no** prefix.
 
 ## Cross-cutting patterns
 
-- **OOP + singleton + alias.** Each service module defines a (mostly stateless)
-  class, instantiates one module-level singleton, then aliases its methods at
-  module level so the functional API (`module.func`) still works — importers and
-  `mocker.patch("module.func")` calls depend on those aliases. A proposal to
-  *unwind* this back to plain functions was reviewed and **rejected**; don't go
-  that way. Stricter OOP is welcome, and may drop the alias shim — but must
-  migrate importers and the `mocker.patch` test calls in the same change.
+- **Constructor injection migration (STG-135, in progress).** Service classes
+  are moving from module-level singletons to `__init__`-injected collaborators,
+  wired once by `container.py`'s composition root. `services.py` is migrated
+  (`Messenger`, `QuotaManager`, `GeminiHelper`, `Tracer` all take their client
+  in `__init__`); other service modules still carry the older class →
+  module-singleton → method-alias shim so `module.func` and
+  `mocker.patch("module.func")` keep working, dropped module by module as each
+  one's importers and tests move to injection. Unwinding back to plain
+  functions remains **rejected**.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one
   unit. A global per-minute limit throttles by sleeping. Counters live in Valkey;

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -50,7 +50,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `main.py` | Telegram entry point. Command handlers + the unified `handle_message`; routes by `content_type`; top-level error → user-message mapping. |
 | `handlers.py` | Per-content-type handlers. Media validation, builds `SummaryKwargs` from the user record, picks the summarize path. |
 | `summary.py` | `Summarizer` — the core summarization orchestrator. Owns the input-type branching, assembles the message content, and calls `llm.run_model`. |
-| `llm.py` | `LLMClient` — the provider seam. One pydantic-ai `Agent`; model, instructions and settings are resolved per run. Provider dispatch lives in `_build_model` (keyed on `config.MODEL_SPECS[...].provider`); `build_settings` currently carries only the provider-agnostic thinking level. |
+| `llm.py` | `LLMClient` — the provider seam. Each instance holds one pydantic-ai `Agent`; model, instructions and settings are resolved per run. Provider dispatch lives in `build_model` (keyed on `config.MODEL_SPECS[...].provider`); `build_settings` currently carries only the provider-agnostic thinking level. |
 | `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (orchestrator over `ApiBackend` primary → `YtDlpBackend` fallback, mirroring `parsing.py`'s `ParserBackend`). |
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
 | `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
@@ -134,13 +134,13 @@ to Gemini — return the raw model text with **no** prefix.
 ## Cross-cutting patterns
 
 - **Constructor injection migration (STG-135, in progress).** Service classes
-  are moving from module-level singletons to `__init__`-injected collaborators,
-  wired once by `container.py`'s composition root. `services.py` and
-  `database.py` are migrated (`Messenger`, `QuotaManager`, `GeminiHelper`,
-  `Tracer`, `UserRepository` all take their client/factory in `__init__`);
-  other modules still carry the older class → module-singleton → method-alias
-  shim (`module.func`, `mocker.patch("module.func")` keep working) until their
-  importers and tests migrate too. Unwinding back to plain functions remains
+  move from module-level singletons to `__init__`-injected collaborators, wired
+  once by `container.py`'s composition root. `services.py`, `database.py`, and
+  `llm.py` are migrated (`Messenger`, `QuotaManager`, `GeminiHelper`, `Tracer`,
+  `UserRepository`, `LLMClient` take their client/factory in `__init__`); other
+  modules still carry the class → module-singleton → method-alias shim
+  (`module.func`, `mocker.patch("module.func")` keep working) until their
+  importers and tests migrate too. Unwinding to plain functions is
   **rejected**.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -59,7 +59,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `database.py` | `UserRepository` — users table access (SQLAlchemy + Postgres). |
 | `models.py` | `UsersOrm` — the single `users` table (id, approval, per-user settings, `daily_limit`). |
 | `exceptions.py` | Domain exceptions: `LimitExceededError`, `WebParseError`, `TranscriptDownloadError`, `FetchTranscriptError`. |
-| `config.py` | All clients/singletons + the `MODEL_SPECS` registry, labels, defaults, limits, constants. Side-effectful import (Sentry, logging, env). |
+| `config.py` | All third-party clients (by design — see Cross-cutting patterns) + the `MODEL_SPECS` registry, labels, defaults, limits, constants. Side-effectful import (Sentry, logging, env). |
 | `prompts.py` | `PROMPTS` (strategy templates) + `SYSTEM_INSTRUCTION`. |
 | `domain.py` | `PrefixedText` + `format_prefixed_summary` — source-provenance prefixing. |
 | `utils.py` | Proxy pick, temp-name gen, `classify_url` (shared URL routing), `compress_audio` (ffmpeg Opus 16k mono), `clean_up`. |
@@ -134,15 +134,13 @@ to Gemini — return the raw model text with **no** prefix.
 
 ## Cross-cutting patterns
 
-- **Constructor injection migration (STG-135, in progress).** Service classes
-  move from module-level singletons to collaborators injected once by
-  `container.py`. Migrated: `Messenger`, `QuotaManager`, `GeminiHelper`,
-  `Tracer` (`services.py`); `UserRepository` (`database.py`); `LLMClient`
-  (`llm.py`); `Downloader` (`download.py`); `WebParser` (`parsing.py`);
-  `AudioTranscriber`/`YouTubeTranscriber` (`transcription.py`); `Summarizer`
-  (`summary.py`); `MessageHandlers` (`handlers.py`); `BotApp` (`main.py`).
-  Only deleting the now-unused transitional shims remains. Unwinding to plain
-  functions is **rejected**.
+- **Constructor injection (settled, STG-135).** Collaborators arrive via
+  `__init__`, wired once by `container.py`'s `build_container()` from
+  `config`'s third-party clients; `main.build_app` turns the graph into the
+  running `BotApp`. No module-level service singletons or method aliases
+  remain. `config.py` keeps the clients by design — `container.py`, not
+  `config.py`, is the composition root. Unwinding to plain functions is
+  **rejected**.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one
   unit. A global per-minute limit throttles by sleeping. Counters live in Valkey;

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -134,12 +134,12 @@ to Gemini — return the raw model text with **no** prefix.
 ## Cross-cutting patterns
 
 - **Constructor injection migration (STG-135, in progress).** Service classes
-  move from module-level singletons to injected collaborators, wired once by
-  `container.py`. Migrated so far: `Messenger`, `QuotaManager`, `GeminiHelper`,
+  move from module-level singletons to collaborators injected once by
+  `container.py`. Migrated: `Messenger`, `QuotaManager`, `GeminiHelper`,
   `Tracer` (`services.py`); `UserRepository` (`database.py`); `LLMClient`
-  (`llm.py`); `Downloader` (`download.py`); `WebParser` (`parsing.py`).
-  Remaining modules keep the class → module-singleton → method-alias shim
-  (`module.func`, `mocker.patch("module.func")`) until migrated too. Unwinding
+  (`llm.py`); `Downloader` (`download.py`); `WebParser` (`parsing.py`);
+  `AudioTranscriber`/`YouTubeTranscriber` (`transcription.py`). Remaining
+  modules keep the class → singleton → alias shim until migrated. Unwinding
   to plain functions is **rejected**.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -55,7 +55,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
 | `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
 | `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (MIME, file upload/poll), `Tracer` (Langfuse root span per message). |
-| `container.py` | `Container` + `build_container()` — the composition root; wires `services.py` collaborators to `config`'s clients. |
+| `container.py` | `Container` + `build_container()` — the composition root; wires collaborators to `config`'s clients. |
 | `database.py` | `UserRepository` — users table access (SQLAlchemy + Postgres). |
 | `models.py` | `UsersOrm` — the single `users` table (id, approval, per-user settings, `daily_limit`). |
 | `exceptions.py` | Domain exceptions: `LimitExceededError`, `WebParseError`, `TranscriptDownloadError`, `FetchTranscriptError`. |
@@ -135,13 +135,13 @@ to Gemini — return the raw model text with **no** prefix.
 
 - **Constructor injection migration (STG-135, in progress).** Service classes
   are moving from module-level singletons to `__init__`-injected collaborators,
-  wired once by `container.py`'s composition root. `services.py` is migrated
-  (`Messenger`, `QuotaManager`, `GeminiHelper`, `Tracer` all take their client
-  in `__init__`); other service modules still carry the older class →
-  module-singleton → method-alias shim so `module.func` and
-  `mocker.patch("module.func")` keep working, dropped module by module as each
-  one's importers and tests move to injection. Unwinding back to plain
-  functions remains **rejected**.
+  wired once by `container.py`'s composition root. `services.py` and
+  `database.py` are migrated (`Messenger`, `QuotaManager`, `GeminiHelper`,
+  `Tracer`, `UserRepository` all take their client/factory in `__init__`);
+  other modules still carry the older class → module-singleton → method-alias
+  shim (`module.func`, `mocker.patch("module.func")` keep working) until their
+  importers and tests migrate too. Unwinding back to plain functions remains
+  **rejected**.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one
   unit. A global per-minute limit throttles by sleeping. Counters live in Valkey;

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -134,14 +134,13 @@ to Gemini — return the raw model text with **no** prefix.
 ## Cross-cutting patterns
 
 - **Constructor injection migration (STG-135, in progress).** Service classes
-  move from module-level singletons to `__init__`-injected collaborators, wired
-  once by `container.py`'s composition root. Migrated so far: `Messenger`,
-  `QuotaManager`, `GeminiHelper`, `Tracer` (`services.py`); `UserRepository`
-  (`database.py`); `LLMClient` (`llm.py`); `Downloader` (`download.py`). Other
-  modules still carry the class → module-singleton → method-alias shim
-  (`module.func`, `mocker.patch("module.func")` keep working) until their
-  importers and tests migrate too. Unwinding to plain functions is
-  **rejected**.
+  move from module-level singletons to injected collaborators, wired once by
+  `container.py`. Migrated so far: `Messenger`, `QuotaManager`, `GeminiHelper`,
+  `Tracer` (`services.py`); `UserRepository` (`database.py`); `LLMClient`
+  (`llm.py`); `Downloader` (`download.py`); `WebParser` (`parsing.py`).
+  Remaining modules keep the class → module-singleton → method-alias shim
+  (`module.func`, `mocker.patch("module.func")`) until migrated too. Unwinding
+  to plain functions is **rejected**.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one
   unit. A global per-minute limit throttles by sleeping. Counters live in Valkey;

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -48,7 +48,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | Module | Role |
 |--------|------|
 | `main.py` | Telegram entry point. Command handlers + the unified `handle_message`; routes by `content_type`; top-level error → user-message mapping. |
-| `handlers.py` | Per-content-type handlers. Media validation, builds `SummaryKwargs` from the user record, picks the summarize path. |
+| `handlers.py` | `MessageHandlers` — per-content-type handlers. Media validation, builds `SummaryKwargs` from the user record, picks the summarize path. |
 | `summary.py` | `Summarizer` — the core summarization orchestrator. Owns the input-type branching, assembles the message content, and calls the injected `LLMClient.run`. |
 | `llm.py` | `LLMClient` — the provider seam. Each instance holds one pydantic-ai `Agent`; model, instructions and settings are resolved per run. Provider dispatch lives in `build_model` (keyed on `config.MODEL_SPECS[...].provider`); `build_settings` currently carries only the provider-agnostic thinking level. |
 | `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (orchestrator over `ApiBackend` primary → `YtDlpBackend` fallback, mirroring `parsing.py`'s `ParserBackend`). |
@@ -79,7 +79,7 @@ Telegram update
     video / video_note ──────────► download_tg(.mp4) → compress_audio(.ogg) → summarize(path)
     document ────────────────────► summarize_with_document(File, mime)
     text (treated as URL) ── classify_url ──┬─ "youtube" / "castro" ► summarize(url)
-                                            └─ "web"  ► parse_url → summarize_text
+                                            └─ "web"  ► WebParser.parse → summarize_text
 ```
 
 ### Summarizer input branching (`summary.py:summarize`)
@@ -140,8 +140,8 @@ to Gemini — return the raw model text with **no** prefix.
   `Tracer` (`services.py`); `UserRepository` (`database.py`); `LLMClient`
   (`llm.py`); `Downloader` (`download.py`); `WebParser` (`parsing.py`);
   `AudioTranscriber`/`YouTubeTranscriber` (`transcription.py`); `Summarizer`
-  (`summary.py`). Remaining modules keep the shim until migrated. Unwinding
-  to plain functions is **rejected**.
+  (`summary.py`); `MessageHandlers` (`handlers.py`). Only `main.py` adopting
+  the container remains. Unwinding to plain functions is **rejected**.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one
   unit. A global per-minute limit throttles by sleeping. Counters live in Valkey;

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -134,7 +134,7 @@ to Gemini — return the raw model text with **no** prefix.
 
 ## Cross-cutting patterns
 
-- **Constructor injection (settled, STG-135).** Collaborators arrive via
+- **Constructor injection.** Collaborators arrive via
   `__init__`, wired once by `container.py`'s `build_container()` from
   `config`'s third-party clients; `main.build_app` turns the graph into the
   running `BotApp`. No module-level service singletons or method aliases

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -135,9 +135,9 @@ to Gemini — return the raw model text with **no** prefix.
 
 - **Constructor injection migration (STG-135, in progress).** Service classes
   move from module-level singletons to `__init__`-injected collaborators, wired
-  once by `container.py`'s composition root. `services.py`, `database.py`, and
-  `llm.py` are migrated (`Messenger`, `QuotaManager`, `GeminiHelper`, `Tracer`,
-  `UserRepository`, `LLMClient` take their client/factory in `__init__`); other
+  once by `container.py`'s composition root. Migrated so far: `Messenger`,
+  `QuotaManager`, `GeminiHelper`, `Tracer` (`services.py`); `UserRepository`
+  (`database.py`); `LLMClient` (`llm.py`); `Downloader` (`download.py`). Other
   modules still carry the class → module-singleton → method-alias shim
   (`module.func`, `mocker.patch("module.func")` keep working) until their
   importers and tests migrate too. Unwinding to plain functions is

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -49,7 +49,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 |--------|------|
 | `main.py` | Telegram entry point. Command handlers + the unified `handle_message`; routes by `content_type`; top-level error → user-message mapping. |
 | `handlers.py` | Per-content-type handlers. Media validation, builds `SummaryKwargs` from the user record, picks the summarize path. |
-| `summary.py` | `Summarizer` — the core summarization orchestrator. Owns the input-type branching, assembles the message content, and calls `llm.run_model`. |
+| `summary.py` | `Summarizer` — the core summarization orchestrator. Owns the input-type branching, assembles the message content, and calls the injected `LLMClient.run`. |
 | `llm.py` | `LLMClient` — the provider seam. Each instance holds one pydantic-ai `Agent`; model, instructions and settings are resolved per run. Provider dispatch lives in `build_model` (keyed on `config.MODEL_SPECS[...].provider`); `build_settings` currently carries only the provider-agnostic thinking level. |
 | `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (orchestrator over `ApiBackend` primary → `YtDlpBackend` fallback, mirroring `parsing.py`'s `ParserBackend`). |
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
@@ -90,13 +90,14 @@ download path. Neither may re-derive the kind on its own — a second, narrower
 classifier here previously let www-prefixed and uppercase-host media URLs reach
 the Gemini file upload with the URL string as their file path.
 
-- **YouTube URL** → try transcript (`get_yt_transcript`); on success summarize
-  the transcript. On failure → `download_yt` audio, then the file path below.
-- **Castro URL** → `download_castro` audio → file path.
-- **Telegram File** → `download_tg(.ogg)` → file path.
+- **YouTube URL** → try transcript (`YouTubeTranscriber.get_transcript`); on
+  success summarize the transcript. On failure → `Downloader.download_yt`
+  audio, then the file path below.
+- **Castro URL** → `Downloader.download_castro` audio → file path.
+- **Telegram File** → `Downloader.download_tg(.ogg)` → file path.
 - **File path** → `summarize_with_file` (upload to Gemini, generate). If that
-  exhausts retries → fallback: `compress_audio` → `transcribe` (Replicate) →
-  `summarize_text`.
+  exhausts retries → fallback: `compress_audio` → `AudioTranscriber.transcribe`
+  (Replicate) → `summarize_text`.
 
 So there are two layered fallbacks for spoken content: transcript-first for
 YouTube, and Gemini-file-first with a Replicate-transcription rescue for any
@@ -138,8 +139,8 @@ to Gemini — return the raw model text with **no** prefix.
   `container.py`. Migrated: `Messenger`, `QuotaManager`, `GeminiHelper`,
   `Tracer` (`services.py`); `UserRepository` (`database.py`); `LLMClient`
   (`llm.py`); `Downloader` (`download.py`); `WebParser` (`parsing.py`);
-  `AudioTranscriber`/`YouTubeTranscriber` (`transcription.py`). Remaining
-  modules keep the class → singleton → alias shim until migrated. Unwinding
+  `AudioTranscriber`/`YouTubeTranscriber` (`transcription.py`); `Summarizer`
+  (`summary.py`). Remaining modules keep the shim until migrated. Unwinding
   to plain functions is **rejected**.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -47,7 +47,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 
 | Module | Role |
 |--------|------|
-| `main.py` | Telegram entry point. Command handlers + the unified `handle_message`; routes by `content_type`; top-level error → user-message mapping. |
+| `main.py` | `BotApp` — Telegram entry point. Command handlers + the unified `handle_message`; routes by `content_type`; top-level error → user-message mapping. `build_app(container)` wires it from the composition root and registers its handlers; the `__main__` block just calls `build_app`, `run`, `shutdown`. |
 | `handlers.py` | `MessageHandlers` — per-content-type handlers. Media validation, builds `SummaryKwargs` from the user record, picks the summarize path. |
 | `summary.py` | `Summarizer` — the core summarization orchestrator. Owns the input-type branching, assembles the message content, and calls the injected `LLMClient.run`. |
 | `llm.py` | `LLMClient` — the provider seam. Each instance holds one pydantic-ai `Agent`; model, instructions and settings are resolved per run. Provider dispatch lives in `build_model` (keyed on `config.MODEL_SPECS[...].provider`); `build_settings` currently carries only the provider-agnostic thinking level. |
@@ -55,7 +55,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
 | `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
 | `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (MIME, file upload/poll), `Tracer` (Langfuse root span per message). |
-| `container.py` | `Container` + `build_container()` — the composition root; wires collaborators to `config`'s clients. |
+| `container.py` | `Container` + `build_container()` — the composition root; wires every collaborator, including the `bot` client, to `config`'s clients. |
 | `database.py` | `UserRepository` — users table access (SQLAlchemy + Postgres). |
 | `models.py` | `UsersOrm` — the single `users` table (id, approval, per-user settings, `daily_limit`). |
 | `exceptions.py` | Domain exceptions: `LimitExceededError`, `WebParseError`, `TranscriptDownloadError`, `FetchTranscriptError`. |
@@ -70,7 +70,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 
 ```
 Telegram update
-  └─ main.handle_message
+  └─ BotApp.handle_message
        ├─ select_user (Postgres) ─ reject if not approved
        └─ process_message_content  ── routes by content_type ──┐
                                                                │
@@ -140,8 +140,9 @@ to Gemini — return the raw model text with **no** prefix.
   `Tracer` (`services.py`); `UserRepository` (`database.py`); `LLMClient`
   (`llm.py`); `Downloader` (`download.py`); `WebParser` (`parsing.py`);
   `AudioTranscriber`/`YouTubeTranscriber` (`transcription.py`); `Summarizer`
-  (`summary.py`); `MessageHandlers` (`handlers.py`). Only `main.py` adopting
-  the container remains. Unwinding to plain functions is **rejected**.
+  (`summary.py`); `MessageHandlers` (`handlers.py`); `BotApp` (`main.py`).
+  Only deleting the now-unused transitional shims remains. Unwinding to plain
+  functions is **rejected**.
 - **Quota model.** `check_quota(..., quantity=0)` is a pre-check that raises when
   the daily budget is exhausted but consumes nothing; `quantity=1` consumes one
   unit. A global per-minute limit throttles by sleeping. Counters live in Valkey;
@@ -160,7 +161,7 @@ to Gemini — return the raw model text with **no** prefix.
   and `LANGFUSE_SECRET_KEY` are set (`config.langfuse_client`, else `None`). When on,
   `Agent.instrument_all()` makes pydantic-ai emit an OpenTelemetry span per model
   call, which the OTel-based Langfuse SDK ingests — no provider-specific
-  instrumentor. `services.observe_message` (used in `main.handle_message`) wraps
+  instrumentor. `Tracer.observe_message` (used in `BotApp.handle_message`) wraps
   each Telegram message in one root span attributed to the user and tagged with the
   content type, so all model calls for a message nest under a single trace.
   `langfuse_client.shutdown()` flushes on exit. Independent of Sentry, which handles

--- a/docs/context/style-guide.md
+++ b/docs/context/style-guide.md
@@ -57,10 +57,9 @@ Use `# noqa` sparingly and always specify the exact rule code.
 ## Classes
 
 Collaborators arrive via `__init__` and are stored on private attributes (e.g. `self._client`);
-`container.py`'s composition root does the wiring, once, from `config`'s clients. This is an
-in-progress migration (STG-135, see `docs/context/architecture.md`) — the class →
-module-singleton → method-alias blocks that remain in unmigrated modules are a transitional shim,
-removed slice by slice as each module's importers and tests move to injection.
+`container.py`'s composition root does the wiring, once, from `config`'s clients (see
+`docs/context/architecture.md`). No module-level service singletons or method aliases — a class
+is the entire public surface.
 
 - `@staticmethod` is reserved for **private** helpers (`_name`) that need no instance state.
 - Annotate class-level constants with `ClassVar`, e.g. `_DEFAULTS: ClassVar[dict[str, str]]` —

--- a/docs/context/style-guide.md
+++ b/docs/context/style-guide.md
@@ -56,12 +56,13 @@ Use `# noqa` sparingly and always specify the exact rule code.
 
 ## Classes
 
-Service modules follow the class → module-singleton → method-alias pattern documented in
-`docs/context/architecture.md` (Cross-cutting patterns). Beyond that:
+Collaborators arrive via `__init__` and are stored on private attributes (e.g. `self._client`);
+`container.py`'s composition root does the wiring, once, from `config`'s clients. This is an
+in-progress migration (STG-135, see `docs/context/architecture.md`) — the class →
+module-singleton → method-alias blocks that remain in unmigrated modules are a transitional shim,
+removed slice by slice as each module's importers and tests move to injection.
 
 - `@staticmethod` is reserved for **private** helpers (`_name`) that need no instance state.
-  Public methods keep `self` even when they don't use it — they form the aliased singleton
-  surface (`check_quota = quota_manager.check_quota`), so they must stay bound methods.
 - Annotate class-level constants with `ClassVar`, e.g. `_DEFAULTS: ClassVar[dict[str, str]]` —
   without it Ruff (`RUF012`) reads a mutable class attribute as an un-annotated instance field.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ default-groups = ["dev", "test"]
 exclude-newer = "3 days"
 
 [tool.ruff]
+# Both are import roots at test time, so isort treats each as first-party.
+src = ["src", "tests"]
 extend-exclude = ["temp", "migrations"]
 line-length = 88
 indent-width = 4
@@ -145,7 +147,8 @@ exclude = ["tests"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+# "tests" makes the shared builders in tests/helpers.py importable by name.
+pythonpath = ["src", "tests"]
 addopts = "-v --tb=short"
 
 [tool.coverage.run]

--- a/src/container.py
+++ b/src/container.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import config
 import database
@@ -15,14 +16,17 @@ from services import GeminiHelper, Messenger, QuotaManager, Tracer
 from summary import Summarizer
 from transcription import ApiBackend, AudioTranscriber, YouTubeTranscriber, YtDlpBackend
 
-# main.py adopting the container (STG-135) is all that remains after this
-# slice.
+if TYPE_CHECKING:
+    import telebot
+
+# Only the shim deletion (STG-135) remains after this slice.
 
 
 @dataclass(frozen=True)
 class Container:
     """The wired-up collaborators the application runs on."""
 
+    bot: telebot.TeleBot
     messenger: Messenger
     quota_manager: QuotaManager
     gemini_helper: GeminiHelper
@@ -39,7 +43,8 @@ class Container:
 
 def build_container() -> Container:
     """Construct the application object graph from config's clients."""
-    messenger = Messenger(config.bot)
+    bot = config.bot
+    messenger = Messenger(bot)
     quota_manager = QuotaManager(config.rate_limiter, config.per_minute_rate)
     gemini_helper = GeminiHelper(config.gemini_client)
     llm_client = LLMClient(config.gemini_client)
@@ -60,6 +65,7 @@ def build_container() -> Container:
         yt_transcriber,
     )
     return Container(
+        bot=bot,
         messenger=messenger,
         quota_manager=quota_manager,
         gemini_helper=gemini_helper,
@@ -72,7 +78,7 @@ def build_container() -> Container:
         yt_transcriber=yt_transcriber,
         summarizer=summarizer,
         handlers=MessageHandlers(
-            config.bot,
+            bot,
             messenger,
             summarizer,
             web_parser,

--- a/src/container.py
+++ b/src/container.py
@@ -7,9 +7,10 @@ from dataclasses import dataclass
 import config
 import database
 from database import UserRepository
+from llm import LLMClient
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
 
-# Later slices append llm_client, downloader, web_parser, audio_transcriber,
+# Later slices append downloader, web_parser, audio_transcriber,
 # yt_transcriber, summarizer, and the handlers to this dataclass; main.py
 # adopts the container in a later slice (STG-135).
 
@@ -23,6 +24,7 @@ class Container:
     gemini_helper: GeminiHelper
     tracer: Tracer
     user_repo: UserRepository
+    llm_client: LLMClient
 
 
 def build_container() -> Container:
@@ -33,4 +35,5 @@ def build_container() -> Container:
         gemini_helper=GeminiHelper(config.gemini_client),
         tracer=Tracer(config.langfuse_client),
         user_repo=UserRepository(database.Session),
+        llm_client=LLMClient(config.gemini_client),
     )

--- a/src/container.py
+++ b/src/container.py
@@ -1,0 +1,32 @@
+"""Composition root: builds the application object graph once, from config's clients."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import config
+from services import GeminiHelper, Messenger, QuotaManager, Tracer
+
+# Later slices append user_repo, llm_client, downloader, web_parser,
+# audio_transcriber, yt_transcriber, summarizer, and the handlers to this
+# dataclass; main.py adopts the container in a later slice (STG-135).
+
+
+@dataclass(frozen=True)
+class Container:
+    """The wired-up collaborators the application runs on."""
+
+    messenger: Messenger
+    quota_manager: QuotaManager
+    gemini_helper: GeminiHelper
+    tracer: Tracer
+
+
+def build_container() -> Container:
+    """Construct the application object graph from config's clients."""
+    return Container(
+        messenger=Messenger(config.bot),
+        quota_manager=QuotaManager(config.rate_limiter, config.per_minute_rate),
+        gemini_helper=GeminiHelper(config.gemini_client),
+        tracer=Tracer(config.langfuse_client),
+    )

--- a/src/container.py
+++ b/src/container.py
@@ -11,10 +11,11 @@ from download import Downloader
 from llm import LLMClient
 from parsing import ExaBackend, TavilyBackend, UrlResolver, WebParser
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
+from summary import Summarizer
 from transcription import ApiBackend, AudioTranscriber, YouTubeTranscriber, YtDlpBackend
 
-# Later slices append summarizer and the handlers to this dataclass; main.py
-# adopts the container in a later slice (STG-135).
+# Later slices append the handlers to this dataclass; main.py adopts the
+# container in a later slice (STG-135).
 
 
 @dataclass(frozen=True)
@@ -31,23 +32,38 @@ class Container:
     web_parser: WebParser
     audio_transcriber: AudioTranscriber
     yt_transcriber: YouTubeTranscriber
+    summarizer: Summarizer
 
 
 def build_container() -> Container:
     """Construct the application object graph from config's clients."""
+    quota_manager = QuotaManager(config.rate_limiter, config.per_minute_rate)
+    gemini_helper = GeminiHelper(config.gemini_client)
+    llm_client = LLMClient(config.gemini_client)
+    downloader = Downloader(config.TG_API_TOKEN)
+    audio_transcriber = AudioTranscriber(config.replicate_client)
+    yt_transcriber = YouTubeTranscriber(ApiBackend(), YtDlpBackend())
     return Container(
         messenger=Messenger(config.bot),
-        quota_manager=QuotaManager(config.rate_limiter, config.per_minute_rate),
-        gemini_helper=GeminiHelper(config.gemini_client),
+        quota_manager=quota_manager,
+        gemini_helper=gemini_helper,
         tracer=Tracer(config.langfuse_client),
         user_repo=UserRepository(database.Session),
-        llm_client=LLMClient(config.gemini_client),
-        downloader=Downloader(config.TG_API_TOKEN),
+        llm_client=llm_client,
+        downloader=downloader,
         web_parser=WebParser(
             ExaBackend(config.exa_client),
             TavilyBackend(config.tavily_client),
             UrlResolver(),
         ),
-        audio_transcriber=AudioTranscriber(config.replicate_client),
-        yt_transcriber=YouTubeTranscriber(ApiBackend(), YtDlpBackend()),
+        audio_transcriber=audio_transcriber,
+        yt_transcriber=yt_transcriber,
+        summarizer=Summarizer(
+            quota_manager,
+            gemini_helper,
+            llm_client,
+            downloader,
+            audio_transcriber,
+            yt_transcriber,
+        ),
     )

--- a/src/container.py
+++ b/src/container.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import config
+import database
+from database import UserRepository
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
 
-# Later slices append user_repo, llm_client, downloader, web_parser,
-# audio_transcriber, yt_transcriber, summarizer, and the handlers to this
-# dataclass; main.py adopts the container in a later slice (STG-135).
+# Later slices append llm_client, downloader, web_parser, audio_transcriber,
+# yt_transcriber, summarizer, and the handlers to this dataclass; main.py
+# adopts the container in a later slice (STG-135).
 
 
 @dataclass(frozen=True)
@@ -20,6 +22,7 @@ class Container:
     quota_manager: QuotaManager
     gemini_helper: GeminiHelper
     tracer: Tracer
+    user_repo: UserRepository
 
 
 def build_container() -> Container:
@@ -29,4 +32,5 @@ def build_container() -> Container:
         quota_manager=QuotaManager(config.rate_limiter, config.per_minute_rate),
         gemini_helper=GeminiHelper(config.gemini_client),
         tracer=Tracer(config.langfuse_client),
+        user_repo=UserRepository(database.Session),
     )

--- a/src/container.py
+++ b/src/container.py
@@ -8,14 +8,15 @@ import config
 import database
 from database import UserRepository
 from download import Downloader
+from handlers import MessageHandlers
 from llm import LLMClient
 from parsing import ExaBackend, TavilyBackend, UrlResolver, WebParser
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
 from summary import Summarizer
 from transcription import ApiBackend, AudioTranscriber, YouTubeTranscriber, YtDlpBackend
 
-# Later slices append the handlers to this dataclass; main.py adopts the
-# container in a later slice (STG-135).
+# main.py adopting the container (STG-135) is all that remains after this
+# slice.
 
 
 @dataclass(frozen=True)
@@ -33,37 +34,49 @@ class Container:
     audio_transcriber: AudioTranscriber
     yt_transcriber: YouTubeTranscriber
     summarizer: Summarizer
+    handlers: MessageHandlers
 
 
 def build_container() -> Container:
     """Construct the application object graph from config's clients."""
+    messenger = Messenger(config.bot)
     quota_manager = QuotaManager(config.rate_limiter, config.per_minute_rate)
     gemini_helper = GeminiHelper(config.gemini_client)
     llm_client = LLMClient(config.gemini_client)
     downloader = Downloader(config.TG_API_TOKEN)
+    web_parser = WebParser(
+        ExaBackend(config.exa_client),
+        TavilyBackend(config.tavily_client),
+        UrlResolver(),
+    )
     audio_transcriber = AudioTranscriber(config.replicate_client)
     yt_transcriber = YouTubeTranscriber(ApiBackend(), YtDlpBackend())
+    summarizer = Summarizer(
+        quota_manager,
+        gemini_helper,
+        llm_client,
+        downloader,
+        audio_transcriber,
+        yt_transcriber,
+    )
     return Container(
-        messenger=Messenger(config.bot),
+        messenger=messenger,
         quota_manager=quota_manager,
         gemini_helper=gemini_helper,
         tracer=Tracer(config.langfuse_client),
         user_repo=UserRepository(database.Session),
         llm_client=llm_client,
         downloader=downloader,
-        web_parser=WebParser(
-            ExaBackend(config.exa_client),
-            TavilyBackend(config.tavily_client),
-            UrlResolver(),
-        ),
+        web_parser=web_parser,
         audio_transcriber=audio_transcriber,
         yt_transcriber=yt_transcriber,
-        summarizer=Summarizer(
+        summarizer=summarizer,
+        handlers=MessageHandlers(
+            config.bot,
+            messenger,
+            summarizer,
+            web_parser,
             quota_manager,
-            gemini_helper,
-            llm_client,
             downloader,
-            audio_transcriber,
-            yt_transcriber,
         ),
     )

--- a/src/container.py
+++ b/src/container.py
@@ -9,11 +9,12 @@ import database
 from database import UserRepository
 from download import Downloader
 from llm import LLMClient
+from parsing import ExaBackend, TavilyBackend, UrlResolver, WebParser
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
 
-# Later slices append web_parser, audio_transcriber, yt_transcriber,
-# summarizer, and the handlers to this dataclass; main.py adopts the
-# container in a later slice (STG-135).
+# Later slices append audio_transcriber, yt_transcriber, summarizer, and the
+# handlers to this dataclass; main.py adopts the container in a later slice
+# (STG-135).
 
 
 @dataclass(frozen=True)
@@ -27,6 +28,7 @@ class Container:
     user_repo: UserRepository
     llm_client: LLMClient
     downloader: Downloader
+    web_parser: WebParser
 
 
 def build_container() -> Container:
@@ -39,4 +41,9 @@ def build_container() -> Container:
         user_repo=UserRepository(database.Session),
         llm_client=LLMClient(config.gemini_client),
         downloader=Downloader(config.TG_API_TOKEN),
+        web_parser=WebParser(
+            ExaBackend(config.exa_client),
+            TavilyBackend(config.tavily_client),
+            UrlResolver(),
+        ),
     )

--- a/src/container.py
+++ b/src/container.py
@@ -7,12 +7,13 @@ from dataclasses import dataclass
 import config
 import database
 from database import UserRepository
+from download import Downloader
 from llm import LLMClient
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
 
-# Later slices append downloader, web_parser, audio_transcriber,
-# yt_transcriber, summarizer, and the handlers to this dataclass; main.py
-# adopts the container in a later slice (STG-135).
+# Later slices append web_parser, audio_transcriber, yt_transcriber,
+# summarizer, and the handlers to this dataclass; main.py adopts the
+# container in a later slice (STG-135).
 
 
 @dataclass(frozen=True)
@@ -25,6 +26,7 @@ class Container:
     tracer: Tracer
     user_repo: UserRepository
     llm_client: LLMClient
+    downloader: Downloader
 
 
 def build_container() -> Container:
@@ -36,4 +38,5 @@ def build_container() -> Container:
         tracer=Tracer(config.langfuse_client),
         user_repo=UserRepository(database.Session),
         llm_client=LLMClient(config.gemini_client),
+        downloader=Downloader(config.TG_API_TOKEN),
     )

--- a/src/container.py
+++ b/src/container.py
@@ -11,10 +11,10 @@ from download import Downloader
 from llm import LLMClient
 from parsing import ExaBackend, TavilyBackend, UrlResolver, WebParser
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
+from transcription import ApiBackend, AudioTranscriber, YouTubeTranscriber, YtDlpBackend
 
-# Later slices append audio_transcriber, yt_transcriber, summarizer, and the
-# handlers to this dataclass; main.py adopts the container in a later slice
-# (STG-135).
+# Later slices append summarizer and the handlers to this dataclass; main.py
+# adopts the container in a later slice (STG-135).
 
 
 @dataclass(frozen=True)
@@ -29,6 +29,8 @@ class Container:
     llm_client: LLMClient
     downloader: Downloader
     web_parser: WebParser
+    audio_transcriber: AudioTranscriber
+    yt_transcriber: YouTubeTranscriber
 
 
 def build_container() -> Container:
@@ -46,4 +48,6 @@ def build_container() -> Container:
             TavilyBackend(config.tavily_client),
             UrlResolver(),
         ),
+        audio_transcriber=AudioTranscriber(config.replicate_client),
+        yt_transcriber=YouTubeTranscriber(ApiBackend(), YtDlpBackend()),
     )

--- a/src/container.py
+++ b/src/container.py
@@ -19,8 +19,6 @@ from transcription import ApiBackend, AudioTranscriber, YouTubeTranscriber, YtDl
 if TYPE_CHECKING:
     import telebot
 
-# Only the shim deletion (STG-135) remains after this slice.
-
 
 @dataclass(frozen=True)
 class Container:

--- a/src/database.py
+++ b/src/database.py
@@ -20,9 +20,9 @@ from config import (
 from models import UsersOrm
 
 if TYPE_CHECKING:
-    # Aliased to avoid shadowing the module-level `Session` session-factory
-    # singleton below, which reuses the SQLAlchemy convention of naming a
-    # sessionmaker instance after the class it produces.
+    # Aliased to avoid shadowing the module-level `Session` session factory
+    # below, which reuses the SQLAlchemy convention of naming a sessionmaker
+    # instance after the class it produces.
     from sqlalchemy.orm import Session as SQLAlchemySession
 
 engine = create_engine(DSN, echo=False, pool_pre_ping=True)

--- a/src/database.py
+++ b/src/database.py
@@ -131,17 +131,3 @@ class UserRepository:
         if normalized not in ALLOWED_PROMPT_KEYS:
             return False
         return self._update_field(user_id, "prompt_key_for_summary", normalized)
-
-
-# Module-level singleton and aliases — transitional shim (STG-135).
-# main.py still imports these; removed once every consumer is migrated to
-# constructor injection.
-user_repo = UserRepository(Session)
-
-register_user = user_repo.register_user
-select_user = user_repo.select_user
-check_auth = user_repo.check_auth
-set_target_language = user_repo.set_target_language
-set_summarizing_model = user_repo.set_summarizing_model
-set_thinking_level = user_repo.set_thinking_level
-set_prompt_strategy = user_repo.set_prompt_strategy

--- a/src/database.py
+++ b/src/database.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -15,12 +19,22 @@ from config import (
 )
 from models import UsersOrm
 
+if TYPE_CHECKING:
+    # Aliased to avoid shadowing the module-level `Session` session-factory
+    # singleton below, which reuses the SQLAlchemy convention of naming a
+    # sessionmaker instance after the class it produces.
+    from sqlalchemy.orm import Session as SQLAlchemySession
+
 engine = create_engine(DSN, echo=False, pool_pre_ping=True)
 Session = sessionmaker(engine)
 
 
 class UserRepository:
     """Data-access object for the users table."""
+
+    def __init__(self, session_factory: sessionmaker[SQLAlchemySession]) -> None:
+        """Store the injected SQLAlchemy session factory."""
+        self._session_factory = session_factory
 
     def register_user(
         self,
@@ -40,7 +54,7 @@ class UserRepository:
         reads False as "already registered". Any other violation — a NOT NULL
         column passed None, or constraints added later — reports identically.
         """
-        with Session() as session:
+        with self._session_factory() as session:
             try:
                 stmt = UsersOrm(
                     user_id=user_id,
@@ -68,7 +82,7 @@ class UserRepository:
             ValueError: If the user is not found.
 
         """
-        with Session() as session:
+        with self._session_factory() as session:
             user = session.get(UsersOrm, user_id)
             if user is None:
                 msg = "User not found"
@@ -82,7 +96,7 @@ class UserRepository:
 
     def _update_field(self, user_id: int, field: str, value: str) -> bool:
         """Persist a single validated settings field; False if the user is unknown."""
-        with Session() as session:
+        with self._session_factory() as session:
             user = session.get(UsersOrm, user_id)
             if user is None:
                 return False
@@ -119,11 +133,11 @@ class UserRepository:
         return self._update_field(user_id, "prompt_key_for_summary", normalized)
 
 
-# Module-level singleton
-user_repo = UserRepository()
+# Module-level singleton and aliases — transitional shim (STG-135).
+# main.py still imports these; removed once every consumer is migrated to
+# constructor injection.
+user_repo = UserRepository(Session)
 
-
-# Module-level aliases — preserve the existing public API
 register_user = user_repo.register_user
 select_user = user_repo.select_user
 check_auth = user_repo.check_auth

--- a/src/download.py
+++ b/src/download.py
@@ -37,6 +37,10 @@ tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 class Downloader:
     """Downloads media from YouTube, Castro, and Telegram."""
 
+    def __init__(self, tg_api_token: str) -> None:
+        """Store the injected Telegram bot API token."""
+        self._tg_api_token = tg_api_token
+
     @staticmethod
     def _choose_yt_audio_format(info: dict[str, Any]) -> str:
         """Return the most suitable audio format id for a YouTube video.
@@ -206,17 +210,18 @@ class Downloader:
             msg = "Telegram file path is missing."
             raise ValueError(msg)
         file_url = (
-            f"https://api.telegram.org/file/bot{TG_API_TOKEN}/{file_id.file_path}"
+            f"https://api.telegram.org/file/bot{self._tg_api_token}/{file_id.file_path}"
         )
         self._stream_to_file(file_url, temporary_file_name)
         return temporary_file_name
 
 
-# Module-level singleton
-downloader = Downloader()
+# Module-level singleton and aliases — transitional shim (STG-135).
+# summary.py and handlers.py still import these; removed once every consumer
+# is migrated to constructor injection. TG_API_TOKEN above is imported for
+# this block alone.
+downloader = Downloader(TG_API_TOKEN)
 
-
-# Module-level aliases — preserve the existing public API
 download_yt = downloader.download_yt
 download_castro = downloader.download_castro
 download_tg = downloader.download_tg

--- a/src/download.py
+++ b/src/download.py
@@ -21,7 +21,6 @@ from tenacity import (
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
-from config import TG_API_TOKEN
 from utils import generate_temporary_name, get_proxy
 
 if TYPE_CHECKING:
@@ -214,14 +213,3 @@ class Downloader:
         )
         self._stream_to_file(file_url, temporary_file_name)
         return temporary_file_name
-
-
-# Module-level singleton and aliases — transitional shim (STG-135).
-# summary.py and handlers.py still import these; removed once every consumer
-# is migrated to constructor injection. TG_API_TOKEN above is imported for
-# this block alone.
-downloader = Downloader(TG_API_TOKEN)
-
-download_yt = downloader.download_yt
-download_castro = downloader.download_castro
-download_tg = downloader.download_tg

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypedDict
 
-from config import TG_MAX_FILE_SIZE, bot
+from config import TG_MAX_FILE_SIZE
 from domain import format_prefixed_summary
-from download import Downloader, downloader
-from parsing import WebParser, web_parser
-from services import Messenger, QuotaManager, messenger, quota_manager
-from summary import Summarizer, summarizer
 from utils import classify_url, clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
     import telebot
     from telebot.types import Audio, Document, File, Message, Video, VideoNote, Voice
 
+    from download import Downloader
     from models import UsersOrm
+    from parsing import WebParser
+    from services import Messenger, QuotaManager
+    from summary import Summarizer
 
     _SizedMedia = Audio | Voice | Video | VideoNote | Document
 
@@ -172,22 +172,3 @@ class MessageHandlers:
             self._messenger.send_answer(message, answer)
         else:
             self._bot.send_message(message.chat.id, "No data to proceed.")
-
-
-# Module-level singleton and aliases — transitional shim (STG-135).
-# main.py still imports these; removed once main.py adopts the container.
-message_handlers = MessageHandlers(
-    bot,
-    messenger,
-    summarizer,
-    web_parser,
-    quota_manager,
-    downloader,
-)
-
-handle_audio = message_handlers.handle_audio
-handle_voice = message_handlers.handle_voice
-handle_video = message_handlers.handle_video
-handle_video_note = message_handlers.handle_video_note
-handle_document = message_handlers.handle_document
-handle_url = message_handlers.handle_url

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -4,17 +4,14 @@ from typing import TYPE_CHECKING, TypedDict
 
 from config import TG_MAX_FILE_SIZE, bot
 from domain import format_prefixed_summary
-from download import download_tg
-from parsing import parse_url
-from services import (
-    check_quota,
-    get_file_with_retry,
-    send_answer,
-)
-from summary import summarize, summarize_text, summarize_with_document
+from download import Downloader, downloader
+from parsing import WebParser, web_parser
+from services import Messenger, QuotaManager, messenger, quota_manager
+from summary import Summarizer, summarizer
 from utils import classify_url, clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
+    import telebot
     from telebot.types import Audio, Document, File, Message, Video, VideoNote, Voice
 
     from models import UsersOrm
@@ -33,124 +30,164 @@ class SummaryKwargs(TypedDict):
     thinking_level: str
 
 
-def _summary_kwargs(user: UsersOrm) -> SummaryKwargs:
-    """Build the recurring summarize() kwargs sourced from a user record."""
-    return {
-        "model": user.summarizing_model,
-        "prompt_key": user.prompt_key_for_summary,
-        "target_language": user.target_language,
-        "user_id": user.user_id,
-        "daily_limit": user.daily_limit,
-        "thinking_level": user.thinking_level,
-    }
+class MessageHandlers:
+    """Per-content-type Telegram message handlers."""
 
+    def __init__(
+        self,
+        bot: telebot.TeleBot,
+        messenger: Messenger,
+        summarizer: Summarizer,
+        web_parser: WebParser,
+        quota_manager: QuotaManager,
+        downloader: Downloader,
+    ) -> None:
+        """Store the injected collaborators used to handle Telegram messages."""
+        self._bot = bot
+        self._messenger = messenger
+        self._summarizer = summarizer
+        self._web_parser = web_parser
+        self._quota_manager = quota_manager
+        self._downloader = downloader
 
-def _fetch_media(
-    message: Message,
-    media: _SizedMedia | None,
-    missing_msg: str,
-) -> File | None:
-    """Validate a Telegram media object and return its downloaded File handle.
+    @staticmethod
+    def _summary_kwargs(user: UsersOrm) -> SummaryKwargs:
+        """Build the recurring summarize() kwargs sourced from a user record."""
+        return {
+            "model": user.summarizing_model,
+            "prompt_key": user.prompt_key_for_summary,
+            "target_language": user.target_language,
+            "user_id": user.user_id,
+            "daily_limit": user.daily_limit,
+            "thinking_level": user.thinking_level,
+        }
 
-    Replies to the user and returns None when the media is missing or exceeds
-    the Telegram 20MB getFile cap.
+    def _fetch_media(
+        self,
+        message: Message,
+        media: _SizedMedia | None,
+        missing_msg: str,
+    ) -> File | None:
+        """Validate a Telegram media object and return its downloaded File handle.
 
-    """
-    if media is None or media.file_size is None:
-        bot.reply_to(message, missing_msg)
-        return None
-    if media.file_size > TG_MAX_FILE_SIZE:
-        bot.reply_to(message, "File is too big.")
-        return None
-    return get_file_with_retry(media.file_id)
+        Replies to the user and returns None when the media is missing or exceeds
+        the Telegram 20MB getFile cap.
 
+        """
+        if media is None or media.file_size is None:
+            self._bot.reply_to(message, missing_msg)
+            return None
+        if media.file_size > TG_MAX_FILE_SIZE:
+            self._bot.reply_to(message, "File is too big.")
+            return None
+        return self._messenger.get_file_with_retry(media.file_id)
 
-def handle_audio(message: Message, user: UsersOrm) -> None:
-    """Handle audio file processing."""
-    data = _fetch_media(message, message.audio, "No audio file found.")
-    if data is None:
-        return
-    answer = summarize(
-        data=data,
-        **_summary_kwargs(user),
-    )
-    send_answer(message, answer)
-
-
-def handle_voice(message: Message, user: UsersOrm) -> None:
-    """Handle voice file processing."""
-    data = _fetch_media(message, message.voice, "No voice message found.")
-    if data is None:
-        return
-    answer = summarize(
-        data=data,
-        **_summary_kwargs(user),
-    )
-    send_answer(message, answer)
-
-
-def _handle_video_like(message: Message, user: UsersOrm, data: File) -> None:
-    """Shared video / video-note pipeline: download, compress, summarize."""
-    downloaded_file = download_tg(data, ext=".mp4")
-    compressed_file = generate_temporary_name(ext=".ogg")
-    try:
-        compress_audio(input_file=downloaded_file, output_file=compressed_file)
-        answer = summarize(
-            data=compressed_file,
-            **_summary_kwargs(user),
+    def handle_audio(self, message: Message, user: UsersOrm) -> None:
+        """Handle audio file processing."""
+        data = self._fetch_media(message, message.audio, "No audio file found.")
+        if data is None:
+            return
+        answer = self._summarizer.summarize(
+            data=data,
+            **self._summary_kwargs(user),
         )
-        send_answer(message, answer)
-    finally:
-        clean_up(file=downloaded_file)
-        clean_up(file=compressed_file)
+        self._messenger.send_answer(message, answer)
 
-
-def handle_video_note(message: Message, user: UsersOrm) -> None:
-    """Handle video note file processing."""
-    data = _fetch_media(message, message.video_note, "No video note found.")
-    if data is None:
-        return
-    _handle_video_like(message, user, data)
-
-
-def handle_video(message: Message, user: UsersOrm) -> None:
-    """Handle video file processing."""
-    data = _fetch_media(message, message.video, "No video file found.")
-    if data is None:
-        return
-    _handle_video_like(message, user, data)
-
-
-def handle_document(message: Message, user: UsersOrm) -> None:
-    """Handle document file processing."""
-    document = message.document
-    data = _fetch_media(message, document, "No document found.")
-    if data is None or document is None:
-        return
-    answer = summarize_with_document(
-        file=data,
-        mime_type=document.mime_type or "application/octet-stream",
-        **_summary_kwargs(user),
-    )
-    send_answer(message, answer)
-
-
-def handle_url(message: Message, user: UsersOrm, url: str) -> None:
-    """Handle URL processing."""
-    kind = classify_url(url)
-    if kind in ("youtube", "castro"):
-        answer = summarize(
-            data=url,
-            **_summary_kwargs(user),
+    def handle_voice(self, message: Message, user: UsersOrm) -> None:
+        """Handle voice file processing."""
+        data = self._fetch_media(message, message.voice, "No voice message found.")
+        if data is None:
+            return
+        answer = self._summarizer.summarize(
+            data=data,
+            **self._summary_kwargs(user),
         )
-        send_answer(message, answer)
-    elif kind == "web":
-        check_quota(user_id=user.user_id, daily_limit=user.daily_limit, quantity=0)
-        parsed = parse_url(url)
-        answer = format_prefixed_summary(
-            parsed.prefix,
-            summarize_text(text=parsed.text, **_summary_kwargs(user)),
+        self._messenger.send_answer(message, answer)
+
+    def _handle_video_like(self, message: Message, user: UsersOrm, data: File) -> None:
+        """Shared video / video-note pipeline: download, compress, summarize."""
+        downloaded_file = self._downloader.download_tg(data, ext=".mp4")
+        compressed_file = generate_temporary_name(ext=".ogg")
+        try:
+            compress_audio(input_file=downloaded_file, output_file=compressed_file)
+            answer = self._summarizer.summarize(
+                data=compressed_file,
+                **self._summary_kwargs(user),
+            )
+            self._messenger.send_answer(message, answer)
+        finally:
+            clean_up(file=downloaded_file)
+            clean_up(file=compressed_file)
+
+    def handle_video_note(self, message: Message, user: UsersOrm) -> None:
+        """Handle video note file processing."""
+        data = self._fetch_media(message, message.video_note, "No video note found.")
+        if data is None:
+            return
+        self._handle_video_like(message, user, data)
+
+    def handle_video(self, message: Message, user: UsersOrm) -> None:
+        """Handle video file processing."""
+        data = self._fetch_media(message, message.video, "No video file found.")
+        if data is None:
+            return
+        self._handle_video_like(message, user, data)
+
+    def handle_document(self, message: Message, user: UsersOrm) -> None:
+        """Handle document file processing."""
+        document = message.document
+        data = self._fetch_media(message, document, "No document found.")
+        if data is None or document is None:
+            return
+        answer = self._summarizer.summarize_with_document(
+            file=data,
+            mime_type=document.mime_type or "application/octet-stream",
+            **self._summary_kwargs(user),
         )
-        send_answer(message, answer)
-    else:
-        bot.send_message(message.chat.id, "No data to proceed.")
+        self._messenger.send_answer(message, answer)
+
+    def handle_url(self, message: Message, user: UsersOrm, url: str) -> None:
+        """Handle URL processing."""
+        kind = classify_url(url)
+        if kind in ("youtube", "castro"):
+            answer = self._summarizer.summarize(
+                data=url,
+                **self._summary_kwargs(user),
+            )
+            self._messenger.send_answer(message, answer)
+        elif kind == "web":
+            self._quota_manager.check_quota(
+                user_id=user.user_id,
+                daily_limit=user.daily_limit,
+                quantity=0,
+            )
+            parsed = self._web_parser.parse(url)
+            answer = format_prefixed_summary(
+                parsed.prefix,
+                self._summarizer.summarize_text(
+                    text=parsed.text,
+                    **self._summary_kwargs(user),
+                ),
+            )
+            self._messenger.send_answer(message, answer)
+        else:
+            self._bot.send_message(message.chat.id, "No data to proceed.")
+
+
+# Module-level singleton and aliases — transitional shim (STG-135).
+# main.py still imports these; removed once main.py adopts the container.
+message_handlers = MessageHandlers(
+    bot,
+    messenger,
+    summarizer,
+    web_parser,
+    quota_manager,
+    downloader,
+)
+
+handle_audio = message_handlers.handle_audio
+handle_voice = message_handlers.handle_voice
+handle_video = message_handlers.handle_video
+handle_video_note = message_handlers.handle_video_note
+handle_document = message_handlers.handle_document
+handle_url = message_handlers.handle_url

--- a/src/llm.py
+++ b/src/llm.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import lru_cache
 from textwrap import dedent
 from typing import TYPE_CHECKING, cast
 
@@ -15,33 +14,37 @@ from prompts import SYSTEM_INSTRUCTION
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from google import genai
     from google.genai import types
     from pydantic_ai.messages import UploadedFileProviderName, UserContent
     from pydantic_ai.models import Model
     from pydantic_ai.settings import ThinkingLevel
 
 
-# A single agent serves every call: pydantic-ai takes the model, the instructions
-# and the settings per run, so nothing here is model-, language- or user-specific.
-_agent: Agent[None, str] = Agent()
-
-
-@lru_cache
-def _build_model(model_id: str) -> Model:
-    """Build the provider model for a registered id, cached for reuse."""
-    spec = MODEL_SPECS[model_id]
-    if spec.provider == "google":
-        return GoogleModel(model_id, provider=GoogleProvider(client=gemini_client))
-    msg = f"No model builder for provider: {spec.provider}"
-    raise ValueError(msg)
-
-
 class LLMClient:
     """Provider-agnostic entry point for every summarization model call."""
 
+    def __init__(self, client: genai.Client) -> None:
+        """Store the injected Gemini client and this client's model cache."""
+        self._client = client
+        # A single agent serves every call: pydantic-ai takes the model, the
+        # instructions and the settings per run, so nothing here is model-,
+        # language- or user-specific.
+        self._agent: Agent[None, str] = Agent()
+        self._models: dict[str, Model] = {}
+
     def build_model(self, model_id: str) -> Model:
         """Return the pydantic-ai model for a registered id, shared across calls."""
-        return _build_model(model_id)
+        if model_id not in self._models:
+            spec = MODEL_SPECS[model_id]
+            if spec.provider != "google":
+                msg = f"No model builder for provider: {spec.provider}"
+                raise ValueError(msg)
+            self._models[model_id] = GoogleModel(
+                model_id,
+                provider=GoogleProvider(client=self._client),
+            )
+        return self._models[model_id]
 
     def build_settings(self, model_id: str, thinking_level: str) -> ModelSettings:
         """Build the per-run settings, adding provider-specific options.
@@ -108,7 +111,7 @@ class LLMClient:
         instructions = dedent(
             SYSTEM_INSTRUCTION.format(language=target_language),
         ).strip()
-        result = _agent.run_sync(
+        result = self._agent.run_sync(
             content,
             model=self.build_model(model_id),
             instructions=instructions,
@@ -122,11 +125,11 @@ class LLMClient:
         return result.output
 
 
-# Module-level singleton
-llm_client = LLMClient()
+# Module-level singleton and aliases — transitional shim (STG-135).
+# summary.py still imports build_uploaded_file and run_model; removed once
+# every consumer is migrated to constructor injection.
+llm_client = LLMClient(gemini_client)
 
-
-# Module-level aliases — preserve the existing public API
 build_model = llm_client.build_model
 build_settings = llm_client.build_settings
 build_uploaded_file = llm_client.build_uploaded_file

--- a/src/llm.py
+++ b/src/llm.py
@@ -74,9 +74,9 @@ class LLMClient:
 
         Raises:
             ValueError: If the model is not served by the provider that stores
-                the file. `services.upload_and_wait_for_file` only ever uploads
-                to Gemini, so referencing it from anything else would hand the
-                model an id it cannot resolve.
+                the file. `services.GeminiHelper.upload_and_wait_for_file` only
+                ever uploads to Gemini, so referencing it from anything else
+                would hand the model an id it cannot resolve.
 
         """
         spec = MODEL_SPECS[model_id]

--- a/src/llm.py
+++ b/src/llm.py
@@ -8,7 +8,7 @@ from pydantic_ai.models.google import GoogleModel, GoogleModelSettings
 from pydantic_ai.providers.google import GoogleProvider
 from pydantic_ai.settings import ModelSettings
 
-from config import MODEL_SPECS, gemini_client
+from config import MODEL_SPECS
 from prompts import SYSTEM_INSTRUCTION
 
 if TYPE_CHECKING:
@@ -123,14 +123,3 @@ class LLMClient:
         if not result.output:
             raise AttributeError
         return result.output
-
-
-# Module-level singleton and aliases — transitional shim (STG-135).
-# summary.py still imports build_uploaded_file and run_model; removed once
-# every consumer is migrated to constructor injection.
-llm_client = LLMClient(gemini_client)
-
-build_model = llm_client.build_model
-build_settings = llm_client.build_settings
-build_uploaded_file = llm_client.build_uploaded_file
-run_model = llm_client.run

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+"""Telegram bot entry point: builds and runs the BotApp from the composition root."""
+
 from __future__ import annotations
 
 from textwrap import dedent
@@ -20,329 +22,365 @@ from config import (
     SUPPORTED_LANGUAGES,
     THINKING_LEVEL_LABELS,
     THINKING_LEVEL_LABELS_REVERSE,
-    bot,
-    langfuse_client,
 )
-from database import (
-    check_auth,
-    register_user,
-    select_user,
-    set_prompt_strategy,
-    set_summarizing_model,
-    set_target_language,
-    set_thinking_level,
-)
+from container import build_container
 from exceptions import LimitExceededError, WebParseError
-from handlers import (
-    handle_audio,
-    handle_document,
-    handle_url,
-    handle_video,
-    handle_video_note,
-    handle_voice,
-)
-from services import get_remaining_quota, observe_message
 from utils import clean_up
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import telebot
     from telebot.types import Message
 
+    from container import Container
+    from database import UserRepository
+    from handlers import MessageHandlers
     from models import UsersOrm
+    from services import QuotaManager, Tracer
 
 
-# /start
-@bot.message_handler(commands=["start"])
-def handle_start(message: Message) -> None:
-    """Handle /start: register a new user, or welcome back an existing one."""
-    if message.from_user is None:
-        bot.reply_to(message, "User information is missing.")
-        return
-    if register_user(
-        message.from_user.id,
-        message.from_user.first_name or "",
-        message.from_user.last_name or "",
-        message.from_user.username or "",
-    ):
-        bot.send_message(
-            message.chat.id,
-            "Hi there. I'm a private bot, if you know how to use me, go ahead.",
-        )
-    else:
-        bot.send_message(
-            message.chat.id,
-            "You are good to go!",
-        )
+class BotApp:
+    """Telegram entry point: registers handlers and routes incoming messages."""
 
+    def __init__(
+        self,
+        bot: telebot.TeleBot,
+        user_repo: UserRepository,
+        quota_manager: QuotaManager,
+        tracer: Tracer,
+        handlers: MessageHandlers,
+    ) -> None:
+        """Store the injected collaborators used to register and run handlers."""
+        self._bot = bot
+        self._user_repo = user_repo
+        self._quota_manager = quota_manager
+        self._tracer = tracer
+        self._handlers = handlers
 
-# /info
-@bot.message_handler(commands=["info"])
-def handle_info(message: Message) -> None:
-    """Handle /info: reply with the sender's Telegram user ID."""
-    if message.from_user is None:
-        bot.reply_to(message, "User information is missing.")
-        return
-    bot.send_message(message.chat.id, f"{message.from_user.id}")
-
-
-# /myinfo
-@bot.message_handler(
-    commands=["myinfo"],
-    func=lambda message: (
-        message.from_user is not None and check_auth(message.from_user.id)
-    ),
-)
-def handle_myinfo(message: Message) -> None:
-    """Handle /myinfo: reply with the user's settings, limit, and remaining quota."""
-    if message.from_user is None:
-        bot.reply_to(message, "User information is missing.")
-        return
-    user = select_user(message.from_user.id)
-    msg = dedent(f"""
-                UserId: {user.user_id}
-                Approved: {user.approved}
-                Target language: {user.target_language}
-                Summarizing model: {MODEL_LABELS.get(user.summarizing_model, user.summarizing_model)}
-                Prompt strategy: {PROMPT_STRATEGY_LABELS.get(user.prompt_key_for_summary, user.prompt_key_for_summary)}
-                Thinking level: {THINKING_LEVEL_LABELS.get(user.thinking_level, user.thinking_level)}
-                Daily limit: {user.daily_limit}
-                Remaining quota: {get_remaining_quota(user.user_id, user.daily_limit)}
-                """).strip()  # noqa: E501
-    bot.send_message(message.chat.id, msg)
-
-
-def _prompt_choice(
-    message: Message,
-    prompt: str,
-    labels: list[str],
-    next_step: Callable[[Message], None],
-) -> None:
-    """Send a one-time reply keyboard of `labels` and queue a next-step handler."""
-    markup = ReplyKeyboardMarkup(resize_keyboard=True, one_time_keyboard=True)
-    markup.add(*(KeyboardButton(label) for label in labels))
-    bot.send_message(message.chat.id, prompt, reply_markup=markup)
-    bot.register_next_step_handler(message, next_step)
-
-
-# /set_target_language
-@bot.message_handler(
-    commands=["set_target_language"],
-    func=lambda message: (
-        message.from_user is not None and check_auth(message.from_user.id)
-    ),
-)
-def handle_set_target_language(message: Message) -> None:
-    """Handle the /set_target_language command for the bot."""
-    _prompt_choice(
-        message,
-        "Select target language 👇",
-        [lang.title() for lang in SUPPORTED_LANGUAGES],
-        proceed_set_target_language,
-    )
-
-
-def proceed_set_target_language(message: Message) -> None:
-    """Apply the language picked from the keyboard, or report it as unknown."""
-    if message.from_user is None or message.text is None:
-        bot.reply_to(message, "User information or language is missing.")
-        return
-    set_lang = set_target_language(message.from_user.id, message.text)
-    if not set_lang:
-        msg = "Unknown language"
-        bot.send_message(message.chat.id, msg)
-        return
-    markup = ReplyKeyboardRemove()
-    bot.send_message(
-        message.chat.id,
-        f"The target language is set to {message.text}.",
-        reply_markup=markup,
-    )
-
-
-# /set_summarizing_model
-@bot.message_handler(
-    commands=["set_summarizing_model"],
-    func=lambda message: (
-        message.from_user is not None and check_auth(message.from_user.id)
-    ),
-)
-def handle_set_summarizing_model(message: Message) -> None:
-    """Handle the /set_summarizing_model command for the bot."""
-    _prompt_choice(
-        message,
-        "Select summarizing model 👇",
-        list(MODEL_LABELS.values()),
-        proceed_set_summarizing_model,
-    )
-
-
-def proceed_set_summarizing_model(message: Message) -> None:
-    """Apply the model picked from the keyboard, or report it as unknown."""
-    if message.from_user is None or message.text is None:
-        bot.reply_to(message, "User information or model is missing.")
-        return
-    model_id = MODEL_LABELS_REVERSE.get(message.text)
-    if model_id is None:
-        bot.send_message(message.chat.id, "Unknown model")
-        return
-    if not set_summarizing_model(message.from_user.id, model_id):
-        bot.send_message(message.chat.id, "Failed to update summarizing model.")
-        return
-    markup = ReplyKeyboardRemove()
-    bot.send_message(
-        message.chat.id,
-        f"The summarizing model is set to {message.text}.",
-        reply_markup=markup,
-    )
-
-
-# /set_prompt_strategy
-@bot.message_handler(
-    commands=["set_prompt_strategy"],
-    func=lambda message: (
-        message.from_user is not None and check_auth(message.from_user.id)
-    ),
-)
-def handle_set_prompt_strategy(message: Message) -> None:
-    """Handle the /set_prompt_strategy command for the bot."""
-    _prompt_choice(
-        message,
-        "Select summarization strategy 👇",
-        list(PROMPT_STRATEGY_LABELS.values()),
-        proceed_set_prompt_strategy,
-    )
-
-
-def proceed_set_prompt_strategy(message: Message) -> None:
-    """Apply the strategy picked from the keyboard, or report it as unknown."""
-    if message.from_user is None or message.text is None:
-        bot.reply_to(message, "User information or strategy is missing.")
-        return
-    prompt_key = PROMPT_STRATEGY_LABELS_REVERSE.get(message.text)
-    if prompt_key is None:
-        bot.send_message(message.chat.id, "Unknown strategy")
-        return
-    if not set_prompt_strategy(message.from_user.id, prompt_key):
-        bot.send_message(message.chat.id, "Failed to update prompt strategy.")
-        return
-    markup = ReplyKeyboardRemove()
-    bot.send_message(
-        message.chat.id,
-        f"The prompt strategy is set to {message.text}.",
-        reply_markup=markup,
-    )
-
-
-# /set_thinking_level
-@bot.message_handler(
-    commands=["set_thinking_level"],
-    func=lambda message: (
-        message.from_user is not None and check_auth(message.from_user.id)
-    ),
-)
-def handle_set_thinking_level(message: Message) -> None:
-    """Handle the /set_thinking_level command for the bot."""
-    _prompt_choice(
-        message,
-        "Select thinking level 👇",
-        list(THINKING_LEVEL_LABELS.values()),
-        proceed_set_thinking_level,
-    )
-
-
-def proceed_set_thinking_level(message: Message) -> None:
-    """Apply the thinking level picked from the keyboard, or report it as unknown."""
-    if message.from_user is None or message.text is None:
-        bot.reply_to(message, "User information or level is missing.")
-        return
-    level_key = THINKING_LEVEL_LABELS_REVERSE.get(message.text)
-    if level_key is None:
-        bot.send_message(message.chat.id, "Unknown level")
-        return
-    if not set_thinking_level(message.from_user.id, level_key):
-        bot.send_message(message.chat.id, "Failed to update thinking level.")
-        return
-    markup = ReplyKeyboardRemove()
-    bot.send_message(
-        message.chat.id,
-        f"The thinking level is set to {message.text}.",
-        reply_markup=markup,
-    )
-
-
-def process_message_content(message: Message, user: UsersOrm) -> None:
-    """Route a validated message to the handler for its content type."""
-    if message.content_type == "audio":
-        handle_audio(message, user)
-    elif (
-        message.content_type == "document"
-        and message.document is not None
-        and message.document.mime_type in SUPPORTED_DOCUMENT_MIME_TYPES
-    ):
-        handle_document(message, user)
-    elif message.content_type == "video_note":
-        handle_video_note(message, user)
-    elif message.content_type == "voice":
-        handle_voice(message, user)
-    elif message.content_type == "video":
-        handle_video(message, user)
-    else:
-        if message.text is None:
-            bot.send_message(message.chat.id, "No text to process.")
-            return
-        url = message.text.strip().split(" ", maxsplit=1)[0]
-        handle_url(message, user, url)
-
-
-# Unified handler
-@bot.message_handler(
-    content_types=["text", "audio", "document", "video_note", "voice", "video"],
-)
-def handle_message(message: Message) -> None:
-    """Universal entry point: authorize the sender, then route and trace the message.
-
-    Every failure the summarization pipeline raises terminates here — reported to
-    Sentry, answered with a user-facing message. The command and settings handlers
-    are separate entry points and are not covered by this guard.
-    """
-    try:
+    # /start
+    def handle_start(self, message: Message) -> None:
+        """Handle /start: register a new user, or welcome back an existing one."""
         if message.from_user is None:
-            bot.reply_to(message, "User information is missing.")
+            self._bot.reply_to(message, "User information is missing.")
             return
-        user = select_user(message.from_user.id)
+        if self._user_repo.register_user(
+            message.from_user.id,
+            message.from_user.first_name or "",
+            message.from_user.last_name or "",
+            message.from_user.username or "",
+        ):
+            self._bot.send_message(
+                message.chat.id,
+                "Hi there. I'm a private bot, if you know how to use me, go ahead.",
+            )
+        else:
+            self._bot.send_message(
+                message.chat.id,
+                "You are good to go!",
+            )
 
-        if not user.approved:
-            bot.send_message(message.chat.id, "You are not approved.")
+    # /info
+    def handle_info(self, message: Message) -> None:
+        """Handle /info: reply with the sender's Telegram user ID."""
+        if message.from_user is None:
+            self._bot.reply_to(message, "User information is missing.")
             return
+        self._bot.send_message(message.chat.id, f"{message.from_user.id}")
 
-        with observe_message(user.user_id, message.content_type):
-            process_message_content(message, user)
+    # /myinfo
+    def handle_myinfo(self, message: Message) -> None:
+        """Handle /myinfo: reply with the user's settings, limit, and quota."""
+        if message.from_user is None:
+            self._bot.reply_to(message, "User information is missing.")
+            return
+        user = self._user_repo.select_user(message.from_user.id)
+        msg = dedent(f"""
+                    UserId: {user.user_id}
+                    Approved: {user.approved}
+                    Target language: {user.target_language}
+                    Summarizing model: {MODEL_LABELS.get(user.summarizing_model, user.summarizing_model)}
+                    Prompt strategy: {PROMPT_STRATEGY_LABELS.get(user.prompt_key_for_summary, user.prompt_key_for_summary)}
+                    Thinking level: {THINKING_LEVEL_LABELS.get(user.thinking_level, user.thinking_level)}
+                    Daily limit: {user.daily_limit}
+                    Remaining quota: {self._quota_manager.get_remaining_quota(user.user_id, user.daily_limit)}
+                    """).strip()  # noqa: E501
+        self._bot.send_message(message.chat.id, msg)
 
-    except LimitExceededError as e:
-        capture_exception(e)
-        bot.reply_to(message, "Daily limit has been exceeded, try again tomorrow.")
-    except WebParseError as e:
-        capture_exception(e)
-        bot.reply_to(
+    def _prompt_choice(
+        self,
+        message: Message,
+        prompt: str,
+        labels: list[str],
+        next_step: Callable[[Message], None],
+    ) -> None:
+        """Send a one-time reply keyboard of `labels` and queue a next-step handler."""
+        markup = ReplyKeyboardMarkup(resize_keyboard=True, one_time_keyboard=True)
+        markup.add(*(KeyboardButton(label) for label in labels))
+        self._bot.send_message(message.chat.id, prompt, reply_markup=markup)
+        self._bot.register_next_step_handler(message, next_step)
+
+    # /set_target_language
+    def handle_set_target_language(self, message: Message) -> None:
+        """Handle the /set_target_language command for the bot."""
+        self._prompt_choice(
             message,
-            "Check provided URL, looks like the page is not available.",
+            "Select target language 👇",
+            [lang.title() for lang in SUPPORTED_LANGUAGES],
+            self.proceed_set_target_language,
         )
-    except RetryError as e:
-        capture_exception(e)
-        bot.reply_to(
+
+    def proceed_set_target_language(self, message: Message) -> None:
+        """Apply the language picked from the keyboard, or report it as unknown."""
+        if message.from_user is None or message.text is None:
+            self._bot.reply_to(message, "User information or language is missing.")
+            return
+        set_lang = self._user_repo.set_target_language(
+            message.from_user.id,
+            message.text,
+        )
+        if not set_lang:
+            msg = "Unknown language"
+            self._bot.send_message(message.chat.id, msg)
+            return
+        markup = ReplyKeyboardRemove()
+        self._bot.send_message(
+            message.chat.id,
+            f"The target language is set to {message.text}.",
+            reply_markup=markup,
+        )
+
+    # /set_summarizing_model
+    def handle_set_summarizing_model(self, message: Message) -> None:
+        """Handle the /set_summarizing_model command for the bot."""
+        self._prompt_choice(
             message,
-            "An error occurred during execution. Please try again in 10 minutes.",
+            "Select summarizing model 👇",
+            list(MODEL_LABELS.values()),
+            self.proceed_set_summarizing_model,
         )
-    except Exception as e:
-        capture_exception(e)
-        bot.reply_to(message, f"Unexpected: {type(e).__name__}")
+
+    def proceed_set_summarizing_model(self, message: Message) -> None:
+        """Apply the model picked from the keyboard, or report it as unknown."""
+        if message.from_user is None or message.text is None:
+            self._bot.reply_to(message, "User information or model is missing.")
+            return
+        model_id = MODEL_LABELS_REVERSE.get(message.text)
+        if model_id is None:
+            self._bot.send_message(message.chat.id, "Unknown model")
+            return
+        if not self._user_repo.set_summarizing_model(message.from_user.id, model_id):
+            self._bot.send_message(
+                message.chat.id,
+                "Failed to update summarizing model.",
+            )
+            return
+        markup = ReplyKeyboardRemove()
+        self._bot.send_message(
+            message.chat.id,
+            f"The summarizing model is set to {message.text}.",
+            reply_markup=markup,
+        )
+
+    # /set_prompt_strategy
+    def handle_set_prompt_strategy(self, message: Message) -> None:
+        """Handle the /set_prompt_strategy command for the bot."""
+        self._prompt_choice(
+            message,
+            "Select summarization strategy 👇",
+            list(PROMPT_STRATEGY_LABELS.values()),
+            self.proceed_set_prompt_strategy,
+        )
+
+    def proceed_set_prompt_strategy(self, message: Message) -> None:
+        """Apply the strategy picked from the keyboard, or report it as unknown."""
+        if message.from_user is None or message.text is None:
+            self._bot.reply_to(message, "User information or strategy is missing.")
+            return
+        prompt_key = PROMPT_STRATEGY_LABELS_REVERSE.get(message.text)
+        if prompt_key is None:
+            self._bot.send_message(message.chat.id, "Unknown strategy")
+            return
+        if not self._user_repo.set_prompt_strategy(message.from_user.id, prompt_key):
+            self._bot.send_message(
+                message.chat.id,
+                "Failed to update prompt strategy.",
+            )
+            return
+        markup = ReplyKeyboardRemove()
+        self._bot.send_message(
+            message.chat.id,
+            f"The prompt strategy is set to {message.text}.",
+            reply_markup=markup,
+        )
+
+    # /set_thinking_level
+    def handle_set_thinking_level(self, message: Message) -> None:
+        """Handle the /set_thinking_level command for the bot."""
+        self._prompt_choice(
+            message,
+            "Select thinking level 👇",
+            list(THINKING_LEVEL_LABELS.values()),
+            self.proceed_set_thinking_level,
+        )
+
+    def proceed_set_thinking_level(self, message: Message) -> None:
+        """Apply the picked thinking level, or report it as unknown."""
+        if message.from_user is None or message.text is None:
+            self._bot.reply_to(message, "User information or level is missing.")
+            return
+        level_key = THINKING_LEVEL_LABELS_REVERSE.get(message.text)
+        if level_key is None:
+            self._bot.send_message(message.chat.id, "Unknown level")
+            return
+        if not self._user_repo.set_thinking_level(message.from_user.id, level_key):
+            self._bot.send_message(
+                message.chat.id,
+                "Failed to update thinking level.",
+            )
+            return
+        markup = ReplyKeyboardRemove()
+        self._bot.send_message(
+            message.chat.id,
+            f"The thinking level is set to {message.text}.",
+            reply_markup=markup,
+        )
+
+    def process_message_content(self, message: Message, user: UsersOrm) -> None:
+        """Route a validated message to the handler for its content type."""
+        if message.content_type == "audio":
+            self._handlers.handle_audio(message, user)
+        elif (
+            message.content_type == "document"
+            and message.document is not None
+            and message.document.mime_type in SUPPORTED_DOCUMENT_MIME_TYPES
+        ):
+            self._handlers.handle_document(message, user)
+        elif message.content_type == "video_note":
+            self._handlers.handle_video_note(message, user)
+        elif message.content_type == "voice":
+            self._handlers.handle_voice(message, user)
+        elif message.content_type == "video":
+            self._handlers.handle_video(message, user)
+        else:
+            if message.text is None:
+                self._bot.send_message(message.chat.id, "No text to process.")
+                return
+            url = message.text.strip().split(" ", maxsplit=1)[0]
+            self._handlers.handle_url(message, user, url)
+
+    # Unified handler
+    def handle_message(self, message: Message) -> None:
+        """Universal entry point: authorize the sender, then route and trace it.
+
+        Every failure the summarization pipeline raises terminates here — reported to
+        Sentry, answered with a user-facing message. The command and settings handlers
+        are separate entry points and are not covered by this guard.
+        """
+        try:
+            if message.from_user is None:
+                self._bot.reply_to(message, "User information is missing.")
+                return
+            user = self._user_repo.select_user(message.from_user.id)
+
+            if not user.approved:
+                self._bot.send_message(message.chat.id, "You are not approved.")
+                return
+
+            with self._tracer.observe_message(user.user_id, message.content_type):
+                self.process_message_content(message, user)
+
+        except LimitExceededError as e:
+            capture_exception(e)
+            self._bot.reply_to(
+                message,
+                "Daily limit has been exceeded, try again tomorrow.",
+            )
+        except WebParseError as e:
+            capture_exception(e)
+            self._bot.reply_to(
+                message,
+                "Check provided URL, looks like the page is not available.",
+            )
+        except RetryError as e:
+            capture_exception(e)
+            self._bot.reply_to(
+                message,
+                "An error occurred during execution. Please try again in 10 minutes.",
+            )
+        except Exception as e:
+            capture_exception(e)
+            self._bot.reply_to(message, f"Unexpected: {type(e).__name__}")
+
+    def register(self) -> None:
+        """Register every handler on the bot. Replaces the import-time decorators."""
+        self._bot.message_handler(commands=["start"])(self.handle_start)
+        self._bot.message_handler(commands=["info"])(self.handle_info)
+        self._bot.message_handler(
+            commands=["myinfo"],
+            func=lambda message: (
+                message.from_user is not None
+                and self._user_repo.check_auth(message.from_user.id)
+            ),
+        )(self.handle_myinfo)
+        self._bot.message_handler(
+            commands=["set_target_language"],
+            func=lambda message: (
+                message.from_user is not None
+                and self._user_repo.check_auth(message.from_user.id)
+            ),
+        )(self.handle_set_target_language)
+        self._bot.message_handler(
+            commands=["set_summarizing_model"],
+            func=lambda message: (
+                message.from_user is not None
+                and self._user_repo.check_auth(message.from_user.id)
+            ),
+        )(self.handle_set_summarizing_model)
+        self._bot.message_handler(
+            commands=["set_prompt_strategy"],
+            func=lambda message: (
+                message.from_user is not None
+                and self._user_repo.check_auth(message.from_user.id)
+            ),
+        )(self.handle_set_prompt_strategy)
+        self._bot.message_handler(
+            commands=["set_thinking_level"],
+            func=lambda message: (
+                message.from_user is not None
+                and self._user_repo.check_auth(message.from_user.id)
+            ),
+        )(self.handle_set_thinking_level)
+        self._bot.message_handler(
+            content_types=["text", "audio", "document", "video_note", "voice", "video"],
+        )(self.handle_message)
+
+    def run(self) -> None:
+        """Start polling Telegram for updates."""
+        self._bot.infinity_polling(timeout=20)
+
+    def shutdown(self) -> None:
+        """Remove temp download files and flush the tracer."""
+        clean_up(all_downloads=True)
+        self._tracer.shutdown()
+
+
+def build_app(container: Container) -> BotApp:
+    """Build the BotApp from the composition root, handlers already registered."""
+    app = BotApp(
+        container.bot,
+        container.user_repo,
+        container.quota_manager,
+        container.tracer,
+        container.handlers,
+    )
+    app.register()
+    return app
 
 
 if __name__ == "__main__":
+    app = build_app(build_container())
     try:
-        bot.infinity_polling(timeout=20)
+        app.run()
     finally:
-        clean_up(all_downloads=True)
-        if langfuse_client is not None:
-            langfuse_client.shutdown()
+        app.shutdown()

--- a/src/main.py
+++ b/src/main.py
@@ -313,10 +313,19 @@ class BotApp:
             self._bot.reply_to(message, f"Unexpected: {type(e).__name__}")
 
     def _authorized(self, message: Message) -> bool:
-        """Gate the settings commands on a known, approved sender."""
-        return message.from_user is not None and self._user_repo.check_auth(
-            message.from_user.id,
-        )
+        """Gate the settings commands on a known, approved sender.
+
+        Runs as TeleBot's `func=` filter, which is evaluated outside
+        `handle_message` and is not guarded by the library: an exception here
+        aborts handler matching for the whole update, so an unregistered sender
+        has to read as unauthorized rather than raise.
+        """
+        if message.from_user is None:
+            return False
+        try:
+            return self._user_repo.check_auth(message.from_user.id)
+        except ValueError:
+            return False
 
     def register(self) -> None:
         """Register every handler on the bot. Replaces the import-time decorators."""
@@ -351,9 +360,15 @@ class BotApp:
         self._bot.infinity_polling(timeout=20)
 
     def shutdown(self) -> None:
-        """Remove temp download files and flush the tracer."""
-        clean_up(all_downloads=True)
-        self._tracer.shutdown()
+        """Remove temp download files and flush the tracer.
+
+        The sweep unlinks files directly, so one `OSError` would otherwise cost
+        every span still buffered in the tracer.
+        """
+        try:
+            clean_up(all_downloads=True)
+        finally:
+            self._tracer.shutdown()
 
 
 def build_app(container: Container) -> BotApp:

--- a/src/main.py
+++ b/src/main.py
@@ -312,44 +312,35 @@ class BotApp:
             capture_exception(e)
             self._bot.reply_to(message, f"Unexpected: {type(e).__name__}")
 
+    def _authorized(self, message: Message) -> bool:
+        """Gate the settings commands on a known, approved sender."""
+        return message.from_user is not None and self._user_repo.check_auth(
+            message.from_user.id,
+        )
+
     def register(self) -> None:
         """Register every handler on the bot. Replaces the import-time decorators."""
         self._bot.message_handler(commands=["start"])(self.handle_start)
         self._bot.message_handler(commands=["info"])(self.handle_info)
         self._bot.message_handler(
             commands=["myinfo"],
-            func=lambda message: (
-                message.from_user is not None
-                and self._user_repo.check_auth(message.from_user.id)
-            ),
+            func=self._authorized,
         )(self.handle_myinfo)
         self._bot.message_handler(
             commands=["set_target_language"],
-            func=lambda message: (
-                message.from_user is not None
-                and self._user_repo.check_auth(message.from_user.id)
-            ),
+            func=self._authorized,
         )(self.handle_set_target_language)
         self._bot.message_handler(
             commands=["set_summarizing_model"],
-            func=lambda message: (
-                message.from_user is not None
-                and self._user_repo.check_auth(message.from_user.id)
-            ),
+            func=self._authorized,
         )(self.handle_set_summarizing_model)
         self._bot.message_handler(
             commands=["set_prompt_strategy"],
-            func=lambda message: (
-                message.from_user is not None
-                and self._user_repo.check_auth(message.from_user.id)
-            ),
+            func=self._authorized,
         )(self.handle_set_prompt_strategy)
         self._bot.message_handler(
             commands=["set_thinking_level"],
-            func=lambda message: (
-                message.from_user is not None
-                and self._user_repo.check_auth(message.from_user.id)
-            ),
+            func=self._authorized,
         )(self.handle_set_thinking_level)
         self._bot.message_handler(
             content_types=["text", "audio", "document", "video_note", "voice", "video"],

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -251,6 +251,10 @@ class WebParser:
                 raise WebParseError(msg) from fallback_error
 
 
+# Module-level singleton and alias — transitional shim (STG-135).
+# handlers.py still imports parse_url; removed once every consumer is
+# migrated to constructor injection. The config clients above are imported
+# for this block alone.
 web_parser = WebParser(
     ExaBackend(exa_client),
     TavilyBackend(tavily_client),

--- a/src/parsing.py
+++ b/src/parsing.py
@@ -18,7 +18,6 @@ from tenacity import (
     wait_fixed,
 )
 
-from config import exa_client, tavily_client
 from domain import PrefixedText
 from exceptions import WebParseError
 from utils import get_proxy
@@ -249,19 +248,3 @@ class WebParser:
                 )
                 msg = "Both parsing backends failed"
                 raise WebParseError(msg) from fallback_error
-
-
-# Module-level singleton and alias — transitional shim (STG-135).
-# handlers.py still imports parse_url; removed once every consumer is
-# migrated to constructor injection. The config clients above are imported
-# for this block alone.
-web_parser = WebParser(
-    ExaBackend(exa_client),
-    TavilyBackend(tavily_client),
-    UrlResolver(),
-)
-
-
-def parse_url(url: str) -> PrefixedText:
-    """Extract main textual content from a URL via the default WebParser."""
-    return web_parser.parse(url)

--- a/src/services.py
+++ b/src/services.py
@@ -19,15 +19,7 @@ from tenacity import (
     wait_fixed,
 )
 
-from config import (
-    DAILY_LIMIT_KEY,
-    MINUTE_LIMIT_KEY,
-    bot,
-    gemini_client,
-    langfuse_client,
-    per_minute_rate,
-    rate_limiter,
-)
+from config import DAILY_LIMIT_KEY, MINUTE_LIMIT_KEY
 from exceptions import LimitExceededError
 
 if TYPE_CHECKING:
@@ -213,21 +205,3 @@ class Tracer:
             propagate_attributes(user_id=str(user_id), tags=[content_type]),
         ):
             yield
-
-
-# Module-level singletons and aliases — transitional shim (STG-135).
-# Consumers (summary.py, handlers.py, main.py) still import these; removed once
-# every consumer is migrated to constructor injection. The config clients above
-# are imported for this block alone — no method body reads them.
-messenger = Messenger(bot)
-quota_manager = QuotaManager(rate_limiter, per_minute_rate)
-gemini_helper = GeminiHelper(gemini_client)
-tracer = Tracer(langfuse_client)
-
-get_file_with_retry = messenger.get_file_with_retry
-send_answer = messenger.send_answer
-check_quota = quota_manager.check_quota
-get_remaining_quota = quota_manager.get_remaining_quota
-resolve_mime_type = gemini_helper.resolve_mime_type
-upload_and_wait_for_file = gemini_helper.upload_and_wait_for_file
-observe_message = tracer.observe_message

--- a/src/services.py
+++ b/src/services.py
@@ -180,6 +180,10 @@ class GeminiHelper:
             raise AttributeError
         return uploaded
 
+    def delete_file(self, name: str) -> None:
+        """Delete a file from the provider's file API."""
+        self._client.files.delete(name=name)
+
 
 class Tracer:
     """Groups all model calls for one Telegram message into a single Langfuse trace."""
@@ -220,22 +224,5 @@ send_answer = messenger.send_answer
 check_quota = quota_manager.check_quota
 get_remaining_quota = quota_manager.get_remaining_quota
 resolve_mime_type = gemini_helper.resolve_mime_type
-
-
-def upload_and_wait_for_file(file: str, mime_type: str, sleep_time: int) -> types.File:
-    """Transitional alias for `GeminiHelper.upload_and_wait_for_file` (STG-135).
-
-    Builds a fresh `GeminiHelper` around the current module-level `gemini_client`
-    on every call, rather than delegating to the `gemini_helper` singleton's
-    already-bound method, so `tests/test_summary.py`'s
-    `mocker.patch("services.gemini_client", ...)` calls keep working until that
-    test module migrates to injecting a `GeminiHelper` directly.
-    """
-    return GeminiHelper(gemini_client).upload_and_wait_for_file(
-        file,
-        mime_type,
-        sleep_time,
-    )
-
-
+upload_and_wait_for_file = gemini_helper.upload_and_wait_for_file
 observe_message = tracer.observe_message

--- a/src/services.py
+++ b/src/services.py
@@ -105,11 +105,15 @@ class QuotaManager:
             msg = "The daily limit for requests has been exceeded"
             raise LimitExceededError(msg)
         daily_rate = parse_rate_limit(f"{daily_limit} per day")
-        if not self._rate_limiter.hit(
-            daily_rate,
-            f"{DAILY_LIMIT_KEY}:{user_id}",
-            cost=quantity,
-        ):
+        daily_key = f"{DAILY_LIMIT_KEY}:{user_id}"
+        # quantity=0 is the non-consuming pre-check. hit(cost=0) increments by
+        # nothing, so an exhausted window still compares <= the limit and reads
+        # as open; test() asks whether one more unit would fit, without taking it.
+        if quantity == 0:
+            allowed = self._rate_limiter.test(daily_rate, daily_key)
+        else:
+            allowed = self._rate_limiter.hit(daily_rate, daily_key, cost=quantity)
+        if not allowed:
             msg = "The daily limit for requests has been exceeded"
             raise LimitExceededError(msg)
         while not self._rate_limiter.hit(

--- a/src/services.py
+++ b/src/services.py
@@ -192,6 +192,11 @@ class Tracer:
         """Store the injected Langfuse client (None when tracing is disabled)."""
         self._client = client
 
+    def shutdown(self) -> None:
+        """Flush buffered spans; a no-op when tracing is not configured."""
+        if self._client is not None:
+            self._client.shutdown()
+
     @contextmanager
     def observe_message(self, user_id: int, content_type: str) -> Generator[None]:
         """Group all model calls for one Telegram message into a single trace.

--- a/src/services.py
+++ b/src/services.py
@@ -33,7 +33,12 @@ from exceptions import LimitExceededError
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    import telebot
+    from google import genai
     from google.genai import types
+    from langfuse import Langfuse
+    from limits import RateLimitItem
+    from limits.strategies import FixedWindowRateLimiter
     from telebot.types import File, Message
     from tenacity import _utils as tenacity_utils
 
@@ -44,7 +49,10 @@ tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 class Messenger:
     """Handles all Telegram bot messaging with retry logic."""
 
-    @staticmethod
+    def __init__(self, bot: telebot.TeleBot) -> None:
+        """Store the injected Telegram bot client."""
+        self._bot = bot
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_fixed(1),
@@ -53,12 +61,13 @@ class Messenger:
         reraise=True,
     )
     def _reply_with_retry(
+        self,
         message: Message,
         text: str,
         entities: list[dict[str, object]],
     ) -> None:
         """Send a reply with retry logic on Telegram API errors."""
-        bot.reply_to(message, text, entities=entities)
+        self._bot.reply_to(message, text, entities=entities)
 
     @retry(
         stop=stop_after_attempt(3),
@@ -69,7 +78,7 @@ class Messenger:
     )
     def get_file_with_retry(self, file_id: str) -> File:
         """Get file information from Telegram, with retries on timeout."""
-        return bot.get_file(file_id)
+        return self._bot.get_file(file_id)
 
     def send_answer(self, message: Message, answer: str) -> None:
         """Send a response message, splitting at Telegram's 4 096-code-unit limit."""
@@ -89,21 +98,37 @@ class Messenger:
 class QuotaManager:
     """Enforces per-user daily and global per-minute rate limits."""
 
+    def __init__(
+        self,
+        rate_limiter: FixedWindowRateLimiter,
+        per_minute_rate: RateLimitItem,
+    ) -> None:
+        """Store the injected rate limiter and its parsed per-minute rate."""
+        self._rate_limiter = rate_limiter
+        self._per_minute_rate = per_minute_rate
+
     def check_quota(self, user_id: int, daily_limit: int, quantity: int = 1) -> bool:
         """Enforce rate limits; raise if daily exceeded; sleep on per-minute."""
         if daily_limit <= 0:
             msg = "The daily limit for requests has been exceeded"
             raise LimitExceededError(msg)
         daily_rate = parse_rate_limit(f"{daily_limit} per day")
-        if not rate_limiter.hit(
+        if not self._rate_limiter.hit(
             daily_rate,
             f"{DAILY_LIMIT_KEY}:{user_id}",
             cost=quantity,
         ):
             msg = "The daily limit for requests has been exceeded"
             raise LimitExceededError(msg)
-        while not rate_limiter.hit(per_minute_rate, MINUTE_LIMIT_KEY, cost=quantity):
-            stats = rate_limiter.get_window_stats(per_minute_rate, MINUTE_LIMIT_KEY)
+        while not self._rate_limiter.hit(
+            self._per_minute_rate,
+            MINUTE_LIMIT_KEY,
+            cost=quantity,
+        ):
+            stats = self._rate_limiter.get_window_stats(
+                self._per_minute_rate,
+                MINUTE_LIMIT_KEY,
+            )
             time.sleep(max(0.0, stats.reset_time - time.time()))
         return True
 
@@ -112,7 +137,7 @@ class QuotaManager:
         if daily_limit <= 0:
             return 0
         daily_rate = parse_rate_limit(f"{daily_limit} per day")
-        stats = rate_limiter.get_window_stats(
+        stats = self._rate_limiter.get_window_stats(
             daily_rate,
             f"{DAILY_LIMIT_KEY}:{user_id}",
         )
@@ -121,6 +146,10 @@ class QuotaManager:
 
 class GeminiHelper:
     """Utilities for Gemini file management."""
+
+    def __init__(self, client: genai.Client) -> None:
+        """Store the injected Gemini client."""
+        self._client = client
 
     def resolve_mime_type(self, file: str) -> str:
         """Resolve the MIME type for a file path, defaulting to octet-stream."""
@@ -133,7 +162,7 @@ class GeminiHelper:
         sleep_time: int,
     ) -> types.File:
         """Upload a file to Gemini and wait for processing to finish."""
-        uploaded = gemini_client.files.upload(
+        uploaded = self._client.files.upload(
             file=file,
             config={"mime_type": mime_type},
         )
@@ -142,7 +171,7 @@ class GeminiHelper:
         file_name = uploaded.name
         while uploaded.state == "PROCESSING":
             time.sleep(sleep_time)
-            uploaded = gemini_client.files.get(name=file_name)
+            uploaded = self._client.files.get(name=file_name)
         if uploaded.state == "FAILED":
             raise ValueError(uploaded.state)
         # Re-check name on the polled object, not just the upload response:
@@ -152,37 +181,61 @@ class GeminiHelper:
         return uploaded
 
 
-@contextmanager
-def observe_message(user_id: int, content_type: str) -> Generator[None]:
-    """Group all model calls for one Telegram message into a single trace.
+class Tracer:
+    """Groups all model calls for one Telegram message into a single Langfuse trace."""
 
-    Opens a Langfuse root span attributed to the user and tagged with the
-    message content type, so the generation spans emitted by pydantic-ai nest
-    under one trace. A no-op when Langfuse is not configured.
-    """
-    if langfuse_client is None:
-        yield
-        return
-    with (
-        langfuse_client.start_as_current_observation(name="handle_message"),
-        propagate_attributes(user_id=str(user_id), tags=[content_type]),
-    ):
-        yield
+    def __init__(self, client: Langfuse | None) -> None:
+        """Store the injected Langfuse client (None when tracing is disabled)."""
+        self._client = client
+
+    @contextmanager
+    def observe_message(self, user_id: int, content_type: str) -> Generator[None]:
+        """Group all model calls for one Telegram message into a single trace.
+
+        Opens a Langfuse root span attributed to the user and tagged with the
+        message content type, so the generation spans emitted by pydantic-ai nest
+        under one trace. A no-op when Langfuse is not configured.
+        """
+        if self._client is None:
+            yield
+            return
+        with (
+            self._client.start_as_current_observation(name="handle_message"),
+            propagate_attributes(user_id=str(user_id), tags=[content_type]),
+        ):
+            yield
 
 
-# Module-level singletons
-messenger = Messenger()
-quota_manager = QuotaManager()
-gemini_helper = GeminiHelper()
+# Module-level singletons and aliases — transitional shim (STG-135).
+# Consumers (summary.py, handlers.py, main.py) still import these; removed once
+# every consumer is migrated to constructor injection. The config clients above
+# are imported for this block alone — no method body reads them.
+messenger = Messenger(bot)
+quota_manager = QuotaManager(rate_limiter, per_minute_rate)
+gemini_helper = GeminiHelper(gemini_client)
+tracer = Tracer(langfuse_client)
 
-
-# Module-level aliases — keep the existing public API intact so that
-# all importers and mocker.patch("services.*") calls continue to work.
 get_file_with_retry = messenger.get_file_with_retry
 send_answer = messenger.send_answer
-
 check_quota = quota_manager.check_quota
 get_remaining_quota = quota_manager.get_remaining_quota
-
 resolve_mime_type = gemini_helper.resolve_mime_type
-upload_and_wait_for_file = gemini_helper.upload_and_wait_for_file
+
+
+def upload_and_wait_for_file(file: str, mime_type: str, sleep_time: int) -> types.File:
+    """Transitional alias for `GeminiHelper.upload_and_wait_for_file` (STG-135).
+
+    Builds a fresh `GeminiHelper` around the current module-level `gemini_client`
+    on every call, rather than delegating to the `gemini_helper` singleton's
+    already-bound method, so `tests/test_summary.py`'s
+    `mocker.patch("services.gemini_client", ...)` calls keep working until that
+    test module migrates to injecting a `GeminiHelper` directly.
+    """
+    return GeminiHelper(gemini_client).upload_and_wait_for_file(
+        file,
+        mime_type,
+        sleep_time,
+    )
+
+
+observe_message = tracer.observe_message

--- a/src/summary.py
+++ b/src/summary.py
@@ -305,7 +305,7 @@ class Summarizer:
                     transcript_result = self._yt_transcriber.get_transcript(data)
                 except (FetchTranscriptError, ValueError) as e:
                     logger.warning(
-                        "get_yt_transcript failed, falling back to download: %s",
+                        "get_transcript failed, falling back to download: %s",
                         e,
                     )
                 else:

--- a/src/summary.py
+++ b/src/summary.py
@@ -20,21 +20,17 @@ from tenacity import (
 
 from config import MODEL_SPECS
 from domain import format_prefixed_summary
-from download import Downloader, downloader
 from exceptions import FetchTranscriptError
-from llm import LLMClient, llm_client
 from prompts import PROMPTS
-from services import GeminiHelper, QuotaManager, gemini_helper, quota_manager
-from transcription import (
-    AudioTranscriber,
-    YouTubeTranscriber,
-    audio_transcriber,
-    yt_transcriber,
-)
 from utils import classify_url, clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
     from tenacity import _utils as tenacity_utils
+
+    from download import Downloader
+    from llm import LLMClient
+    from services import GeminiHelper, QuotaManager
+    from transcription import AudioTranscriber, YouTubeTranscriber
 
 logger = logging.getLogger(__name__)
 tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
@@ -400,23 +396,3 @@ class Summarizer:
             )
         finally:
             clean_up(file=new_file)
-
-
-# Module-level singleton and aliases — transitional shim (STG-135).
-# handlers.py still imports these; removed once every consumer is migrated
-# to constructor injection.
-summarizer = Summarizer(
-    quota_manager,
-    gemini_helper,
-    llm_client,
-    downloader,
-    audio_transcriber,
-    yt_transcriber,
-)
-
-
-# Module-level aliases — preserve the existing public API
-summarize_with_file = summarizer.summarize_with_file
-summarize_text = summarizer.summarize_text
-summarize_with_document = summarizer.summarize_with_document
-summarize = summarizer.summarize

--- a/src/summary.py
+++ b/src/summary.py
@@ -18,18 +18,19 @@ from tenacity import (
     wait_fixed,
 )
 
-from config import MODEL_SPECS, gemini_client
+from config import MODEL_SPECS
 from domain import format_prefixed_summary
-from download import download_castro, download_tg, download_yt
+from download import Downloader, downloader
 from exceptions import FetchTranscriptError
-from llm import build_uploaded_file, run_model
+from llm import LLMClient, llm_client
 from prompts import PROMPTS
-from services import (
-    check_quota,
-    resolve_mime_type,
-    upload_and_wait_for_file,
+from services import GeminiHelper, QuotaManager, gemini_helper, quota_manager
+from transcription import (
+    AudioTranscriber,
+    YouTubeTranscriber,
+    audio_transcriber,
+    yt_transcriber,
 )
-from transcription import get_yt_transcript, transcribe
 from utils import classify_url, clean_up, compress_audio, generate_temporary_name
 
 if TYPE_CHECKING:
@@ -41,6 +42,23 @@ tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 class Summarizer:
     """Generates model-backed summaries from audio, video, documents, and URLs."""
+
+    def __init__(
+        self,
+        quota_manager: QuotaManager,
+        gemini_helper: GeminiHelper,
+        llm_client: LLMClient,
+        downloader: Downloader,
+        audio_transcriber: AudioTranscriber,
+        yt_transcriber: YouTubeTranscriber,
+    ) -> None:
+        """Store the injected collaborators used to build a summary."""
+        self._quota_manager = quota_manager
+        self._gemini_helper = gemini_helper
+        self._llm_client = llm_client
+        self._downloader = downloader
+        self._audio_transcriber = audio_transcriber
+        self._yt_transcriber = yt_transcriber
 
     @retry(
         stop=stop_after_attempt(2),
@@ -71,21 +89,32 @@ class Summarizer:
             RetryError: If transient model or network errors persist after retries.
 
         """
-        check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
+        self._quota_manager.check_quota(
+            user_id=user_id,
+            daily_limit=daily_limit,
+            quantity=0,
+        )
         prompt = dedent(PROMPTS[prompt_key]).strip()
-        mime_type = resolve_mime_type(file)
-        audio_file = upload_and_wait_for_file(
+        mime_type = self._gemini_helper.resolve_mime_type(file)
+        audio_file = self._gemini_helper.upload_and_wait_for_file(
             file=file,
             mime_type=mime_type,
             sleep_time=sleep_time,
         )
         audio_file_name = cast("str", audio_file.name)
         try:
-            check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-            return run_model(
+            self._quota_manager.check_quota(
+                user_id=user_id,
+                daily_limit=daily_limit,
+                quantity=1,
+            )
+            return self._llm_client.run(
                 content=[
                     prompt,
-                    build_uploaded_file(model_id=model, file=audio_file),
+                    self._llm_client.build_uploaded_file(
+                        model_id=model,
+                        file=audio_file,
+                    ),
                 ],
                 model_id=model,
                 target_language=target_language,
@@ -93,7 +122,7 @@ class Summarizer:
             )
         finally:
             try:
-                gemini_client.files.delete(name=audio_file_name)
+                self._gemini_helper.delete_file(audio_file_name)
             except Exception as e:
                 logger.warning(
                     "Failed to delete Gemini file %s: %s",
@@ -128,8 +157,12 @@ class Summarizer:
 
         """
         prompt = (f"{dedent(PROMPTS[prompt_key])} {text}").strip()
-        check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-        return run_model(
+        self._quota_manager.check_quota(
+            user_id=user_id,
+            daily_limit=daily_limit,
+            quantity=1,
+        )
+        return self._llm_client.run(
             content=prompt,
             model_id=model,
             target_language=target_language,
@@ -179,8 +212,12 @@ class Summarizer:
         data: str | None = None
         document_file_name: str | None = None
         if mime_type.startswith("audio/") and not MODEL_SPECS[model].supports_audio:
-            check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
-            data = download_tg(file, ext=".ogg")
+            self._quota_manager.check_quota(
+                user_id=user_id,
+                daily_limit=daily_limit,
+                quantity=0,
+            )
+            data = self._downloader.download_tg(file, ext=".ogg")
             try:
                 return self._summarize_via_transcription(
                     data=data,
@@ -194,20 +231,31 @@ class Summarizer:
             finally:
                 clean_up(file=data)
         try:
-            check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
-            data = download_tg(file)
+            self._quota_manager.check_quota(
+                user_id=user_id,
+                daily_limit=daily_limit,
+                quantity=0,
+            )
+            data = self._downloader.download_tg(file)
             prompt = dedent(PROMPTS[prompt_key]).strip()
-            document_file = upload_and_wait_for_file(
+            document_file = self._gemini_helper.upload_and_wait_for_file(
                 file=data,
                 mime_type=mime_type,
                 sleep_time=sleep_time,
             )
             document_file_name = document_file.name
-            check_quota(user_id=user_id, daily_limit=daily_limit, quantity=1)
-            summary = run_model(
+            self._quota_manager.check_quota(
+                user_id=user_id,
+                daily_limit=daily_limit,
+                quantity=1,
+            )
+            summary = self._llm_client.run(
                 content=[
                     prompt,
-                    build_uploaded_file(model_id=model, file=document_file),
+                    self._llm_client.build_uploaded_file(
+                        model_id=model,
+                        file=document_file,
+                    ),
                 ],
                 model_id=model,
                 target_language=target_language,
@@ -216,7 +264,7 @@ class Summarizer:
         finally:
             if document_file_name is not None:
                 try:
-                    gemini_client.files.delete(name=document_file_name)
+                    self._gemini_helper.delete_file(document_file_name)
                 except Exception as e:
                     logger.warning(
                         "Failed to delete Gemini file %s: %s",
@@ -247,14 +295,18 @@ class Summarizer:
             RetryError: If all summarization attempts fail after retries.
 
         """
-        check_quota(user_id=user_id, daily_limit=daily_limit, quantity=0)
+        self._quota_manager.check_quota(
+            user_id=user_id,
+            daily_limit=daily_limit,
+            quantity=0,
+        )
         if isinstance(data, str):
             kind = classify_url(data)
             if kind == "castro":
-                data = download_castro(data)
+                data = self._downloader.download_castro(data)
             elif kind == "youtube":
                 try:
-                    transcript_result = get_yt_transcript(data)
+                    transcript_result = self._yt_transcriber.get_transcript(data)
                 except (FetchTranscriptError, ValueError) as e:
                     logger.warning(
                         "get_yt_transcript failed, falling back to download: %s",
@@ -273,9 +325,9 @@ class Summarizer:
                             thinking_level=thinking_level,
                         ),
                     )
-                data = download_yt(data)
+                data = self._downloader.download_yt(data)
         if isinstance(data, File):
-            data = download_tg(data, ext=".ogg")
+            data = self._downloader.download_tg(data, ext=".ogg")
 
         try:
             if not MODEL_SPECS[model].supports_audio:
@@ -333,7 +385,7 @@ class Summarizer:
         new_file = generate_temporary_name(ext=".ogg")
         try:
             compress_audio(input_file=data, output_file=new_file)
-            transcription = transcribe(new_file)
+            transcription = self._audio_transcriber.transcribe(new_file)
             return format_prefixed_summary(
                 "📝",
                 self.summarize_text(
@@ -350,8 +402,17 @@ class Summarizer:
             clean_up(file=new_file)
 
 
-# Module-level singleton
-summarizer = Summarizer()
+# Module-level singleton and aliases — transitional shim (STG-135).
+# handlers.py still imports these; removed once every consumer is migrated
+# to constructor injection.
+summarizer = Summarizer(
+    quota_manager,
+    gemini_helper,
+    llm_client,
+    downloader,
+    audio_transcriber,
+    yt_transcriber,
+)
 
 
 # Module-level aliases — preserve the existing public API

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -452,13 +452,14 @@ class YouTubeTranscriber:
         return PrefixedText(text=text, prefix=self._primary.prefix)
 
 
-# Module-level singletons
+# Module-level singletons and aliases — transitional shim (STG-135).
+# summary.py still imports transcribe and get_yt_transcript; removed once
+# every consumer is migrated to constructor injection. The config client
+# above is imported for this block alone.
 audio_transcriber = AudioTranscriber(replicate_client)
 api_backend = ApiBackend()
 ytdlp_backend = YtDlpBackend()
 yt_transcriber = YouTubeTranscriber(api_backend, ytdlp_backend)
 
-
-# Module-level aliases — preserve the existing public API
 transcribe = audio_transcriber.transcribe
 get_yt_transcript = yt_transcriber.get_transcript

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -29,7 +29,7 @@ from youtube_transcript_api.proxies import GenericProxyConfig
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
-from config import YT_HOSTS, replicate_client
+from config import YT_HOSTS
 from domain import PrefixedText
 from exceptions import (
     FetchTranscriptError,
@@ -450,16 +450,3 @@ class YouTubeTranscriber:
                 raise FetchTranscriptError(msg) from fallback_error
             return PrefixedText(text=text, prefix=self._fallback.prefix)
         return PrefixedText(text=text, prefix=self._primary.prefix)
-
-
-# Module-level singletons and aliases — transitional shim (STG-135).
-# summary.py still imports transcribe and get_yt_transcript; removed once
-# every consumer is migrated to constructor injection. The config client
-# above is imported for this block alone.
-audio_transcriber = AudioTranscriber(replicate_client)
-api_backend = ApiBackend()
-ytdlp_backend = YtDlpBackend()
-yt_transcriber = YouTubeTranscriber(api_backend, ytdlp_backend)
-
-transcribe = audio_transcriber.transcribe
-get_yt_transcript = yt_transcriber.get_transcript

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,23 +35,6 @@ sentry_sdk.init = lambda *args, **kwargs: None
 
 
 @pytest.fixture
-def mock_db_session(mocker):
-    """Fixture to mock the database session."""
-    session_mock = mocker.MagicMock()
-    # Mocking the Session factory from our database module
-    # The actual database functions do:
-    # with Session() as session:
-    # So Session() must return a context manager that yields session_mock
-    context_manager_mock = mocker.MagicMock()
-    context_manager_mock.__enter__.return_value = session_mock
-
-    mocker.patch("database.Session", return_value=context_manager_mock)
-    # Also mock engine if accessed
-    mocker.patch("database.engine", mocker.MagicMock())
-    return session_mock
-
-
-@pytest.fixture
 def message_factory():
     """Fixture to generate a mock telebot Message with variable content."""
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,24 @@
+"""Builders shared by more than one test module."""
+
+from types import SimpleNamespace
+
+from main import BotApp
+
+
+def make_app(mocker):
+    """Return (app, fakes) with every BotApp collaborator injected as a MagicMock."""
+    fakes = SimpleNamespace(
+        bot=mocker.MagicMock(),
+        user_repo=mocker.MagicMock(),
+        quota_manager=mocker.MagicMock(),
+        tracer=mocker.MagicMock(),
+        handlers=mocker.MagicMock(),
+    )
+    app = BotApp(
+        fakes.bot,
+        fakes.user_repo,
+        fakes.quota_manager,
+        fakes.tracer,
+        fakes.handlers,
+    )
+    return app, fakes

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,34 +1,13 @@
-from types import SimpleNamespace
-
 import pytest
 
-from main import BotApp
+from helpers import make_app
 from models import UsersOrm
-
-
-def _make_app(mocker):
-    """Return (app, fakes) with every collaborator injected as a MagicMock."""
-    fakes = SimpleNamespace(
-        bot=mocker.MagicMock(),
-        user_repo=mocker.MagicMock(),
-        quota_manager=mocker.MagicMock(),
-        tracer=mocker.MagicMock(),
-        handlers=mocker.MagicMock(),
-    )
-    app = BotApp(
-        fakes.bot,
-        fakes.user_repo,
-        fakes.quota_manager,
-        fakes.tracer,
-        fakes.handlers,
-    )
-    return app, fakes
 
 
 def test_handle_start_new_user(message_factory, mocker):
     """Test /start for a new user (registration)."""
     msg = message_factory(content_type="text", text="/start")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.register_user.return_value = True
 
     app.handle_start(msg)
@@ -41,7 +20,7 @@ def test_handle_start_new_user(message_factory, mocker):
 def test_handle_start_existing_user(message_factory, mocker):
     """Test /start for an existing user."""
     msg = message_factory(content_type="text", text="/start")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.register_user.return_value = False
 
     app.handle_start(msg)
@@ -53,7 +32,7 @@ def test_handle_start_missing_user(message_factory, mocker):
     """Test /start rejects messages without Telegram user metadata."""
     msg = message_factory(content_type="text", text="/start")
     msg.from_user = None
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     app.handle_start(msg)
 
@@ -64,7 +43,7 @@ def test_handle_start_missing_user(message_factory, mocker):
 def test_handle_info(message_factory, mocker):
     """Test /info command."""
     msg = message_factory(content_type="text", text="/info")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     app.handle_info(msg)
 
@@ -75,7 +54,7 @@ def test_handle_info_missing_user(message_factory, mocker):
     """Test /info rejects messages without Telegram user metadata."""
     msg = message_factory(content_type="text", text="/info")
     msg.from_user = None
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     app.handle_info(msg)
 
@@ -85,7 +64,7 @@ def test_handle_info_missing_user(message_factory, mocker):
 def test_handle_myinfo(message_factory, mocker):
     """Test /myinfo command."""
     msg = message_factory(content_type="text", text="/myinfo")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     mock_user = UsersOrm(
         user_id=123,
         approved=True,
@@ -116,7 +95,7 @@ def test_handle_myinfo_missing_user(message_factory, mocker):
     """Test /myinfo rejects messages without Telegram user metadata."""
     msg = message_factory(content_type="text", text="/myinfo")
     msg.from_user = None
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     app.handle_myinfo(msg)
 
@@ -157,7 +136,7 @@ def test_handle_set_setting_shows_keyboard(
 ):
     """Test each /set_* command shows its selection keyboard."""
     msg = message_factory(content_type="text")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     getattr(app, handler_name)(msg)
 
@@ -171,7 +150,7 @@ def test_handle_set_setting_shows_keyboard(
 def test_proceed_set_target_language_success(message_factory, mocker):
     """Test successful language selection."""
     msg = message_factory(content_type="text", text="Russian")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.set_target_language.return_value = True
 
     app.proceed_set_target_language(msg)
@@ -185,7 +164,7 @@ def test_proceed_set_target_language_success(message_factory, mocker):
 def test_proceed_set_summarizing_model_success(message_factory, mocker):
     """Test successful model selection."""
     msg = message_factory(content_type="text", text="Gemini 3.5 Flash")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.set_summarizing_model.return_value = True
 
     app.proceed_set_summarizing_model(msg)
@@ -203,7 +182,7 @@ def test_proceed_set_summarizing_model_success(message_factory, mocker):
 def test_proceed_set_prompt_strategy_success(message_factory, mocker):
     """Test successful strategy selection."""
     msg = message_factory(content_type="text", text="Detailed Summary")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.set_prompt_strategy.return_value = True
 
     app.proceed_set_prompt_strategy(msg)
@@ -221,7 +200,7 @@ def test_proceed_set_prompt_strategy_success(message_factory, mocker):
 def test_proceed_set_thinking_level_success(message_factory, mocker):
     """Test successful thinking level selection."""
     msg = message_factory(content_type="text", text="High")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.set_thinking_level.return_value = True
 
     app.proceed_set_thinking_level(msg)
@@ -270,7 +249,7 @@ def test_proceed_set_setting_missing_input(
     """Test each setting selection fails fast when user or text is missing."""
     msg = message_factory(content_type="text", text="Anything")
     setattr(msg, null_attr, None)
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     getattr(app, proceed_name)(msg)
 
@@ -311,7 +290,7 @@ def test_proceed_set_setting_invalid_choice(
 ):
     """Test an invalid label short-circuits before calling the setter."""
     msg = message_factory(content_type="text", text=bad_text)
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     getattr(app, proceed_name)(msg)
 
@@ -322,7 +301,7 @@ def test_proceed_set_setting_invalid_choice(
 def test_proceed_set_target_language_invalid_choice(message_factory, mocker):
     """Test an unknown language is rejected via the setter returning False."""
     msg = message_factory(content_type="text", text="Klingon")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.set_target_language.return_value = False
 
     app.proceed_set_target_language(msg)
@@ -363,7 +342,7 @@ def test_proceed_set_setting_db_failure(
 ):
     """Test a DB failure returns a clear user-facing message, not success."""
     msg = message_factory(content_type="text", text=valid_text)
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     getattr(fakes.user_repo, setter_name).return_value = False
 
     getattr(app, proceed_name)(msg)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,82 +1,91 @@
+from types import SimpleNamespace
+
 import pytest
 
-from main import (
-    handle_info,
-    handle_myinfo,
-    handle_set_prompt_strategy,
-    handle_set_summarizing_model,
-    handle_set_target_language,
-    handle_set_thinking_level,
-    handle_start,
-    proceed_set_prompt_strategy,
-    proceed_set_summarizing_model,
-    proceed_set_target_language,
-    proceed_set_thinking_level,
-)
+from main import BotApp
 from models import UsersOrm
+
+
+def _make_app(mocker):
+    """Return (app, fakes) with every collaborator injected as a MagicMock."""
+    fakes = SimpleNamespace(
+        bot=mocker.MagicMock(),
+        user_repo=mocker.MagicMock(),
+        quota_manager=mocker.MagicMock(),
+        tracer=mocker.MagicMock(),
+        handlers=mocker.MagicMock(),
+    )
+    app = BotApp(
+        fakes.bot,
+        fakes.user_repo,
+        fakes.quota_manager,
+        fakes.tracer,
+        fakes.handlers,
+    )
+    return app, fakes
 
 
 def test_handle_start_new_user(message_factory, mocker):
     """Test /start for a new user (registration)."""
     msg = message_factory(content_type="text", text="/start")
-    mock_register = mocker.patch("main.register_user", return_value=True)
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.register_user.return_value = True
 
-    handle_start(msg)
+    app.handle_start(msg)
 
-    mock_register.assert_called_once()
-    mock_send.assert_called_once()
-    assert "Hi there" in mock_send.call_args[0][1]
+    fakes.user_repo.register_user.assert_called_once()
+    fakes.bot.send_message.assert_called_once()
+    assert "Hi there" in fakes.bot.send_message.call_args[0][1]
 
 
 def test_handle_start_existing_user(message_factory, mocker):
     """Test /start for an existing user."""
     msg = message_factory(content_type="text", text="/start")
-    mocker.patch("main.register_user", return_value=False)
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.register_user.return_value = False
 
-    handle_start(msg)
+    app.handle_start(msg)
 
-    assert "You are good to go!" in mock_send.call_args[0][1]
+    assert "You are good to go!" in fakes.bot.send_message.call_args[0][1]
 
 
 def test_handle_start_missing_user(message_factory, mocker):
     """Test /start rejects messages without Telegram user metadata."""
     msg = message_factory(content_type="text", text="/start")
     msg.from_user = None
-    mock_reply = mocker.patch("main.bot.reply_to")
-    mock_register = mocker.patch("main.register_user")
+    app, fakes = _make_app(mocker)
 
-    handle_start(msg)
+    app.handle_start(msg)
 
-    mock_reply.assert_called_once_with(msg, "User information is missing.")
-    mock_register.assert_not_called()
+    fakes.bot.reply_to.assert_called_once_with(msg, "User information is missing.")
+    fakes.user_repo.register_user.assert_not_called()
 
 
 def test_handle_info(message_factory, mocker):
     """Test /info command."""
     msg = message_factory(content_type="text", text="/info")
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
 
-    handle_info(msg)
+    app.handle_info(msg)
 
-    assert str(msg.from_user.id) in mock_send.call_args[0][1]
+    assert str(msg.from_user.id) in fakes.bot.send_message.call_args[0][1]
 
 
 def test_handle_info_missing_user(message_factory, mocker):
     """Test /info rejects messages without Telegram user metadata."""
     msg = message_factory(content_type="text", text="/info")
     msg.from_user = None
-    mock_reply = mocker.patch("main.bot.reply_to")
+    app, fakes = _make_app(mocker)
 
-    handle_info(msg)
+    app.handle_info(msg)
 
-    mock_reply.assert_called_once_with(msg, "User information is missing.")
+    fakes.bot.reply_to.assert_called_once_with(msg, "User information is missing.")
 
 
 def test_handle_myinfo(message_factory, mocker):
     """Test /myinfo command."""
     msg = message_factory(content_type="text", text="/myinfo")
+    app, fakes = _make_app(mocker)
     mock_user = UsersOrm(
         user_id=123,
         approved=True,
@@ -86,13 +95,12 @@ def test_handle_myinfo(message_factory, mocker):
         daily_limit=10,
         thinking_level="MINIMAL",
     )
-    mocker.patch("main.select_user", return_value=mock_user)
-    mocker.patch("main.get_remaining_quota", return_value=7)
-    mock_send = mocker.patch("main.bot.send_message")
+    fakes.user_repo.select_user.return_value = mock_user
+    fakes.quota_manager.get_remaining_quota.return_value = 7
 
-    handle_myinfo(msg)
+    app.handle_myinfo(msg)
 
-    content = mock_send.call_args[0][1]
+    content = fakes.bot.send_message.call_args[0][1]
     assert "Approved: True" in content
     assert "Target language: English" in content
     assert "Daily limit: 10" in content
@@ -108,132 +116,144 @@ def test_handle_myinfo_missing_user(message_factory, mocker):
     """Test /myinfo rejects messages without Telegram user metadata."""
     msg = message_factory(content_type="text", text="/myinfo")
     msg.from_user = None
-    mock_reply = mocker.patch("main.bot.reply_to")
+    app, fakes = _make_app(mocker)
 
-    handle_myinfo(msg)
+    app.handle_myinfo(msg)
 
-    mock_reply.assert_called_once_with(msg, "User information is missing.")
+    fakes.bot.reply_to.assert_called_once_with(msg, "User information is missing.")
 
 
 @pytest.mark.parametrize(
-    ("handler", "expected_text", "expected_next_step"),
+    ("handler_name", "expected_text", "expected_next_step_name"),
     [
         (
-            handle_set_target_language,
+            "handle_set_target_language",
             "Select target language",
-            proceed_set_target_language,
+            "proceed_set_target_language",
         ),
         (
-            handle_set_summarizing_model,
+            "handle_set_summarizing_model",
             "Select summarizing model",
-            proceed_set_summarizing_model,
+            "proceed_set_summarizing_model",
         ),
         (
-            handle_set_prompt_strategy,
+            "handle_set_prompt_strategy",
             "Select summarization strategy",
-            proceed_set_prompt_strategy,
+            "proceed_set_prompt_strategy",
         ),
         (
-            handle_set_thinking_level,
+            "handle_set_thinking_level",
             "Select thinking level",
-            proceed_set_thinking_level,
+            "proceed_set_thinking_level",
         ),
     ],
 )
 def test_handle_set_setting_shows_keyboard(
     message_factory,
     mocker,
-    handler,
+    handler_name,
     expected_text,
-    expected_next_step,
+    expected_next_step_name,
 ):
     """Test each /set_* command shows its selection keyboard."""
     msg = message_factory(content_type="text")
-    mock_send = mocker.patch("main.bot.send_message")
-    mock_register = mocker.patch("main.bot.register_next_step_handler")
+    app, fakes = _make_app(mocker)
 
-    handler(msg)
+    getattr(app, handler_name)(msg)
 
-    assert expected_text in mock_send.call_args[0][1]
-    mock_register.assert_called_once_with(msg, expected_next_step)
+    assert expected_text in fakes.bot.send_message.call_args[0][1]
+    fakes.bot.register_next_step_handler.assert_called_once_with(
+        msg,
+        getattr(app, expected_next_step_name),
+    )
 
 
 def test_proceed_set_target_language_success(message_factory, mocker):
     """Test successful language selection."""
     msg = message_factory(content_type="text", text="Russian")
-    mocker.patch("main.set_target_language", return_value=True)
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.set_target_language.return_value = True
 
-    proceed_set_target_language(msg)
+    app.proceed_set_target_language(msg)
 
-    assert "The target language is set to Russian" in mock_send.call_args[0][1]
+    assert (
+        "The target language is set to Russian"
+        in fakes.bot.send_message.call_args[0][1]
+    )
 
 
 def test_proceed_set_summarizing_model_success(message_factory, mocker):
     """Test successful model selection."""
     msg = message_factory(content_type="text", text="Gemini 3.5 Flash")
-    mock_set_model = mocker.patch("main.set_summarizing_model", return_value=True)
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.set_summarizing_model.return_value = True
 
-    proceed_set_summarizing_model(msg)
+    app.proceed_set_summarizing_model(msg)
 
-    mock_set_model.assert_called_once_with(msg.from_user.id, "gemini-3.5-flash")
+    fakes.user_repo.set_summarizing_model.assert_called_once_with(
+        msg.from_user.id,
+        "gemini-3.5-flash",
+    )
     assert (
-        "The summarizing model is set to Gemini 3.5 Flash" in mock_send.call_args[0][1]
+        "The summarizing model is set to Gemini 3.5 Flash"
+        in fakes.bot.send_message.call_args[0][1]
     )
 
 
 def test_proceed_set_prompt_strategy_success(message_factory, mocker):
     """Test successful strategy selection."""
     msg = message_factory(content_type="text", text="Detailed Summary")
-    mock_set_strategy = mocker.patch("main.set_prompt_strategy", return_value=True)
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.set_prompt_strategy.return_value = True
 
-    proceed_set_prompt_strategy(msg)
+    app.proceed_set_prompt_strategy(msg)
 
-    mock_set_strategy.assert_called_once_with(
+    fakes.user_repo.set_prompt_strategy.assert_called_once_with(
         msg.from_user.id,
         "basic_prompt_for_transcript",
     )
-    assert "The prompt strategy is set to Detailed Summary" in mock_send.call_args[0][1]
+    assert (
+        "The prompt strategy is set to Detailed Summary"
+        in fakes.bot.send_message.call_args[0][1]
+    )
 
 
 def test_proceed_set_thinking_level_success(message_factory, mocker):
     """Test successful thinking level selection."""
     msg = message_factory(content_type="text", text="High")
-    mock_set = mocker.patch("main.set_thinking_level", return_value=True)
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.set_thinking_level.return_value = True
 
-    proceed_set_thinking_level(msg)
+    app.proceed_set_thinking_level(msg)
 
-    mock_set.assert_called_once_with(msg.from_user.id, "HIGH")
-    assert "The thinking level is set to High" in mock_send.call_args[0][1]
+    fakes.user_repo.set_thinking_level.assert_called_once_with(msg.from_user.id, "HIGH")
+    assert "The thinking level is set to High" in fakes.bot.send_message.call_args[0][1]
 
 
 @pytest.mark.parametrize(
-    ("proceed", "setter_path", "null_attr", "error_msg"),
+    ("proceed_name", "setter_name", "null_attr", "error_msg"),
     [
         (
-            proceed_set_target_language,
-            "main.set_target_language",
+            "proceed_set_target_language",
+            "set_target_language",
             "text",
             "User information or language is missing.",
         ),
         (
-            proceed_set_summarizing_model,
-            "main.set_summarizing_model",
+            "proceed_set_summarizing_model",
+            "set_summarizing_model",
             "from_user",
             "User information or model is missing.",
         ),
         (
-            proceed_set_prompt_strategy,
-            "main.set_prompt_strategy",
+            "proceed_set_prompt_strategy",
+            "set_prompt_strategy",
             "text",
             "User information or strategy is missing.",
         ),
         (
-            proceed_set_thinking_level,
-            "main.set_thinking_level",
+            "proceed_set_thinking_level",
+            "set_thinking_level",
             "text",
             "User information or level is missing.",
         ),
@@ -242,41 +262,40 @@ def test_proceed_set_thinking_level_success(message_factory, mocker):
 def test_proceed_set_setting_missing_input(
     message_factory,
     mocker,
-    proceed,
-    setter_path,
+    proceed_name,
+    setter_name,
     null_attr,
     error_msg,
 ):
     """Test each setting selection fails fast when user or text is missing."""
     msg = message_factory(content_type="text", text="Anything")
     setattr(msg, null_attr, None)
-    mock_reply = mocker.patch("main.bot.reply_to")
-    mock_setter = mocker.patch(setter_path)
+    app, fakes = _make_app(mocker)
 
-    proceed(msg)
+    getattr(app, proceed_name)(msg)
 
-    mock_reply.assert_called_once_with(msg, error_msg)
-    mock_setter.assert_not_called()
+    fakes.bot.reply_to.assert_called_once_with(msg, error_msg)
+    getattr(fakes.user_repo, setter_name).assert_not_called()
 
 
 @pytest.mark.parametrize(
-    ("proceed", "setter_path", "bad_text", "error_msg"),
+    ("proceed_name", "setter_name", "bad_text", "error_msg"),
     [
         (
-            proceed_set_summarizing_model,
-            "main.set_summarizing_model",
+            "proceed_set_summarizing_model",
+            "set_summarizing_model",
             "Gemini 4 Pro",
             "Unknown model",
         ),
         (
-            proceed_set_prompt_strategy,
-            "main.set_prompt_strategy",
+            "proceed_set_prompt_strategy",
+            "set_prompt_strategy",
             "enterprise",
             "Unknown strategy",
         ),
         (
-            proceed_set_thinking_level,
-            "main.set_thinking_level",
+            "proceed_set_thinking_level",
+            "set_thinking_level",
             "Ludicrous",
             "Unknown level",
         ),
@@ -285,51 +304,50 @@ def test_proceed_set_setting_missing_input(
 def test_proceed_set_setting_invalid_choice(
     message_factory,
     mocker,
-    proceed,
-    setter_path,
+    proceed_name,
+    setter_name,
     bad_text,
     error_msg,
 ):
     """Test an invalid label short-circuits before calling the setter."""
     msg = message_factory(content_type="text", text=bad_text)
-    mock_setter = mocker.patch(setter_path)
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
 
-    proceed(msg)
+    getattr(app, proceed_name)(msg)
 
-    mock_send.assert_called_once_with(msg.chat.id, error_msg)
-    mock_setter.assert_not_called()
+    fakes.bot.send_message.assert_called_once_with(msg.chat.id, error_msg)
+    getattr(fakes.user_repo, setter_name).assert_not_called()
 
 
 def test_proceed_set_target_language_invalid_choice(message_factory, mocker):
     """Test an unknown language is rejected via the setter returning False."""
     msg = message_factory(content_type="text", text="Klingon")
-    mocker.patch("main.set_target_language", return_value=False)
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.set_target_language.return_value = False
 
-    proceed_set_target_language(msg)
+    app.proceed_set_target_language(msg)
 
-    mock_send.assert_called_once_with(msg.chat.id, "Unknown language")
+    fakes.bot.send_message.assert_called_once_with(msg.chat.id, "Unknown language")
 
 
 @pytest.mark.parametrize(
-    ("proceed", "setter_path", "valid_text", "error_msg"),
+    ("proceed_name", "setter_name", "valid_text", "error_msg"),
     [
         (
-            proceed_set_summarizing_model,
-            "main.set_summarizing_model",
+            "proceed_set_summarizing_model",
+            "set_summarizing_model",
             "Gemini 3.5 Flash",
             "Failed to update summarizing model.",
         ),
         (
-            proceed_set_prompt_strategy,
-            "main.set_prompt_strategy",
+            "proceed_set_prompt_strategy",
+            "set_prompt_strategy",
             "Detailed Summary",
             "Failed to update prompt strategy.",
         ),
         (
-            proceed_set_thinking_level,
-            "main.set_thinking_level",
+            "proceed_set_thinking_level",
+            "set_thinking_level",
             "High",
             "Failed to update thinking level.",
         ),
@@ -338,16 +356,16 @@ def test_proceed_set_target_language_invalid_choice(message_factory, mocker):
 def test_proceed_set_setting_db_failure(
     message_factory,
     mocker,
-    proceed,
-    setter_path,
+    proceed_name,
+    setter_name,
     valid_text,
     error_msg,
 ):
     """Test a DB failure returns a clear user-facing message, not success."""
     msg = message_factory(content_type="text", text=valid_text)
-    mocker.patch(setter_path, return_value=False)
-    mock_send = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
+    getattr(fakes.user_repo, setter_name).return_value = False
 
-    proceed(msg)
+    getattr(app, proceed_name)(msg)
 
-    mock_send.assert_called_once_with(msg.chat.id, error_msg)
+    fakes.bot.send_message.assert_called_once_with(msg.chat.id, error_msg)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,7 @@
 import config
+import database
 from container import Container, build_container
+from database import UserRepository
 from download import Downloader
 from handlers import MessageHandlers
 from llm import LLMClient
@@ -19,6 +21,7 @@ def test_build_container_returns_wired_container():
     assert isinstance(container.quota_manager, QuotaManager)
     assert isinstance(container.gemini_helper, GeminiHelper)
     assert isinstance(container.tracer, Tracer)
+    assert isinstance(container.user_repo, UserRepository)
     assert isinstance(container.llm_client, LLMClient)
     assert isinstance(container.downloader, Downloader)
     assert isinstance(container.web_parser, WebParser)
@@ -32,6 +35,7 @@ def test_build_container_returns_wired_container():
     assert container.quota_manager._per_minute_rate is config.per_minute_rate
     assert container.gemini_helper._client is config.gemini_client
     assert container.tracer._client is config.langfuse_client
+    assert container.user_repo._session_factory is database.Session
     assert container.llm_client._client is config.gemini_client
     assert container.downloader._tg_api_token is config.TG_API_TOKEN
     assert container.web_parser._primary._client is config.exa_client

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,6 @@
 import config
 from container import Container, build_container
+from download import Downloader
 from llm import LLMClient
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
 
@@ -14,6 +15,7 @@ def test_build_container_returns_wired_container():
     assert isinstance(container.gemini_helper, GeminiHelper)
     assert isinstance(container.tracer, Tracer)
     assert isinstance(container.llm_client, LLMClient)
+    assert isinstance(container.downloader, Downloader)
 
     assert container.messenger._bot is config.bot
     assert container.quota_manager._rate_limiter is config.rate_limiter
@@ -21,3 +23,4 @@ def test_build_container_returns_wired_container():
     assert container.gemini_helper._client is config.gemini_client
     assert container.tracer._client is config.langfuse_client
     assert container.llm_client._client is config.gemini_client
+    assert container.downloader._tg_api_token is config.TG_API_TOKEN

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -2,6 +2,7 @@ import config
 from container import Container, build_container
 from download import Downloader
 from llm import LLMClient
+from parsing import WebParser
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
 
 
@@ -16,6 +17,7 @@ def test_build_container_returns_wired_container():
     assert isinstance(container.tracer, Tracer)
     assert isinstance(container.llm_client, LLMClient)
     assert isinstance(container.downloader, Downloader)
+    assert isinstance(container.web_parser, WebParser)
 
     assert container.messenger._bot is config.bot
     assert container.quota_manager._rate_limiter is config.rate_limiter
@@ -24,3 +26,5 @@ def test_build_container_returns_wired_container():
     assert container.tracer._client is config.langfuse_client
     assert container.llm_client._client is config.gemini_client
     assert container.downloader._tg_api_token is config.TG_API_TOKEN
+    assert container.web_parser._primary._client is config.exa_client
+    assert container.web_parser._fallback._client is config.tavily_client

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -4,6 +4,7 @@ from download import Downloader
 from llm import LLMClient
 from parsing import WebParser
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
+from summary import Summarizer
 from transcription import ApiBackend, AudioTranscriber, YouTubeTranscriber, YtDlpBackend
 
 
@@ -21,6 +22,7 @@ def test_build_container_returns_wired_container():
     assert isinstance(container.web_parser, WebParser)
     assert isinstance(container.audio_transcriber, AudioTranscriber)
     assert isinstance(container.yt_transcriber, YouTubeTranscriber)
+    assert isinstance(container.summarizer, Summarizer)
 
     assert container.messenger._bot is config.bot
     assert container.quota_manager._rate_limiter is config.rate_limiter
@@ -34,3 +36,12 @@ def test_build_container_returns_wired_container():
     assert container.audio_transcriber._client is config.replicate_client
     assert isinstance(container.yt_transcriber._primary, ApiBackend)
     assert isinstance(container.yt_transcriber._fallback, YtDlpBackend)
+
+    # The summarizer's collaborators must be the container's own instances,
+    # not freshly constructed duplicates, so the object graph is genuinely one.
+    assert container.summarizer._quota_manager is container.quota_manager
+    assert container.summarizer._gemini_helper is container.gemini_helper
+    assert container.summarizer._llm_client is container.llm_client
+    assert container.summarizer._downloader is container.downloader
+    assert container.summarizer._audio_transcriber is container.audio_transcriber
+    assert container.summarizer._yt_transcriber is container.yt_transcriber

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -14,6 +14,7 @@ def test_build_container_returns_wired_container():
     container = build_container()
 
     assert isinstance(container, Container)
+    assert container.bot is config.bot
     assert isinstance(container.messenger, Messenger)
     assert isinstance(container.quota_manager, QuotaManager)
     assert isinstance(container.gemini_helper, GeminiHelper)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -4,6 +4,7 @@ from download import Downloader
 from llm import LLMClient
 from parsing import WebParser
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
+from transcription import ApiBackend, AudioTranscriber, YouTubeTranscriber, YtDlpBackend
 
 
 def test_build_container_returns_wired_container():
@@ -18,6 +19,8 @@ def test_build_container_returns_wired_container():
     assert isinstance(container.llm_client, LLMClient)
     assert isinstance(container.downloader, Downloader)
     assert isinstance(container.web_parser, WebParser)
+    assert isinstance(container.audio_transcriber, AudioTranscriber)
+    assert isinstance(container.yt_transcriber, YouTubeTranscriber)
 
     assert container.messenger._bot is config.bot
     assert container.quota_manager._rate_limiter is config.rate_limiter
@@ -28,3 +31,6 @@ def test_build_container_returns_wired_container():
     assert container.downloader._tg_api_token is config.TG_API_TOKEN
     assert container.web_parser._primary._client is config.exa_client
     assert container.web_parser._fallback._client is config.tavily_client
+    assert container.audio_transcriber._client is config.replicate_client
+    assert isinstance(container.yt_transcriber._primary, ApiBackend)
+    assert isinstance(container.yt_transcriber._fallback, YtDlpBackend)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,6 +1,7 @@
 import config
 from container import Container, build_container
 from download import Downloader
+from handlers import MessageHandlers
 from llm import LLMClient
 from parsing import WebParser
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
@@ -23,6 +24,7 @@ def test_build_container_returns_wired_container():
     assert isinstance(container.audio_transcriber, AudioTranscriber)
     assert isinstance(container.yt_transcriber, YouTubeTranscriber)
     assert isinstance(container.summarizer, Summarizer)
+    assert isinstance(container.handlers, MessageHandlers)
 
     assert container.messenger._bot is config.bot
     assert container.quota_manager._rate_limiter is config.rate_limiter
@@ -45,3 +47,11 @@ def test_build_container_returns_wired_container():
     assert container.summarizer._downloader is container.downloader
     assert container.summarizer._audio_transcriber is container.audio_transcriber
     assert container.summarizer._yt_transcriber is container.yt_transcriber
+
+    # The handlers' collaborators must be the container's own instances too.
+    assert container.handlers._bot is config.bot
+    assert container.handlers._messenger is container.messenger
+    assert container.handlers._summarizer is container.summarizer
+    assert container.handlers._web_parser is container.web_parser
+    assert container.handlers._quota_manager is container.quota_manager
+    assert container.handlers._downloader is container.downloader

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,6 @@
 import config
 from container import Container, build_container
+from llm import LLMClient
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
 
 
@@ -12,9 +13,11 @@ def test_build_container_returns_wired_container():
     assert isinstance(container.quota_manager, QuotaManager)
     assert isinstance(container.gemini_helper, GeminiHelper)
     assert isinstance(container.tracer, Tracer)
+    assert isinstance(container.llm_client, LLMClient)
 
     assert container.messenger._bot is config.bot
     assert container.quota_manager._rate_limiter is config.rate_limiter
     assert container.quota_manager._per_minute_rate is config.per_minute_rate
     assert container.gemini_helper._client is config.gemini_client
     assert container.tracer._client is config.langfuse_client
+    assert container.llm_client._client is config.gemini_client

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,20 @@
+import config
+from container import Container, build_container
+from services import GeminiHelper, Messenger, QuotaManager, Tracer
+
+
+def test_build_container_returns_wired_container():
+    """build_container wires each collaborator to config's actual clients."""
+    container = build_container()
+
+    assert isinstance(container, Container)
+    assert isinstance(container.messenger, Messenger)
+    assert isinstance(container.quota_manager, QuotaManager)
+    assert isinstance(container.gemini_helper, GeminiHelper)
+    assert isinstance(container.tracer, Tracer)
+
+    assert container.messenger._bot is config.bot
+    assert container.quota_manager._rate_limiter is config.rate_limiter
+    assert container.quota_manager._per_minute_rate is config.per_minute_rate
+    assert container.gemini_helper._client is config.gemini_client
+    assert container.tracer._client is config.langfuse_client

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,5 @@
 import pytest
 from sqlalchemy import create_engine
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from config import (
@@ -9,15 +8,7 @@ from config import (
     DEFAULT_PROMPT_KEY,
     DEFAULT_THINKING_LEVEL,
 )
-from database import (
-    check_auth,
-    register_user,
-    select_user,
-    set_prompt_strategy,
-    set_summarizing_model,
-    set_target_language,
-    set_thinking_level,
-)
+from database import UserRepository
 from models import Base, UsersOrm
 
 
@@ -31,20 +22,25 @@ def sqlite_session_factory(tmp_path):
     engine.dispose()
 
 
-def test_register_user_success(mock_db_session):
+@pytest.fixture
+def user_repo(sqlite_session_factory):
+    """Provide a UserRepository backed by the isolated SQLite session factory."""
+    return UserRepository(sqlite_session_factory)
+
+
+def test_register_user_success(user_repo, sqlite_session_factory):
     """Test registering a new user successfully."""
-    result = register_user(123, "First", "Last", "user")
+    result = user_repo.register_user(123, "First", "Last", "user")
 
     assert result is True
-    assert mock_db_session.add.called
-    assert mock_db_session.commit.called
+    with sqlite_session_factory() as session:
+        user = session.get(UsersOrm, 123)
+        assert user is not None
 
 
-def test_register_user_stores_defaults(monkeypatch, sqlite_session_factory):
+def test_register_user_stores_defaults(user_repo, sqlite_session_factory):
     """Test register_user stores the configured defaults when nothing is overridden."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-
-    assert register_user(123, "First", "Last", "user") is True
+    assert user_repo.register_user(123, "First", "Last", "user") is True
     with sqlite_session_factory() as session:
         user = session.get(UsersOrm, 123)
         assert user is not None
@@ -66,70 +62,69 @@ def test_orm_server_defaults_match_config(column, expected):
     assert UsersOrm.__table__.c[column].server_default.arg == expected
 
 
-def test_register_user_duplicate(mock_db_session):
-    """Test register_user returns False when user already exists (IntegrityError)."""
-    mock_db_session.commit.side_effect = IntegrityError("msg", "params", "orig")
+def test_register_user_duplicate(mocker, user_repo, sqlite_session_factory):
+    """Test register_user returns False when user already exists (IntegrityError).
 
-    result = register_user(123, "First", "Last", "user")
+    Registering the same user_id twice raises a real IntegrityError from SQLite's
+    primary-key constraint. The rollback is spied on the Session class, not an
+    instance: the repository opens its own session, so there is none to spy on first.
+    """
+    assert user_repo.register_user(123, "First", "Last", "user") is True
+    rollback_spy = mocker.spy(sqlite_session_factory.class_, "rollback")
+
+    result = user_repo.register_user(123, "First", "Last", "user")
 
     assert result is False
-    assert mock_db_session.rollback.called
+    assert rollback_spy.called
 
 
-def test_select_user_missing(mock_db_session):
+def test_select_user_missing(user_repo):
     """Test select_user raises a clear error for unknown users."""
-    mock_db_session.get.return_value = None
-
     with pytest.raises(ValueError, match="User not found"):
-        select_user(999)
+        user_repo.select_user(999)
 
 
-def test_check_auth_approved_user(mock_db_session):
+def test_check_auth_approved_user(user_repo):
     """Test that an approved user returns True."""
-    mock_db_session.get.return_value = UsersOrm(user_id=123, approved=True)
+    user_repo.register_user(123, "First", "Last", "user", approved=True)
 
-    assert check_auth(123) is True
-    mock_db_session.get.assert_called_once_with(UsersOrm, 123)
+    assert user_repo.check_auth(123) is True
 
 
-def test_check_auth_unapproved_user(mock_db_session):
+def test_check_auth_unapproved_user(user_repo):
     """Test that an unapproved user returns False."""
-    mock_db_session.get.return_value = UsersOrm(user_id=123, approved=False)
+    user_repo.register_user(123, "First", "Last", "user", approved=False)
 
-    assert check_auth(123) is False
-    mock_db_session.get.assert_called_once_with(UsersOrm, 123)
+    assert user_repo.check_auth(123) is False
 
 
-def test_check_auth_unknown_user(mock_db_session):
+def test_check_auth_unknown_user(user_repo):
     """Test that an unknown user ID raises ValueError."""
-    mock_db_session.get.return_value = None
-
     with pytest.raises(ValueError, match="User not found"):
-        check_auth(999)
-    mock_db_session.get.assert_called_once_with(UsersOrm, 999)
+        user_repo.check_auth(999)
 
 
 @pytest.mark.parametrize(
     ("setter", "value", "orm_attr", "stored_value"),
     [
-        (set_target_language, "English", "target_language", "English"),
+        ("set_target_language", "English", "target_language", "English"),
         (
-            set_summarizing_model,
+            "set_summarizing_model",
             "gemini-3.5-flash",
             "summarizing_model",
             "gemini-3.5-flash",
         ),
         (
-            set_prompt_strategy,
+            "set_prompt_strategy",
             "basic_prompt_for_transcript",
             "prompt_key_for_summary",
             "basic_prompt_for_transcript",
         ),
-        (set_thinking_level, "high", "thinking_level", "HIGH"),
+        ("set_thinking_level", "high", "thinking_level", "HIGH"),
     ],
 )
 def test_set_setting_persists(
-    monkeypatch,
+    user_repo,
     sqlite_session_factory,
     setter,
     value,
@@ -137,10 +132,9 @@ def test_set_setting_persists(
     stored_value,
 ):
     """Test each setting setter persists to a real SQLite database."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-    register_user(123, "First", "Last", "user")
+    user_repo.register_user(123, "First", "Last", "user")
 
-    result = setter(123, value)
+    result = getattr(user_repo, setter)(123, value)
 
     assert result is True
     with sqlite_session_factory() as session:
@@ -152,36 +146,30 @@ def test_set_setting_persists(
 @pytest.mark.parametrize(
     ("setter", "bad_value"),
     [
-        (set_target_language, "Klingon"),
-        (set_summarizing_model, "gpt-4"),
-        (set_prompt_strategy, "bogus"),
+        ("set_target_language", "Klingon"),
+        ("set_summarizing_model", "gpt-4"),
+        ("set_prompt_strategy", "bogus"),
     ],
 )
-def test_set_setting_rejects_unsupported(
-    monkeypatch,
-    sqlite_session_factory,
-    setter,
-    bad_value,
-):
+def test_set_setting_rejects_unsupported(user_repo, setter, bad_value):
     """Test each setting setter returns False for unsupported values."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-    register_user(123, "First", "Last", "user")
+    user_repo.register_user(123, "First", "Last", "user")
 
-    assert setter(123, bad_value) is False
+    assert getattr(user_repo, setter)(123, bad_value) is False
 
 
 @pytest.mark.parametrize(
     ("setter", "value", "orm_attr", "stored_value"),
     [
-        (set_target_language, "english", "target_language", "English"),
+        ("set_target_language", "english", "target_language", "English"),
         (
-            set_summarizing_model,
+            "set_summarizing_model",
             "GEMINI-3.5-FLASH",
             "summarizing_model",
             "gemini-3.5-flash",
         ),
         (
-            set_prompt_strategy,
+            "set_prompt_strategy",
             "Key_Points_For_Transcript",
             "prompt_key_for_summary",
             "key_points_for_transcript",
@@ -189,7 +177,7 @@ def test_set_setting_rejects_unsupported(
     ],
 )
 def test_set_setting_stores_normalized_value(
-    monkeypatch,
+    user_repo,
     sqlite_session_factory,
     setter,
     value,
@@ -202,27 +190,25 @@ def test_set_setting_stores_normalized_value(
     raw input would let a non-canonical value through: PROMPTS[...] would raise
     KeyError and a mis-cased model id would be rejected by the Gemini API.
     """
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-    register_user(123, "First", "Last", "user")
+    user_repo.register_user(123, "First", "Last", "user")
 
-    assert setter(123, value) is True
+    assert getattr(user_repo, setter)(123, value) is True
     with sqlite_session_factory() as session:
         user = session.get(UsersOrm, 123)
         assert user is not None
         assert getattr(user, orm_attr) == stored_value
 
 
-def test_set_thinking_level_rejects_unknown_value(monkeypatch, sqlite_session_factory):
+def test_set_thinking_level_rejects_unknown_value(user_repo, sqlite_session_factory):
     """Test set_thinking_level returns False and leaves the stored level unchanged."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-    register_user(123, "First", "Last", "user")
+    user_repo.register_user(123, "First", "Last", "user")
     # Move off the default first, so a rejected value cannot be mistaken for it.
     other_level = next(
         level for level in ALLOWED_THINKING_LEVELS if level != DEFAULT_THINKING_LEVEL
     )
-    assert set_thinking_level(123, other_level) is True
+    assert user_repo.set_thinking_level(123, other_level) is True
 
-    assert set_thinking_level(123, "bogus") is False
+    assert user_repo.set_thinking_level(123, "bogus") is False
     with sqlite_session_factory() as session:
         user = session.get(UsersOrm, 123)
         assert user is not None
@@ -232,14 +218,12 @@ def test_set_thinking_level_rejects_unknown_value(monkeypatch, sqlite_session_fa
 @pytest.mark.parametrize(
     ("setter", "value"),
     [
-        (set_target_language, "English"),
-        (set_summarizing_model, "gemini-3.5-flash"),
-        (set_prompt_strategy, "key_points_for_transcript"),
-        (set_thinking_level, "HIGH"),
+        ("set_target_language", "English"),
+        ("set_summarizing_model", "gemini-3.5-flash"),
+        ("set_prompt_strategy", "key_points_for_transcript"),
+        ("set_thinking_level", "HIGH"),
     ],
 )
-def test_set_setting_missing_user(monkeypatch, sqlite_session_factory, setter, value):
+def test_set_setting_missing_user(user_repo, setter, value):
     """Test each setting setter returns False when the user does not exist."""
-    monkeypatch.setattr("database.Session", sqlite_session_factory)
-
-    assert setter(999, value) is False
+    assert getattr(user_repo, setter)(999, value) is False

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -5,19 +5,21 @@ from curl_cffi.requests.exceptions import HTTPError
 from tenacity import RetryError
 from yt_dlp.utils import DownloadError
 
-from download import Downloader, download_castro, download_tg, download_yt
+from download import Downloader
 
 
-def test_download_tg_happy_path(mocker):
+@pytest.fixture
+def downloader():
+    """Downloader instance wired to a fixed test token."""
+    return Downloader("TEST_TOKEN")
+
+
+def test_download_tg_happy_path(mocker, downloader):
     """Test downloading a file from Telegram successfully."""
-    mocker.patch("download.TG_API_TOKEN", "TEST_TOKEN")
     mock_resp = mocker.MagicMock()
     mock_resp.iter_content.return_value = [b"test ", b"content"]
     mock_resp.status_code = 200
     mock_get = mocker.patch("download.requests.get", return_value=mock_resp)
-
-    # Mock generate_temporary_name to return a fixed name
-    mocker.patch("download.generate_temporary_name", return_value="temp_file.ext")
 
     mock_file = mocker.MagicMock()
     mock_file.file_path = "path/to/file"
@@ -25,9 +27,9 @@ def test_download_tg_happy_path(mocker):
     # We need to mock Path.open to avoid actual file system writes
     mock_path_open = mocker.patch("pathlib.Path.open", mocker.mock_open())
 
-    result = download_tg(mock_file, ext=".ext")
+    result = downloader.download_tg(mock_file, ext=".ext")
 
-    assert result == "temp_file.ext"
+    assert result.endswith(".ext")
     mock_get.assert_called_once_with(
         "https://api.telegram.org/file/botTEST_TOKEN/path/to/file",
         stream=True,
@@ -48,41 +50,38 @@ def test_download_tg_happy_path(mocker):
     assert mock_path_open().write.call_count == 2
 
 
-def test_download_tg_skips_empty_chunks(mocker):
+def test_download_tg_skips_empty_chunks(mocker, downloader):
     """Test download_tg skips empty chunks from iter_content."""
-    mocker.patch("download.TG_API_TOKEN", "TEST_TOKEN")
     mock_resp = mocker.MagicMock()
     mock_resp.iter_content.return_value = [b"", b"data", b""]
     mock_resp.status_code = 200
     mocker.patch("download.requests.get", return_value=mock_resp)
-    mocker.patch("download.generate_temporary_name", return_value="temp_file.ext")
 
     mock_file = mocker.MagicMock()
     mock_file.file_path = "path/to/file"
 
     mock_path_open = mocker.patch("pathlib.Path.open", mocker.mock_open())
 
-    result = download_tg(mock_file, ext=".ext")
+    result = downloader.download_tg(mock_file, ext=".ext")
 
-    assert result == "temp_file.ext"
+    assert result.endswith(".ext")
     mock_resp.iter_content.assert_called_once_with(chunk_size=8192)
     mock_path_open().write.assert_has_calls([mocker.call(b"data")])
     assert mock_path_open().write.call_count == 1
 
 
-def test_download_tg_missing_file_path(mocker):
+def test_download_tg_missing_file_path(mocker, downloader):
     """Test download_tg raises ValueError when file_path is missing."""
     mock_file = mocker.MagicMock()
     mock_file.file_path = None
 
     with pytest.raises(ValueError, match=r"Telegram file path is missing\."):
-        download_tg(mock_file)
+        downloader.download_tg(mock_file)
 
 
-def test_download_yt_happy_path(mocker):
+def test_download_yt_happy_path(mocker, downloader):
     """Test downloading a YouTube audio successfully."""
     mock_ydl = mocker.patch("download.YoutubeDL")
-    mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
 
     info_ydl = mocker.MagicMock()
     info_ydl.extract_info.return_value = {
@@ -109,9 +108,10 @@ def test_download_yt_happy_path(mocker):
         mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
     ]
 
-    result = download_yt("https://youtube.com/watch?v=123")
+    result = downloader.download_yt("https://youtube.com/watch?v=123")
 
-    assert result == "temp_yt.mp3"
+    assert result.endswith(".mp3")
+    output_stem = result.split(".", maxsplit=1)[0]
     info_ydl.extract_info.assert_called_once_with(
         "https://youtube.com/watch?v=123",
         download=False,
@@ -120,7 +120,7 @@ def test_download_yt_happy_path(mocker):
     mock_ydl.assert_any_call(
         {
             "format": "139",
-            "outtmpl": "temp_yt",
+            "outtmpl": output_stem,
             "nocheckcertificate": False,
             "proxy": mocker.ANY,
             "postprocessors": [
@@ -134,10 +134,9 @@ def test_download_yt_happy_path(mocker):
     download_ydl.download.assert_called_once_with("https://youtube.com/watch?v=123")
 
 
-def test_download_yt_extract_info_returns_none(mocker):
+def test_download_yt_extract_info_returns_none(mocker, downloader):
     """Test download_yt raises RetryError when extract_info returns None."""
     mock_ydl = mocker.patch("download.YoutubeDL")
-    mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
     mocker.patch("time.sleep")  # suppress tenacity wait between retries
 
     info_ydl = mocker.MagicMock()
@@ -145,12 +144,14 @@ def test_download_yt_extract_info_returns_none(mocker):
     mock_ydl.return_value.__enter__.return_value = info_ydl
 
     with pytest.raises(RetryError):
-        download_yt("https://youtube.com/watch?v=123")
+        downloader.download_yt("https://youtube.com/watch?v=123")
 
 
-def test_download_yt_removes_partials_on_download_error(mocker):
+def test_download_yt_removes_partials_on_download_error(mocker, downloader):
     """Test download_yt deletes yt-dlp partial files when the download fails."""
     mock_ydl = mocker.patch("download.YoutubeDL")
+    # Fixed name kept: the glob assertion below checks the exact pattern built
+    # from the output stem, which must be known ahead of the call.
     mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
     mocker.patch("time.sleep")  # suppress tenacity wait between retries
 
@@ -181,15 +182,16 @@ def test_download_yt_removes_partials_on_download_error(mocker):
     mock_cwd.return_value.glob.return_value = [partial]
 
     with pytest.raises(RetryError):
-        download_yt("https://youtube.com/watch?v=123")
+        downloader.download_yt("https://youtube.com/watch?v=123")
 
     mock_cwd.return_value.glob.assert_called_with("temp_yt*")
     partial.unlink.assert_called_with(missing_ok=True)
 
 
-def test_download_yt_unlink_oserror_does_not_hide_download_error(mocker):
+def test_download_yt_unlink_oserror_does_not_hide_download_error(mocker, downloader):
     """Test that an OSError from unlink is suppressed and DownloadError still propagates."""
     mock_ydl = mocker.patch("download.YoutubeDL")
+    # Fixed name kept: matches the pre-created partial file's expected stem.
     mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
     mocker.patch("time.sleep")
 
@@ -221,13 +223,12 @@ def test_download_yt_unlink_oserror_does_not_hide_download_error(mocker):
 
     # PermissionError from unlink must not surface; RetryError wraps DownloadError.
     with pytest.raises(RetryError):
-        download_yt("https://youtube.com/watch?v=123")
+        downloader.download_yt("https://youtube.com/watch?v=123")
 
 
-def test_download_yt_keeps_file_on_success(mocker):
+def test_download_yt_keeps_file_on_success(mocker, downloader):
     """Test download_yt does not run partial cleanup on the happy path."""
     mock_ydl = mocker.patch("download.YoutubeDL")
-    mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
 
     info_ydl = mocker.MagicMock()
     info_ydl.extract_info.return_value = {
@@ -248,13 +249,13 @@ def test_download_yt_keeps_file_on_success(mocker):
     ]
     mock_cwd = mocker.patch("download.Path.cwd")
 
-    result = download_yt("https://youtube.com/watch?v=123")
+    result = downloader.download_yt("https://youtube.com/watch?v=123")
 
-    assert result == "temp_yt.mp3"
+    assert result.endswith(".mp3")
     mock_cwd.return_value.glob.assert_not_called()
 
 
-def test_choose_yt_audio_format_falls_back_when_no_audio_only_formats():
+def test_choose_yt_audio_format_falls_back_when_no_audio_only_formats(downloader):
     """Test selector fallback when yt-dlp has no audio-only format ids."""
     info = {
         "formats": [
@@ -268,12 +269,12 @@ def test_choose_yt_audio_format_falls_back_when_no_audio_only_formats():
         ],
     }
 
-    result = Downloader._choose_yt_audio_format(info)
+    result = downloader._choose_yt_audio_format(info)
 
     assert result == "bestaudio/worst[acodec!=none]"
 
 
-def test_choose_yt_audio_format_ranks_missing_bitrates_last():
+def test_choose_yt_audio_format_ranks_missing_bitrates_last(downloader):
     """Test choose_yt_audio_format keeps numeric 0 bitrates ahead of missing values."""
     info = {
         "formats": [
@@ -295,15 +296,13 @@ def test_choose_yt_audio_format_ranks_missing_bitrates_last():
         ],
     }
 
-    result = Downloader._choose_yt_audio_format(info)
+    result = downloader._choose_yt_audio_format(info)
 
     assert result == "zero"
 
 
-def test_download_castro_happy_path(mocker):
+def test_download_castro_happy_path(mocker, downloader):
     """Test downloading a Castro podcast successfully."""
-    mocker.patch("download.generate_temporary_name", return_value="temp_castro.mp3")
-
     # Mock requests.get for the page content
     mock_page_resp = mocker.MagicMock()
     mock_page_resp.content = b'<html><source src="https://audio.link/file.mp3"></html>'
@@ -320,9 +319,9 @@ def test_download_castro_happy_path(mocker):
     # Mock Path.open
     mock_path_open = mocker.patch("pathlib.Path.open", mocker.mock_open())
 
-    result = download_castro("https://castro.fm/episode/123")
+    result = downloader.download_castro("https://castro.fm/episode/123")
 
-    assert result == "temp_castro.mp3"
+    assert result.endswith(".mp3")
     mock_audio_resp.iter_content.assert_called_once_with(chunk_size=8192)
     mock_audio_resp.raise_for_status.assert_called_once()
     mock_path_open.assert_called_once_with("wb")
@@ -335,7 +334,7 @@ def test_download_castro_happy_path(mocker):
     assert mock_path_open().write.call_count == 2
 
 
-def test_download_castro_missing_source_tag(mocker):
+def test_download_castro_missing_source_tag(mocker, downloader):
     """Test download_castro raises ValueError when <source> tag is missing."""
     mock_page_resp = mocker.MagicMock()
     mock_page_resp.content = b"<html><body>No source here</body></html>"
@@ -346,10 +345,10 @@ def test_download_castro_missing_source_tag(mocker):
         ValueError,
         match=r"Audio source tag not found in Castro page\.",
     ):
-        download_castro("https://castro.fm/episode/123")
+        downloader.download_castro("https://castro.fm/episode/123")
 
 
-def test_download_castro_missing_audio_url(mocker):
+def test_download_castro_missing_audio_url(mocker, downloader):
     """Test download_castro raises ValueError when source tag has no src."""
     mock_page_resp = mocker.MagicMock()
     mock_page_resp.content = b"<html><source></html>"
@@ -357,10 +356,10 @@ def test_download_castro_missing_audio_url(mocker):
     mocker.patch("download.requote_uri", side_effect=lambda x: x)
 
     with pytest.raises(ValueError, match=r"Audio URL not found in Castro page\."):
-        download_castro("https://castro.fm/episode/123")
+        downloader.download_castro("https://castro.fm/episode/123")
 
 
-def test_download_castro_non_string_audio_url(mocker):
+def test_download_castro_non_string_audio_url(mocker, downloader):
     """Test download_castro raises TypeError when src attribute is a list."""
     mock_page_resp = mocker.MagicMock()
     mock_page_resp.content = b'<html><source src="a.mp3 b.mp3"></html>'
@@ -374,13 +373,11 @@ def test_download_castro_non_string_audio_url(mocker):
     mocker.patch("download.BeautifulSoup", return_value=mock_soup)
 
     with pytest.raises(TypeError, match=r"Audio URL is not a string\."):
-        download_castro("https://castro.fm/episode/123")
+        downloader.download_castro("https://castro.fm/episode/123")
 
 
-def test_download_castro_http_error(mocker):
+def test_download_castro_http_error(mocker, downloader):
     """Test download_castro logs status code and re-raises HTTPError."""
-    mocker.patch("download.generate_temporary_name", return_value="temp_castro.mp3")
-
     mock_page_resp = mocker.MagicMock()
     mock_page_resp.content = b'<html><source src="https://audio.link/file.mp3"></html>'
 
@@ -393,12 +390,12 @@ def test_download_castro_http_error(mocker):
     mock_logger = mocker.patch("download.logger")
 
     with pytest.raises(HTTPError):
-        download_castro("https://castro.fm/episode/123")
+        downloader.download_castro("https://castro.fm/episode/123")
 
     mock_logger.exception.assert_called_once_with("%s: status code", 500)
 
 
-def test_download_castro_page_http_error(mocker):
+def test_download_castro_page_http_error(mocker, downloader):
     """Test download_castro surfaces an HTTP error from the page fetch."""
     mock_page_resp = mocker.MagicMock()
     mock_page_resp.raise_for_status.side_effect = HTTPError("404 Not Found")
@@ -407,18 +404,15 @@ def test_download_castro_page_http_error(mocker):
     mocker.patch("download.requote_uri", side_effect=lambda x: x)
 
     with pytest.raises(HTTPError):
-        download_castro("https://castro.fm/episode/123")
+        downloader.download_castro("https://castro.fm/episode/123")
 
     # Only the page fetch happens; the audio download is never reached.
     mock_get.assert_called_once()
     mock_page_resp.close.assert_called_once()
 
 
-def test_download_tg_http_error(mocker):
+def test_download_tg_http_error(mocker, downloader):
     """Test download_tg logs status code and re-raises HTTPError."""
-    mocker.patch("download.TG_API_TOKEN", "TEST_TOKEN")
-    mocker.patch("download.generate_temporary_name", return_value="temp_file.ext")
-
     mock_file = mocker.MagicMock()
     mock_file.file_path = "path/to/file"
 
@@ -429,16 +423,13 @@ def test_download_tg_http_error(mocker):
     mock_logger = mocker.patch("download.logger")
 
     with pytest.raises(HTTPError):
-        download_tg(mock_file, ext=".ext")
+        downloader.download_tg(mock_file, ext=".ext")
 
     mock_logger.exception.assert_called_once_with("%s: status code", 403)
 
 
-def test_stream_to_file_removes_partial_on_failure(mocker):
+def test_stream_to_file_removes_partial_on_failure(mocker, downloader):
     """Test _stream_to_file deletes the partial dest file when the write fails."""
-    mocker.patch("download.TG_API_TOKEN", "TEST_TOKEN")
-    mocker.patch("download.generate_temporary_name", return_value="temp_file.ext")
-
     mock_file = mocker.MagicMock()
     mock_file.file_path = "path/to/file"
 
@@ -451,17 +442,14 @@ def test_stream_to_file_removes_partial_on_failure(mocker):
     mock_unlink = mocker.patch("pathlib.Path.unlink")
 
     with pytest.raises(OSError, match="connection reset"):
-        download_tg(mock_file, ext=".ext")
+        downloader.download_tg(mock_file, ext=".ext")
 
     mock_unlink.assert_called_once_with(missing_ok=True)
     mock_resp.close.assert_called_once()
 
 
-def test_stream_to_file_unlink_oserror_does_not_hide_write_error(mocker):
+def test_stream_to_file_unlink_oserror_does_not_hide_write_error(mocker, downloader):
     """Test that an OSError from unlink is suppressed and the original write error propagates."""
-    mocker.patch("download.TG_API_TOKEN", "TEST_TOKEN")
-    mocker.patch("download.generate_temporary_name", return_value="temp_file.ext")
-
     mock_file = mocker.MagicMock()
     mock_file.file_path = "path/to/file"
 
@@ -475,4 +463,4 @@ def test_stream_to_file_unlink_oserror_does_not_hide_write_error(mocker):
 
     # PermissionError from unlink must not surface; original OSError propagates.
     with pytest.raises(OSError, match="connection reset"):
-        download_tg(mock_file, ext=".ext")
+        downloader.download_tg(mock_file, ext=".ext")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,10 +1,39 @@
+from types import SimpleNamespace
+
+import pytest
 from telebot import types
 from tenacity import RetryError
 
 from domain import PrefixedText
 from exceptions import LimitExceededError, WebParseError
+from handlers import MessageHandlers
 from main import handle_message, process_message_content
 from utils import classify_url
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handlers(mocker):
+    """Return (handlers, fakes) with every collaborator injected as a MagicMock."""
+    fakes = SimpleNamespace(
+        bot=mocker.MagicMock(),
+        messenger=mocker.MagicMock(),
+        summarizer=mocker.MagicMock(),
+        web_parser=mocker.MagicMock(),
+        quota_manager=mocker.MagicMock(),
+        downloader=mocker.MagicMock(),
+    )
+    handlers = MessageHandlers(
+        fakes.bot,
+        fakes.messenger,
+        fakes.summarizer,
+        fakes.web_parser,
+        fakes.quota_manager,
+        fakes.downloader,
+    )
+    return handlers, fakes
 
 
 def test_unauthorized_user(message_factory, mocker):
@@ -32,24 +61,25 @@ def test_handle_message_missing_user(message_factory, mocker):
 def test_successful_document_flow(message_factory, mocker):
     """Test a valid user sending a document receives the generated summary."""
     msg = message_factory(content_type="document")
-    mock_user = mocker.MagicMock(
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock(
         approved=True,
         summarizing_model="mock-model",
         prompt_key_for_summary="mock-prompt",
         target_language="English",
     )
     mock_file = mocker.MagicMock(spec=types.File)
-    mocker.patch("main.select_user", return_value=mock_user)
-    mocker.patch("handlers.get_file_with_retry", return_value=mock_file)
-    mocker.patch(
-        "handlers.summarize_with_document",
-        return_value="Here is your awesome summary",
+    fakes.messenger.get_file_with_retry.return_value = mock_file
+    fakes.summarizer.summarize_with_document.return_value = (
+        "Here is your awesome summary"
     )
-    mock_send_answer = mocker.patch("handlers.send_answer")
 
-    handle_message(msg)
+    handlers.handle_document(msg, user)
 
-    mock_send_answer.assert_called_once_with(msg, "Here is your awesome summary")
+    fakes.messenger.send_answer.assert_called_once_with(
+        msg,
+        "Here is your awesome summary",
+    )
 
 
 def test_process_message_content_dispatches_audio(message_factory, mocker):
@@ -74,6 +104,53 @@ def test_process_message_content_dispatches_allowed_document(message_factory, mo
     mock_document.assert_called_once_with(msg, user)
 
 
+def test_process_message_content_dispatches_video_note(message_factory, mocker):
+    """Test video note messages route to handle_video_note."""
+    msg = message_factory(content_type="video_note")
+    user = mocker.MagicMock()
+    mock_video_note = mocker.patch("main.handle_video_note")
+
+    process_message_content(msg, user)
+
+    mock_video_note.assert_called_once_with(msg, user)
+
+
+def test_process_message_content_dispatches_voice(message_factory, mocker):
+    """Test voice messages route to handle_voice."""
+    msg = message_factory(content_type="voice")
+    user = mocker.MagicMock()
+    mock_voice = mocker.patch("main.handle_voice")
+
+    process_message_content(msg, user)
+
+    mock_voice.assert_called_once_with(msg, user)
+
+
+def test_process_message_content_dispatches_video(message_factory, mocker):
+    """Test video messages route to handle_video."""
+    msg = message_factory(content_type="video")
+    user = mocker.MagicMock()
+    mock_video = mocker.patch("main.handle_video")
+
+    process_message_content(msg, user)
+
+    mock_video.assert_called_once_with(msg, user)
+
+
+def test_process_message_content_dispatches_url(message_factory, mocker):
+    """Test text messages extract the first token and route to handle_url."""
+    msg = message_factory(
+        content_type="text",
+        text="https://example.com/article extra words",
+    )
+    user = mocker.MagicMock()
+    mock_url = mocker.patch("main.handle_url")
+
+    process_message_content(msg, user)
+
+    mock_url.assert_called_once_with(msg, user, "https://example.com/article")
+
+
 def test_process_message_content_sends_textless_fallback(message_factory, mocker):
     """Test unsupported non-text messages produce a clear fallback response."""
     msg = message_factory(content_type="document")
@@ -91,63 +168,56 @@ def test_handle_audio_file_too_large(message_factory, mocker):
     """Test that audio files over 20MB are rejected."""
     msg = message_factory(content_type="audio")
     msg.audio.file_size = 25_000_000
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_reply_to = mocker.patch("main.bot.reply_to")
-    mock_summarize = mocker.patch("handlers.summarize")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
 
-    handle_message(msg)
+    handlers.handle_audio(msg, user)
 
-    mock_reply_to.assert_called_once_with(msg, "File is too big.")
-    mock_summarize.assert_not_called()
+    fakes.bot.reply_to.assert_called_once_with(msg, "File is too big.")
+    fakes.summarizer.summarize.assert_not_called()
 
 
 def test_handle_audio_happy_path(message_factory, mocker):
     """Test successful audio file processing."""
     msg = message_factory(content_type="audio")
-    mocker.patch(
-        "main.select_user",
-        return_value=mocker.MagicMock(
-            approved=True,
-            summarizing_model="model",
-            prompt_key_for_summary="prompt",
-            target_language="English",
-        ),
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock(
+        approved=True,
+        summarizing_model="model",
+        prompt_key_for_summary="prompt",
+        target_language="English",
     )
     mock_file = mocker.MagicMock(spec=types.File)
-    mocker.patch("handlers.get_file_with_retry", return_value=mock_file)
-    mock_summarize = mocker.patch("handlers.summarize")
-    mocker.patch("handlers.send_answer")
+    fakes.messenger.get_file_with_retry.return_value = mock_file
 
-    handle_message(msg)
+    handlers.handle_audio(msg, user)
 
-    assert mock_summarize.call_args.kwargs["data"] == mock_file
+    assert fakes.summarizer.summarize.call_args.kwargs["data"] == mock_file
 
 
 def test_handle_document_missing_file_size(message_factory, mocker):
     """Test that a document with no file_size is rejected."""
     msg = message_factory(content_type="document")
     msg.document.file_size = None
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_bot_handlers = mocker.patch("handlers.bot")
-    mock_summarize_with_document = mocker.patch("handlers.summarize_with_document")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
 
-    handle_message(msg)
+    handlers.handle_document(msg, user)
 
-    mock_bot_handlers.reply_to.assert_called_once_with(msg, "No document found.")
-    mock_summarize_with_document.assert_not_called()
+    fakes.bot.reply_to.assert_called_once_with(msg, "No document found.")
+    fakes.summarizer.summarize_with_document.assert_not_called()
 
 
 def test_handle_url_unsupported_pattern(message_factory, mocker):
     """Test that non-URL text is rejected."""
     msg = message_factory(content_type="text", text="This is not a url.")
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_send_message = mocker.patch("main.bot.send_message")
-    mock_summarize_text = mocker.patch("handlers.summarize_text")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
 
-    handle_message(msg)
+    handlers.handle_url(msg, user, "This is not a url.")
 
-    mock_send_message.assert_called_once_with(msg.chat.id, "No data to proceed.")
-    mock_summarize_text.assert_not_called()
+    fakes.bot.send_message.assert_called_once_with(msg.chat.id, "No data to proceed.")
+    fakes.summarizer.summarize_text.assert_not_called()
 
 
 def test_classify_url_uppercase_youtube_host():
@@ -203,49 +273,47 @@ def test_handle_url_youtube_pattern(message_factory, mocker):
     """Test that YouTube URLs trigger summarize."""
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     msg = message_factory(content_type="text", text=url)
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_summarize = mocker.patch("handlers.summarize")
-    mocker.patch("handlers.send_answer")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
 
-    handle_message(msg)
+    handlers.handle_url(msg, user, url)
 
-    assert mock_summarize.call_args.kwargs["data"] == url
+    assert fakes.summarizer.summarize.call_args.kwargs["data"] == url
 
 
 def test_handle_url_castro_pattern(message_factory, mocker):
     """Test that Castro URLs trigger summarize."""
     url = "https://castro.fm/episode/123"
     msg = message_factory(content_type="text", text=url)
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_summarize = mocker.patch("handlers.summarize")
-    mocker.patch("handlers.send_answer")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
 
-    handle_message(msg)
+    handlers.handle_url(msg, user, url)
 
-    assert mock_summarize.call_args.kwargs["data"] == url
+    assert fakes.summarizer.summarize.call_args.kwargs["data"] == url
 
 
 def test_handle_url_other_http_pattern(message_factory, mocker):
     """Test that other URLs preflight quota, parse, then summarize with parsed text."""
     url = "https://example.com/article"
     msg = message_factory(content_type="text", text=url)
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mocker.patch("handlers.check_quota", return_value=True)
-    mock_parse_url = mocker.patch(
-        "handlers.parse_url",
-        return_value=PrefixedText(text="Parsed page content.", prefix="🌐"),
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.web_parser.parse.return_value = PrefixedText(
+        text="Parsed page content.",
+        prefix="🌐",
     )
-    mock_summarize_text = mocker.patch(
-        "handlers.summarize_text",
-        return_value="Summary text.",
+    fakes.summarizer.summarize_text.return_value = "Summary text."
+
+    handlers.handle_url(msg, user, url)
+
+    fakes.web_parser.parse.assert_called_once_with(url)
+    assert (
+        fakes.summarizer.summarize_text.call_args.kwargs["text"]
+        == "Parsed page content."
     )
-    mock_send_answer = mocker.patch("handlers.send_answer")
-
-    handle_message(msg)
-
-    mock_parse_url.assert_called_once_with(url)
-    assert mock_summarize_text.call_args.kwargs["text"] == "Parsed page content."
-    answer = mock_send_answer.call_args.args[1]
+    answer = fakes.messenger.send_answer.call_args.args[1]
     assert answer.startswith("🌐")
     assert "Summary text." in answer
 
@@ -254,69 +322,60 @@ def test_handle_url_web_preflight_blocks_before_parse_url(message_factory, mocke
     """Test that quota preflight blocks Tavily IO for over-quota users."""
     url = "https://example.com/article"
     msg = message_factory(content_type="text", text=url)
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mocker.patch("handlers.check_quota", side_effect=LimitExceededError)
-    mock_parse_url = mocker.patch("handlers.parse_url")
-    mock_summarize_text = mocker.patch("handlers.summarize_text")
-    mocker.patch("handlers.send_answer")
-    mocker.patch("main.bot.reply_to")
-    mocker.patch("main.capture_exception")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
+    fakes.quota_manager.check_quota.side_effect = LimitExceededError
 
-    handle_message(msg)
+    with pytest.raises(LimitExceededError):
+        handlers.handle_url(msg, user, url)
 
-    mock_parse_url.assert_not_called()
-    mock_summarize_text.assert_not_called()
+    fakes.web_parser.parse.assert_not_called()
+    fakes.summarizer.summarize_text.assert_not_called()
 
 
 def test_handle_url_web_parse_error_skips_summarize(message_factory, mocker):
     """Test that WebParseError from parse_url short-circuits before summarize_text."""
     url = "https://example.com/article"
     msg = message_factory(content_type="text", text=url)
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mocker.patch("handlers.check_quota", return_value=True)
-    mocker.patch("handlers.parse_url", side_effect=WebParseError("boom"))
-    mock_summarize_text = mocker.patch("handlers.summarize_text")
-    mocker.patch("handlers.send_answer")
-    mocker.patch("main.bot.reply_to")
-    mocker.patch("main.capture_exception")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.web_parser.parse.side_effect = WebParseError("boom")
 
-    handle_message(msg)
+    with pytest.raises(WebParseError):
+        handlers.handle_url(msg, user, url)
 
-    mock_summarize_text.assert_not_called()
+    fakes.summarizer.summarize_text.assert_not_called()
 
 
 def test_handle_voice_happy_path(message_factory, mocker):
     """Test successful voice message processing."""
     msg = message_factory(content_type="voice")
-    mocker.patch(
-        "main.select_user",
-        return_value=mocker.MagicMock(
-            approved=True,
-            summarizing_model="model",
-            prompt_key_for_summary="prompt",
-            target_language="English",
-        ),
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock(
+        approved=True,
+        summarizing_model="model",
+        prompt_key_for_summary="prompt",
+        target_language="English",
     )
     mock_file = mocker.MagicMock(spec=types.File)
-    mocker.patch("handlers.get_file_with_retry", return_value=mock_file)
-    mock_summarize = mocker.patch("handlers.summarize")
-    mocker.patch("handlers.send_answer")
+    fakes.messenger.get_file_with_retry.return_value = mock_file
 
-    handle_message(msg)
+    handlers.handle_voice(msg, user)
 
-    assert mock_summarize.call_args.kwargs["data"] == mock_file
+    assert fakes.summarizer.summarize.call_args.kwargs["data"] == mock_file
 
 
 def test_handle_voice_too_big(message_factory, mocker):
     """Test voice message rejection when file exceeds limit (20MB)."""
     msg = message_factory(content_type="voice")
     msg.voice.file_size = 21 * 1024 * 1024
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_bot_handlers = mocker.patch("handlers.bot")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
 
-    handle_message(msg)
+    handlers.handle_voice(msg, user)
 
-    mock_bot_handlers.reply_to.assert_called_once_with(msg, "File is too big.")
+    fakes.bot.reply_to.assert_called_once_with(msg, "File is too big.")
 
 
 def test_handle_voice_missing_info(message_factory, mocker):
@@ -324,36 +383,33 @@ def test_handle_voice_missing_info(message_factory, mocker):
     msg = message_factory(content_type="text")
     msg.content_type = "voice"
     msg.voice = None
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_bot_handlers = mocker.patch("handlers.bot")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
 
-    handle_message(msg)
+    handlers.handle_voice(msg, user)
 
-    mock_bot_handlers.reply_to.assert_called_once_with(msg, "No voice message found.")
+    fakes.bot.reply_to.assert_called_once_with(msg, "No voice message found.")
 
 
 def test_handle_video_happy_path_cleans_up_download(message_factory, mocker):
     """Test video processing cleans up the downloaded temporary file."""
     msg = message_factory(content_type="video")
-    mocker.patch(
-        "main.select_user",
-        return_value=mocker.MagicMock(
-            approved=True,
-            summarizing_model="model",
-            prompt_key_for_summary="prompt",
-            target_language="English",
-        ),
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock(
+        approved=True,
+        summarizing_model="model",
+        prompt_key_for_summary="prompt",
+        target_language="English",
     )
     mock_file = mocker.MagicMock(spec=types.File)
-    mocker.patch("handlers.get_file_with_retry", return_value=mock_file)
-    mocker.patch("handlers.download_tg", return_value="downloaded.mp4")
+    fakes.messenger.get_file_with_retry.return_value = mock_file
+    fakes.downloader.download_tg.return_value = "downloaded.mp4"
     mocker.patch("handlers.generate_temporary_name", return_value="compressed.ogg")
     mocker.patch("handlers.compress_audio")
-    mocker.patch("handlers.summarize", return_value="summary")
-    mocker.patch("handlers.send_answer")
+    fakes.summarizer.summarize.return_value = "summary"
     mock_clean_up = mocker.patch("handlers.clean_up")
 
-    handle_message(msg)
+    handlers.handle_video(msg, user)
 
     assert mock_clean_up.call_args_list == [
         mocker.call(file="downloaded.mp4"),
@@ -364,25 +420,22 @@ def test_handle_video_happy_path_cleans_up_download(message_factory, mocker):
 def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker):
     """Test video note processing cleans up the downloaded temporary file."""
     msg = message_factory(content_type="video_note")
-    mocker.patch(
-        "main.select_user",
-        return_value=mocker.MagicMock(
-            approved=True,
-            summarizing_model="model",
-            prompt_key_for_summary="prompt",
-            target_language="English",
-        ),
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock(
+        approved=True,
+        summarizing_model="model",
+        prompt_key_for_summary="prompt",
+        target_language="English",
     )
     mock_file = mocker.MagicMock(spec=types.File)
-    mocker.patch("handlers.get_file_with_retry", return_value=mock_file)
-    mocker.patch("handlers.download_tg", return_value="downloaded.mp4")
+    fakes.messenger.get_file_with_retry.return_value = mock_file
+    fakes.downloader.download_tg.return_value = "downloaded.mp4"
     mocker.patch("handlers.generate_temporary_name", return_value="compressed.ogg")
     mocker.patch("handlers.compress_audio")
-    mocker.patch("handlers.summarize", return_value="summary")
-    mocker.patch("handlers.send_answer")
+    fakes.summarizer.summarize.return_value = "summary"
     mock_clean_up = mocker.patch("handlers.clean_up")
 
-    handle_message(msg)
+    handlers.handle_video_note(msg, user)
 
     assert mock_clean_up.call_args_list == [
         mocker.call(file="downloaded.mp4"),
@@ -400,27 +453,23 @@ def test_handle_video_cleans_up_compressed_file_when_summarize_raises(
     own cleanup runs, so _handle_video_like must clean up the file it created.
     """
     msg = message_factory(content_type="video")
-    mocker.patch(
-        "main.select_user",
-        return_value=mocker.MagicMock(
-            approved=True,
-            summarizing_model="model",
-            prompt_key_for_summary="prompt",
-            target_language="English",
-        ),
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock(
+        approved=True,
+        summarizing_model="model",
+        prompt_key_for_summary="prompt",
+        target_language="English",
     )
     mock_file = mocker.MagicMock(spec=types.File)
-    mocker.patch("handlers.get_file_with_retry", return_value=mock_file)
-    mocker.patch("handlers.download_tg", return_value="downloaded.mp4")
+    fakes.messenger.get_file_with_retry.return_value = mock_file
+    fakes.downloader.download_tg.return_value = "downloaded.mp4"
     mocker.patch("handlers.generate_temporary_name", return_value="compressed.ogg")
     mocker.patch("handlers.compress_audio")
-    mocker.patch("handlers.summarize", side_effect=LimitExceededError("blocked"))
-    mocker.patch("handlers.send_answer")
-    mocker.patch("main.bot.reply_to")
-    mocker.patch("main.capture_exception")
+    fakes.summarizer.summarize.side_effect = LimitExceededError("blocked")
     mock_clean_up = mocker.patch("handlers.clean_up")
 
-    handle_message(msg)
+    with pytest.raises(LimitExceededError):
+        handlers.handle_video(msg, user)
 
     assert mock_clean_up.call_args_list == [
         mocker.call(file="downloaded.mp4"),
@@ -432,24 +481,24 @@ def test_handle_video_note_file_too_large(message_factory, mocker):
     """Test video note rejection when file exceeds 20MB limit."""
     msg = message_factory(content_type="video_note")
     msg.video_note.file_size = 21 * 1024 * 1024
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_bot_handlers = mocker.patch("handlers.bot")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
 
-    handle_message(msg)
+    handlers.handle_video_note(msg, user)
 
-    mock_bot_handlers.reply_to.assert_called_once_with(msg, "File is too big.")
+    fakes.bot.reply_to.assert_called_once_with(msg, "File is too big.")
 
 
 def test_handle_video_file_too_large(message_factory, mocker):
     """Test video rejection when file exceeds 20MB limit."""
     msg = message_factory(content_type="video")
     msg.video.file_size = 21 * 1024 * 1024
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mock_bot_handlers = mocker.patch("handlers.bot")
+    handlers, fakes = _make_handlers(mocker)
+    user = mocker.MagicMock()
 
-    handle_message(msg)
+    handlers.handle_video(msg, user)
 
-    mock_bot_handlers.reply_to.assert_called_once_with(msg, "File is too big.")
+    fakes.bot.reply_to.assert_called_once_with(msg, "File is too big.")
 
 
 def test_handle_message_limit_exceeded(message_factory, mocker):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -7,7 +7,7 @@ from tenacity import RetryError
 from domain import PrefixedText
 from exceptions import LimitExceededError, WebParseError
 from handlers import MessageHandlers
-from main import BotApp
+from helpers import make_app
 from utils import classify_url
 
 # ---------------------------------------------------------------------------
@@ -36,29 +36,10 @@ def _make_handlers(mocker):
     return handlers, fakes
 
 
-def _make_app(mocker):
-    """Return (app, fakes) with every collaborator injected as a MagicMock."""
-    fakes = SimpleNamespace(
-        bot=mocker.MagicMock(),
-        user_repo=mocker.MagicMock(),
-        quota_manager=mocker.MagicMock(),
-        tracer=mocker.MagicMock(),
-        handlers=mocker.MagicMock(),
-    )
-    app = BotApp(
-        fakes.bot,
-        fakes.user_repo,
-        fakes.quota_manager,
-        fakes.tracer,
-        fakes.handlers,
-    )
-    return app, fakes
-
-
 def test_unauthorized_user(message_factory, mocker):
     """Test that unauthorized users receive an access denied message."""
     msg = message_factory(content_type="text", text="Hello")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=False)
 
     app.handle_message(msg)
@@ -70,7 +51,7 @@ def test_handle_message_missing_user(message_factory, mocker):
     """Test handle_message rejects messages without Telegram user metadata."""
     msg = message_factory(content_type="text", text="Hello")
     msg.from_user = None
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     app.handle_message(msg)
 
@@ -104,7 +85,7 @@ def test_successful_document_flow(message_factory, mocker):
 def test_process_message_content_dispatches_audio(message_factory, mocker):
     """Test audio messages route to handle_audio."""
     msg = message_factory(content_type="audio")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     user = mocker.MagicMock()
 
     app.process_message_content(msg, user)
@@ -115,7 +96,7 @@ def test_process_message_content_dispatches_audio(message_factory, mocker):
 def test_process_message_content_dispatches_allowed_document(message_factory, mocker):
     """Test supported document MIME types route to handle_document."""
     msg = message_factory(content_type="document")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     user = mocker.MagicMock()
 
     app.process_message_content(msg, user)
@@ -126,7 +107,7 @@ def test_process_message_content_dispatches_allowed_document(message_factory, mo
 def test_process_message_content_dispatches_video_note(message_factory, mocker):
     """Test video note messages route to handle_video_note."""
     msg = message_factory(content_type="video_note")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     user = mocker.MagicMock()
 
     app.process_message_content(msg, user)
@@ -137,7 +118,7 @@ def test_process_message_content_dispatches_video_note(message_factory, mocker):
 def test_process_message_content_dispatches_voice(message_factory, mocker):
     """Test voice messages route to handle_voice."""
     msg = message_factory(content_type="voice")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     user = mocker.MagicMock()
 
     app.process_message_content(msg, user)
@@ -148,7 +129,7 @@ def test_process_message_content_dispatches_voice(message_factory, mocker):
 def test_process_message_content_dispatches_video(message_factory, mocker):
     """Test video messages route to handle_video."""
     msg = message_factory(content_type="video")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     user = mocker.MagicMock()
 
     app.process_message_content(msg, user)
@@ -162,7 +143,7 @@ def test_process_message_content_dispatches_url(message_factory, mocker):
         content_type="text",
         text="https://example.com/article extra words",
     )
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     user = mocker.MagicMock()
 
     app.process_message_content(msg, user)
@@ -179,7 +160,7 @@ def test_process_message_content_sends_textless_fallback(message_factory, mocker
     msg = message_factory(content_type="document")
     msg.document.mime_type = "application/zip"
     msg.text = None
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     user = mocker.MagicMock()
 
     app.process_message_content(msg, user)
@@ -527,7 +508,7 @@ def test_handle_video_file_too_large(message_factory, mocker):
 def test_handle_message_limit_exceeded(message_factory, mocker):
     """Test handle_message when rate limit is exceeded."""
     msg = message_factory(content_type="text", text="http://youtube.com/watch?v=123")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=True)
     mocker.patch.object(
         app,
@@ -546,7 +527,7 @@ def test_handle_message_limit_exceeded(message_factory, mocker):
 def test_handle_message_retry_error(message_factory, mocker):
     """Test handle_message when retries are exhausted."""
     msg = message_factory(content_type="text", text="http://youtube.com/watch?v=123")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=True)
     mocker.patch.object(
         app,
@@ -565,7 +546,7 @@ def test_handle_message_retry_error(message_factory, mocker):
 def test_handle_message_web_parse_error(message_factory, mocker):
     """Test handle_message when a webpage URL cannot be parsed."""
     msg = message_factory(content_type="text", text="http://example.com/dead")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=True)
     mocker.patch.object(
         app,
@@ -584,7 +565,7 @@ def test_handle_message_web_parse_error(message_factory, mocker):
 def test_handle_message_unexpected_error(message_factory, mocker):
     """Test handle_message when an unexpected exception occurs."""
     msg = message_factory(content_type="text", text="http://youtube.com/watch?v=123")
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=True)
     mocker.patch.object(
         app,

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -7,7 +7,7 @@ from tenacity import RetryError
 from domain import PrefixedText
 from exceptions import LimitExceededError, WebParseError
 from handlers import MessageHandlers
-from main import handle_message, process_message_content
+from main import BotApp
 from utils import classify_url
 
 # ---------------------------------------------------------------------------
@@ -36,26 +36,45 @@ def _make_handlers(mocker):
     return handlers, fakes
 
 
+def _make_app(mocker):
+    """Return (app, fakes) with every collaborator injected as a MagicMock."""
+    fakes = SimpleNamespace(
+        bot=mocker.MagicMock(),
+        user_repo=mocker.MagicMock(),
+        quota_manager=mocker.MagicMock(),
+        tracer=mocker.MagicMock(),
+        handlers=mocker.MagicMock(),
+    )
+    app = BotApp(
+        fakes.bot,
+        fakes.user_repo,
+        fakes.quota_manager,
+        fakes.tracer,
+        fakes.handlers,
+    )
+    return app, fakes
+
+
 def test_unauthorized_user(message_factory, mocker):
     """Test that unauthorized users receive an access denied message."""
     msg = message_factory(content_type="text", text="Hello")
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=False))
-    mock_send_message = mocker.patch("main.bot.send_message")
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=False)
 
-    handle_message(msg)
+    app.handle_message(msg)
 
-    mock_send_message.assert_called_once_with(msg.chat.id, "You are not approved.")
+    fakes.bot.send_message.assert_called_once_with(msg.chat.id, "You are not approved.")
 
 
 def test_handle_message_missing_user(message_factory, mocker):
     """Test handle_message rejects messages without Telegram user metadata."""
     msg = message_factory(content_type="text", text="Hello")
     msg.from_user = None
-    mock_reply = mocker.patch("main.bot.reply_to")
+    app, fakes = _make_app(mocker)
 
-    handle_message(msg)
+    app.handle_message(msg)
 
-    mock_reply.assert_called_once_with(msg, "User information is missing.")
+    fakes.bot.reply_to.assert_called_once_with(msg, "User information is missing.")
 
 
 def test_successful_document_flow(message_factory, mocker):
@@ -85,56 +104,56 @@ def test_successful_document_flow(message_factory, mocker):
 def test_process_message_content_dispatches_audio(message_factory, mocker):
     """Test audio messages route to handle_audio."""
     msg = message_factory(content_type="audio")
+    app, fakes = _make_app(mocker)
     user = mocker.MagicMock()
-    mock_audio = mocker.patch("main.handle_audio")
 
-    process_message_content(msg, user)
+    app.process_message_content(msg, user)
 
-    mock_audio.assert_called_once_with(msg, user)
+    fakes.handlers.handle_audio.assert_called_once_with(msg, user)
 
 
 def test_process_message_content_dispatches_allowed_document(message_factory, mocker):
     """Test supported document MIME types route to handle_document."""
     msg = message_factory(content_type="document")
+    app, fakes = _make_app(mocker)
     user = mocker.MagicMock()
-    mock_document = mocker.patch("main.handle_document")
 
-    process_message_content(msg, user)
+    app.process_message_content(msg, user)
 
-    mock_document.assert_called_once_with(msg, user)
+    fakes.handlers.handle_document.assert_called_once_with(msg, user)
 
 
 def test_process_message_content_dispatches_video_note(message_factory, mocker):
     """Test video note messages route to handle_video_note."""
     msg = message_factory(content_type="video_note")
+    app, fakes = _make_app(mocker)
     user = mocker.MagicMock()
-    mock_video_note = mocker.patch("main.handle_video_note")
 
-    process_message_content(msg, user)
+    app.process_message_content(msg, user)
 
-    mock_video_note.assert_called_once_with(msg, user)
+    fakes.handlers.handle_video_note.assert_called_once_with(msg, user)
 
 
 def test_process_message_content_dispatches_voice(message_factory, mocker):
     """Test voice messages route to handle_voice."""
     msg = message_factory(content_type="voice")
+    app, fakes = _make_app(mocker)
     user = mocker.MagicMock()
-    mock_voice = mocker.patch("main.handle_voice")
 
-    process_message_content(msg, user)
+    app.process_message_content(msg, user)
 
-    mock_voice.assert_called_once_with(msg, user)
+    fakes.handlers.handle_voice.assert_called_once_with(msg, user)
 
 
 def test_process_message_content_dispatches_video(message_factory, mocker):
     """Test video messages route to handle_video."""
     msg = message_factory(content_type="video")
+    app, fakes = _make_app(mocker)
     user = mocker.MagicMock()
-    mock_video = mocker.patch("main.handle_video")
 
-    process_message_content(msg, user)
+    app.process_message_content(msg, user)
 
-    mock_video.assert_called_once_with(msg, user)
+    fakes.handlers.handle_video.assert_called_once_with(msg, user)
 
 
 def test_process_message_content_dispatches_url(message_factory, mocker):
@@ -143,12 +162,16 @@ def test_process_message_content_dispatches_url(message_factory, mocker):
         content_type="text",
         text="https://example.com/article extra words",
     )
+    app, fakes = _make_app(mocker)
     user = mocker.MagicMock()
-    mock_url = mocker.patch("main.handle_url")
 
-    process_message_content(msg, user)
+    app.process_message_content(msg, user)
 
-    mock_url.assert_called_once_with(msg, user, "https://example.com/article")
+    fakes.handlers.handle_url.assert_called_once_with(
+        msg,
+        user,
+        "https://example.com/article",
+    )
 
 
 def test_process_message_content_sends_textless_fallback(message_factory, mocker):
@@ -156,12 +179,12 @@ def test_process_message_content_sends_textless_fallback(message_factory, mocker
     msg = message_factory(content_type="document")
     msg.document.mime_type = "application/zip"
     msg.text = None
+    app, fakes = _make_app(mocker)
     user = mocker.MagicMock()
-    mock_send = mocker.patch("main.bot.send_message")
 
-    process_message_content(msg, user)
+    app.process_message_content(msg, user)
 
-    mock_send.assert_called_once_with(msg.chat.id, "No text to process.")
+    fakes.bot.send_message.assert_called_once_with(msg.chat.id, "No text to process.")
 
 
 def test_handle_audio_file_too_large(message_factory, mocker):
@@ -504,16 +527,17 @@ def test_handle_video_file_too_large(message_factory, mocker):
 def test_handle_message_limit_exceeded(message_factory, mocker):
     """Test handle_message when rate limit is exceeded."""
     msg = message_factory(content_type="text", text="http://youtube.com/watch?v=123")
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mocker.patch(
-        "main.process_message_content",
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=True)
+    mocker.patch.object(
+        app,
+        "process_message_content",
         side_effect=LimitExceededError("Rate limit exceeded"),
     )
-    mock_reply = mocker.patch("main.bot.reply_to")
 
-    handle_message(msg)
+    app.handle_message(msg)
 
-    mock_reply.assert_called_once_with(
+    fakes.bot.reply_to.assert_called_once_with(
         msg,
         "Daily limit has been exceeded, try again tomorrow.",
     )
@@ -522,16 +546,17 @@ def test_handle_message_limit_exceeded(message_factory, mocker):
 def test_handle_message_retry_error(message_factory, mocker):
     """Test handle_message when retries are exhausted."""
     msg = message_factory(content_type="text", text="http://youtube.com/watch?v=123")
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mocker.patch(
-        "main.process_message_content",
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=True)
+    mocker.patch.object(
+        app,
+        "process_message_content",
         side_effect=RetryError(mocker.MagicMock()),
     )
-    mock_reply = mocker.patch("main.bot.reply_to")
 
-    handle_message(msg)
+    app.handle_message(msg)
 
-    mock_reply.assert_called_once_with(
+    fakes.bot.reply_to.assert_called_once_with(
         msg,
         "An error occurred during execution. Please try again in 10 minutes.",
     )
@@ -540,16 +565,17 @@ def test_handle_message_retry_error(message_factory, mocker):
 def test_handle_message_web_parse_error(message_factory, mocker):
     """Test handle_message when a webpage URL cannot be parsed."""
     msg = message_factory(content_type="text", text="http://example.com/dead")
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mocker.patch(
-        "main.process_message_content",
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=True)
+    mocker.patch.object(
+        app,
+        "process_message_content",
         side_effect=WebParseError("Tavily could not extract content"),
     )
-    mock_reply = mocker.patch("main.bot.reply_to")
 
-    handle_message(msg)
+    app.handle_message(msg)
 
-    mock_reply.assert_called_once_with(
+    fakes.bot.reply_to.assert_called_once_with(
         msg,
         "Check provided URL, looks like the page is not available.",
     )
@@ -558,10 +584,14 @@ def test_handle_message_web_parse_error(message_factory, mocker):
 def test_handle_message_unexpected_error(message_factory, mocker):
     """Test handle_message when an unexpected exception occurs."""
     msg = message_factory(content_type="text", text="http://youtube.com/watch?v=123")
-    mocker.patch("main.select_user", return_value=mocker.MagicMock(approved=True))
-    mocker.patch("main.process_message_content", side_effect=Exception("BOOM"))
-    mock_reply = mocker.patch("main.bot.reply_to")
+    app, fakes = _make_app(mocker)
+    fakes.user_repo.select_user.return_value = mocker.MagicMock(approved=True)
+    mocker.patch.object(
+        app,
+        "process_message_content",
+        side_effect=Exception("BOOM"),
+    )
 
-    handle_message(msg)
+    app.handle_message(msg)
 
-    mock_reply.assert_called_once_with(msg, "Unexpected: Exception")
+    fakes.bot.reply_to.assert_called_once_with(msg, "Unexpected: Exception")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -9,38 +9,40 @@ from pydantic_ai.models.google import GoogleModel
 
 import llm as llm_module
 from config import ModelSpec
-from llm import build_model, build_settings, build_uploaded_file, run_model
+from llm import LLMClient
 
 
-@pytest.fixture(autouse=True)
-def _clear_model_cache():
-    """Keep the module-level model cache from leaking between tests."""
-    llm_module._build_model.cache_clear()
-    yield
-    llm_module._build_model.cache_clear()
+@pytest.fixture
+def llm_client(mocker):
+    """LLMClient wired to a mock Gemini client; unused by most of these tests."""
+    return LLMClient(mocker.MagicMock())
 
 
-def test_build_model_returns_google_model():
+def test_build_model_returns_google_model(llm_client):
     """Test build_model wires a registered Gemini id to a GoogleModel."""
-    model = build_model("gemini-3.5-flash-lite")
+    model = llm_client.build_model("gemini-3.5-flash-lite")
     assert isinstance(model, GoogleModel)
     assert model.model_name == "gemini-3.5-flash-lite"
     assert model.system == "google"
 
 
-def test_build_model_is_cached_per_id():
+def test_build_model_is_cached_per_id(llm_client):
     """Test build_model reuses one model object per id, so clients are shared."""
-    assert build_model("gemini-3.5-flash") is build_model("gemini-3.5-flash")
-    assert build_model("gemini-3.5-flash") is not build_model("gemini-3.6-flash")
+    assert llm_client.build_model("gemini-3.5-flash") is llm_client.build_model(
+        "gemini-3.5-flash",
+    )
+    assert llm_client.build_model("gemini-3.5-flash") is not llm_client.build_model(
+        "gemini-3.6-flash",
+    )
 
 
-def test_build_model_rejects_unregistered_model():
+def test_build_model_rejects_unregistered_model(llm_client):
     """Test an id missing from MODEL_SPECS fails loudly rather than guessing."""
     with pytest.raises(KeyError):
-        build_model("no-such-model")
+        llm_client.build_model("no-such-model")
 
 
-def test_build_model_rejects_provider_without_builder(mocker):
+def test_build_model_rejects_provider_without_builder(llm_client, mocker):
     """Test a registered provider with no builder raises instead of defaulting."""
     mocker.patch.dict(
         llm_module.MODEL_SPECS,
@@ -54,17 +56,23 @@ def test_build_model_rejects_provider_without_builder(mocker):
     )
 
     with pytest.raises(ValueError, match="No model builder for provider: mystery"):
-        build_model("mystery-1")
+        llm_client.build_model("mystery-1")
 
 
 @pytest.mark.parametrize("thinking_level", ["MINIMAL", "LOW", "MEDIUM", "HIGH"])
-def test_build_settings_passes_google_thinking_level_through(thinking_level):
+def test_build_settings_passes_google_thinking_level_through(
+    llm_client,
+    thinking_level,
+):
     """Test Google gets the level verbatim, not the agnostic effort mapping."""
-    settings = build_settings("gemini-3.5-flash", thinking_level=thinking_level)
+    settings = llm_client.build_settings(
+        "gemini-3.5-flash",
+        thinking_level=thinking_level,
+    )
     assert settings == {"google_thinking_config": {"thinking_level": thinking_level}}
 
 
-def test_build_settings_uses_agnostic_effort_for_other_providers(mocker):
+def test_build_settings_uses_agnostic_effort_for_other_providers(llm_client, mocker):
     """Test a non-Google provider gets the portable `thinking` effort instead."""
     mocker.patch.dict(
         llm_module.MODEL_SPECS,
@@ -77,10 +85,12 @@ def test_build_settings_uses_agnostic_effort_for_other_providers(mocker):
         },
     )
 
-    assert build_settings("mystery-1", thinking_level="LOW") == {"thinking": "low"}
+    assert llm_client.build_settings("mystery-1", thinking_level="LOW") == {
+        "thinking": "low",
+    }
 
 
-def test_build_settings_does_not_reject_unknown_thinking_level():
+def test_build_settings_does_not_reject_unknown_thinking_level(llm_client):
     """Lock the lenient handling of a thinking level outside the allow-list.
 
     A stale `users.thinking_level` must not blow up before the request is even
@@ -88,11 +98,11 @@ def test_build_settings_does_not_reject_unknown_thinking_level():
     as it did when the level went through `types.ThinkingLevel`. The agnostic
     `thinking` effort would raise KeyError here.
     """
-    settings = build_settings("gemini-3.5-flash", thinking_level="INVALID")
+    settings = llm_client.build_settings("gemini-3.5-flash", thinking_level="INVALID")
     assert settings["google_thinking_config"] == {"thinking_level": "INVALID"}
 
 
-def test_build_uploaded_file_uses_uri_as_file_id():
+def test_build_uploaded_file_uses_uri_as_file_id(llm_client):
     """Test the uploaded-file part carries the uri, not the file name."""
     file = SimpleNamespace(
         name="files/mock123",
@@ -100,14 +110,14 @@ def test_build_uploaded_file_uses_uri_as_file_id():
         mime_type="audio/ogg",
     )
 
-    part = build_uploaded_file(model_id="gemini-3.5-flash", file=file)
+    part = llm_client.build_uploaded_file(model_id="gemini-3.5-flash", file=file)
 
     assert part.file_id == file.uri
     assert part.media_type == "audio/ogg"
     assert part.provider_name == "google"
 
 
-def test_build_uploaded_file_rejects_non_google_model(mocker):
+def test_build_uploaded_file_rejects_non_google_model(llm_client, mocker):
     """Test a Gemini-stored file is never handed to another provider's model.
 
     upload_and_wait_for_file always uploads to Gemini, so a non-Google model
@@ -126,10 +136,10 @@ def test_build_uploaded_file_rejects_non_google_model(mocker):
     file = SimpleNamespace(name="files/x", uri="https://x", mime_type="audio/ogg")
 
     with pytest.raises(ValueError, match="Cannot reference a Gemini file"):
-        build_uploaded_file(model_id="mystery-1", file=file)
+        llm_client.build_uploaded_file(model_id="mystery-1", file=file)
 
 
-def test_run_drives_a_real_agent_run(mocker):
+def test_run_drives_a_real_agent_run(llm_client, mocker):
     """Test run against the real Agent, with only the model itself substituted.
 
     The other run tests stub `_agent.run_sync`, so they would keep passing if a
@@ -145,12 +155,12 @@ def test_run_drives_a_real_agent_run(mocker):
         return ModelResponse(parts=[TextPart(content="A summary.")])
 
     mocker.patch.object(
-        llm_module,
-        "_build_model",
+        llm_client,
+        "build_model",
         return_value=FunctionModel(capture),
     )
 
-    result = run_model(
+    result = llm_client.run(
         content="Summarize this.",
         model_id="gemini-3.6-flash",
         target_language="Ukrainian",
@@ -163,14 +173,14 @@ def test_run_drives_a_real_agent_run(mocker):
     assert seen["settings"]["google_thinking_config"] == {"thinking_level": "MEDIUM"}
 
 
-def test_run_builds_the_expected_gemini_request_config():
+def test_run_builds_the_expected_gemini_request_config(llm_client):
     """Test the settings reach GenerateContentConfig in the pre-seam shape.
 
     include_thoughts must stay unset: pydantic-ai's agnostic thinking effort
     turns it on, which makes Gemini emit thought summaries that run() discards.
     """
-    model = build_model("gemini-3.5-flash-lite")
-    settings = build_settings("gemini-3.5-flash-lite", thinking_level="HIGH")
+    model = llm_client.build_model("gemini-3.5-flash-lite")
+    settings = llm_client.build_settings("gemini-3.5-flash-lite", thinking_level="HIGH")
     messages = [ModelRequest(parts=[UserPromptPart(content="hello")])]
 
     # Reaches into a GoogleModel private: it is the only way to see the real
@@ -188,15 +198,15 @@ def test_run_builds_the_expected_gemini_request_config():
     assert config["response_json_schema"] is None
 
 
-def test_run_passes_model_and_instructions(mocker):
+def test_run_passes_model_and_instructions(llm_client, mocker):
     """Test run resolves the model and the language instruction per call."""
     mock_run_sync = mocker.patch.object(
-        llm_module._agent,
+        llm_client._agent,
         "run_sync",
         return_value=SimpleNamespace(output="A summary."),
     )
 
-    result = run_model(
+    result = llm_client.run(
         content="Summarize this.",
         model_id="gemini-3.6-flash",
         target_language="Ukrainian",
@@ -210,15 +220,15 @@ def test_run_passes_model_and_instructions(mocker):
     assert "Ukrainian" in call.kwargs["instructions"]
 
 
-def test_run_instructions_are_dedented(mocker):
+def test_run_instructions_are_dedented(llm_client, mocker):
     """Test the system instruction is dedented and stripped before being sent."""
     mock_run_sync = mocker.patch.object(
-        llm_module._agent,
+        llm_client._agent,
         "run_sync",
         return_value=SimpleNamespace(output="A summary."),
     )
 
-    run_model(
+    llm_client.run(
         content="Summarize this.",
         model_id="gemini-3.5-flash",
         target_language="English",
@@ -231,16 +241,16 @@ def test_run_instructions_are_dedented(mocker):
 
 
 @pytest.mark.parametrize("output", ["", None])
-def test_run_raises_on_empty_output(mocker, output):
+def test_run_raises_on_empty_output(llm_client, mocker, output):
     """Test an empty response raises AttributeError, which the retries catch."""
     mocker.patch.object(
-        llm_module._agent,
+        llm_client._agent,
         "run_sync",
         return_value=SimpleNamespace(output=output),
     )
 
     with pytest.raises(AttributeError):
-        run_model(
+        llm_client.run(
             content="Summarize this.",
             model_id="gemini-3.5-flash",
             target_language="English",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,29 +1,11 @@
 from types import SimpleNamespace
 
+from helpers import make_app
 from main import BotApp, build_app
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_app(mocker):
-    """Return (app, fakes) with every collaborator injected as a MagicMock."""
-    fakes = SimpleNamespace(
-        bot=mocker.MagicMock(),
-        user_repo=mocker.MagicMock(),
-        quota_manager=mocker.MagicMock(),
-        tracer=mocker.MagicMock(),
-        handlers=mocker.MagicMock(),
-    )
-    app = BotApp(
-        fakes.bot,
-        fakes.user_repo,
-        fakes.quota_manager,
-        fakes.tracer,
-        fakes.handlers,
-    )
-    return app, fakes
 
 
 def _make_fake_container(mocker):
@@ -55,7 +37,7 @@ def test_build_app_wires_container_and_registers_handlers(mocker):
 
 def test_register_registers_expected_handlers(mocker):
     """register() registers all eight handlers with their exact kwargs."""
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     app.register()
 
@@ -77,20 +59,32 @@ def test_register_registers_expected_handlers(mocker):
         "video",
     ]
 
-    # The four auth-gated commands (myinfo, set_*) wire a func= predicate backed
-    # by user_repo.check_auth.
+    # The five auth-gated commands (myinfo and the four set_*) all wire the same
+    # func= predicate, backed by user_repo.check_auth.
     for call in calls[2:7]:
-        func = call.kwargs["func"]
-        message = mocker.MagicMock()
-        fakes.user_repo.check_auth.return_value = True
-        assert func(message) is True
-        message.from_user = None
-        assert func(message) is False
+        assert call.kwargs["func"] == app._authorized
+
+
+def test_authorized_gates_on_a_known_approved_sender(mocker):
+    """_authorized passes only a present sender that check_auth approves."""
+    app, fakes = make_app(mocker)
+    message = mocker.MagicMock()
+
+    fakes.user_repo.check_auth.return_value = True
+    assert app._authorized(message) is True
+
+    fakes.user_repo.check_auth.return_value = False
+    assert app._authorized(message) is False
+
+    message.from_user = None
+    assert app._authorized(message) is False
+    # The None guard short-circuits, so the repo is not consulted a third time.
+    assert fakes.user_repo.check_auth.call_count == 2
 
 
 def test_run_starts_infinity_polling(mocker):
     """run() polls Telegram with the fixed 20s timeout."""
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
 
     app.run()
 
@@ -103,7 +97,7 @@ def test_shutdown_cleans_up_and_flushes_the_tracer(mocker):
     Whether tracing is configured at all is Tracer.shutdown's decision, covered
     by tests/test_services.py::test_tracer_shutdown_*.
     """
-    app, fakes = _make_app(mocker)
+    app, fakes = make_app(mocker)
     mock_clean_up = mocker.patch("main.clean_up")
 
     app.shutdown()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+
+from main import BotApp, build_app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(mocker):
+    """Return (app, fakes) with every collaborator injected as a MagicMock."""
+    fakes = SimpleNamespace(
+        bot=mocker.MagicMock(),
+        user_repo=mocker.MagicMock(),
+        quota_manager=mocker.MagicMock(),
+        tracer=mocker.MagicMock(),
+        handlers=mocker.MagicMock(),
+    )
+    app = BotApp(
+        fakes.bot,
+        fakes.user_repo,
+        fakes.quota_manager,
+        fakes.tracer,
+        fakes.handlers,
+    )
+    return app, fakes
+
+
+def _make_fake_container(mocker):
+    """Return a duck-typed stand-in exposing only the members build_app reads."""
+    return SimpleNamespace(
+        bot=mocker.MagicMock(),
+        user_repo=mocker.MagicMock(),
+        quota_manager=mocker.MagicMock(),
+        tracer=mocker.MagicMock(),
+        handlers=mocker.MagicMock(),
+    )
+
+
+def test_build_app_wires_container_and_registers_handlers(mocker):
+    """build_app wires BotApp to the container's members and registers handlers."""
+    container = _make_fake_container(mocker)
+
+    app = build_app(container)
+
+    assert isinstance(app, BotApp)
+    assert app._bot is container.bot
+    assert app._user_repo is container.user_repo
+    assert app._quota_manager is container.quota_manager
+    assert app._tracer is container.tracer
+    assert app._handlers is container.handlers
+    # 8 registrations: start, info, myinfo, four /set_* commands, unified handler.
+    assert container.bot.message_handler.call_count == 8
+
+
+def test_register_registers_expected_handlers(mocker):
+    """register() registers all eight handlers with their exact kwargs."""
+    app, fakes = _make_app(mocker)
+
+    app.register()
+
+    assert fakes.bot.message_handler.call_count == 8
+    calls = fakes.bot.message_handler.call_args_list
+    assert calls[0].kwargs == {"commands": ["start"]}
+    assert calls[1].kwargs == {"commands": ["info"]}
+    assert calls[2].kwargs["commands"] == ["myinfo"]
+    assert calls[3].kwargs["commands"] == ["set_target_language"]
+    assert calls[4].kwargs["commands"] == ["set_summarizing_model"]
+    assert calls[5].kwargs["commands"] == ["set_prompt_strategy"]
+    assert calls[6].kwargs["commands"] == ["set_thinking_level"]
+    assert calls[7].kwargs["content_types"] == [
+        "text",
+        "audio",
+        "document",
+        "video_note",
+        "voice",
+        "video",
+    ]
+
+    # The four auth-gated commands (myinfo, set_*) wire a func= predicate backed
+    # by user_repo.check_auth.
+    for call in calls[2:7]:
+        func = call.kwargs["func"]
+        message = mocker.MagicMock()
+        fakes.user_repo.check_auth.return_value = True
+        assert func(message) is True
+        message.from_user = None
+        assert func(message) is False
+
+
+def test_run_starts_infinity_polling(mocker):
+    """run() polls Telegram with the fixed 20s timeout."""
+    app, fakes = _make_app(mocker)
+
+    app.run()
+
+    fakes.bot.infinity_polling.assert_called_once_with(timeout=20)
+
+
+def test_shutdown_cleans_up_and_flushes_the_tracer(mocker):
+    """shutdown() sweeps temp files and flushes the tracer.
+
+    Whether tracing is configured at all is Tracer.shutdown's decision, covered
+    by tests/test_services.py::test_tracer_shutdown_*.
+    """
+    app, fakes = _make_app(mocker)
+    mock_clean_up = mocker.patch("main.clean_up")
+
+    app.shutdown()
+
+    mock_clean_up.assert_called_once_with(all_downloads=True)
+    fakes.tracer.shutdown.assert_called_once_with()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from helpers import make_app
 from main import BotApp, build_app
 
@@ -82,6 +84,19 @@ def test_authorized_gates_on_a_known_approved_sender(mocker):
     assert fakes.user_repo.check_auth.call_count == 2
 
 
+def test_authorized_reads_an_unregistered_sender_as_unauthorized(mocker):
+    """_authorized answers False rather than raising for an unknown user.
+
+    TeleBot evaluates func= filters unguarded, so a ValueError out of
+    check_auth would abort handler matching for the whole update — the sender
+    would get silence instead of falling through to handle_message.
+    """
+    app, fakes = make_app(mocker)
+    fakes.user_repo.check_auth.side_effect = ValueError("User not found")
+
+    assert app._authorized(mocker.MagicMock()) is False
+
+
 def test_run_starts_infinity_polling(mocker):
     """run() polls Telegram with the fixed 20s timeout."""
     app, fakes = make_app(mocker)
@@ -103,4 +118,19 @@ def test_shutdown_cleans_up_and_flushes_the_tracer(mocker):
     app.shutdown()
 
     mock_clean_up.assert_called_once_with(all_downloads=True)
+    fakes.tracer.shutdown.assert_called_once_with()
+
+
+def test_shutdown_flushes_the_tracer_when_the_sweep_fails(mocker):
+    """A failing temp-file sweep still lets buffered spans flush.
+
+    clean_up unlinks files directly, so a single OSError would otherwise cost
+    everything the tracer has buffered.
+    """
+    app, fakes = make_app(mocker)
+    mocker.patch("main.clean_up", side_effect=OSError("device busy"))
+
+    with pytest.raises(OSError, match="device busy"):
+        app.shutdown()
+
     fakes.tracer.shutdown.assert_called_once_with()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -92,9 +92,14 @@ def test_authorized_reads_an_unregistered_sender_as_unauthorized(mocker):
     would get silence instead of falling through to handle_message.
     """
     app, fakes = make_app(mocker)
+    message = mocker.MagicMock()
+    message.from_user.id = 4242
     fakes.user_repo.check_auth.side_effect = ValueError("User not found")
 
-    assert app._authorized(mocker.MagicMock()) is False
+    assert app._authorized(message) is False
+    # Pins the sender's own id as the one looked up, which every other
+    # attribute of a MagicMock message would otherwise satisfy.
+    fakes.user_repo.check_auth.assert_called_once_with(4242)
 
 
 def test_run_starts_infinity_polling(mocker):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -336,12 +336,16 @@ def test_is_public_returns_false_when_any_addr_is_private(mocker):
 
 def test_resolve_returns_final_url_after_redirect(mocker):
     """Test resolve returns the redirected URL and closes the response."""
-    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
+    resolver = UrlResolver()
+    mocker.patch.object(resolver, "_is_public", return_value=True)
+    # get_proxy() reads config.PROXIES, which python-dotenv backfills from the
+    # developer's real .env (conftest.py never sets PROXY) — patch it so the
+    # test result does not depend on what happens to be in that file.
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/final")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
 
-    result = UrlResolver().resolve("https://example.com/start")
+    result = resolver.resolve("https://example.com/start")
 
     assert result == "https://example.com/final"
     mock_resp.close.assert_called_once_with()
@@ -352,12 +356,13 @@ def test_resolve_returns_final_url_after_redirect(mocker):
 
 def test_resolve_returns_original_when_no_redirect(mocker):
     """Test resolve returns the input unchanged when there is no redirect."""
-    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
+    resolver = UrlResolver()
+    mocker.patch.object(resolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mocker.patch("parsing.requests.get", return_value=mock_resp)
 
-    result = UrlResolver().resolve("https://example.com/article")
+    result = resolver.resolve("https://example.com/article")
 
     assert result == "https://example.com/article"
     mock_resp.close.assert_called_once_with()
@@ -365,12 +370,13 @@ def test_resolve_returns_original_when_no_redirect(mocker):
 
 def test_resolve_falls_back_to_original_on_error(mocker, caplog):
     """Test resolve returns the original URL when the request raises."""
-    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
+    resolver = UrlResolver()
+    mocker.patch.object(resolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mocker.patch("parsing.requests.get", side_effect=RuntimeError("boom"))
 
     with caplog.at_level(logging.WARNING, logger="parsing"):
-        result = UrlResolver().resolve("https://example.com/article")
+        result = resolver.resolve("https://example.com/article")
 
     assert result == "https://example.com/article"
     assert "Could not resolve redirects" in caplog.text
@@ -378,51 +384,55 @@ def test_resolve_falls_back_to_original_on_error(mocker, caplog):
 
 def test_resolve_passes_proxy_when_configured(mocker):
     """Test resolve forwards a configured proxy to requests.get."""
-    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
+    resolver = UrlResolver()
+    mocker.patch.object(resolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="https://user:pass@proxy.com:1234")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
 
-    UrlResolver().resolve("https://example.com/article")
+    resolver.resolve("https://example.com/article")
 
     assert mock_get.call_args.kwargs["proxy"] == "https://user:pass@proxy.com:1234"
 
 
 def test_resolve_omits_proxy_when_none_configured(mocker):
     """Test resolve passes proxy=None when no proxy is set."""
-    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
+    resolver = UrlResolver()
+    mocker.patch.object(resolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
 
-    UrlResolver().resolve("https://example.com/article")
+    resolver.resolve("https://example.com/article")
 
     assert mock_get.call_args.kwargs["proxy"] is None
 
 
 def test_resolve_passes_configured_timeout(mocker):
     """Test resolve forwards the instance timeout to requests.get."""
-    mocker.patch.object(parsing.UrlResolver, "_is_public", return_value=True)
+    resolver = UrlResolver(timeout=3)
+    mocker.patch.object(resolver, "_is_public", return_value=True)
     mocker.patch("parsing.get_proxy", return_value="")
     mock_resp = mocker.Mock(url="https://example.com/article")
     mock_get = mocker.patch("parsing.requests.get", return_value=mock_resp)
 
-    UrlResolver(timeout=3).resolve("https://example.com/article")
+    resolver.resolve("https://example.com/article")
 
     assert mock_get.call_args.kwargs["timeout"] == 3
 
 
 def test_resolve_blocks_non_public_initial_url(mocker, caplog):
     """Test resolve returns the original URL without fetching for a private host."""
+    resolver = UrlResolver()
     mocker.patch.object(
-        parsing.UrlResolver,
+        resolver,
         "_is_public",
         side_effect=lambda u: u != "http://192.168.1.1/",
     )
     mock_get = mocker.patch("parsing.requests.get")
 
     with caplog.at_level(logging.WARNING, logger="parsing"):
-        result = UrlResolver().resolve("http://192.168.1.1/")
+        result = resolver.resolve("http://192.168.1.1/")
 
     assert result == "http://192.168.1.1/"
     mock_get.assert_not_called()
@@ -431,8 +441,9 @@ def test_resolve_blocks_non_public_initial_url(mocker, caplog):
 
 def test_resolve_blocks_redirect_to_private_host(mocker, caplog):
     """Test resolve returns the original URL when a redirect lands on a private host."""
+    resolver = UrlResolver()
     mocker.patch.object(
-        parsing.UrlResolver,
+        resolver,
         "_is_public",
         side_effect=[True, False],  # public initial URL, private redirect
     )
@@ -441,7 +452,7 @@ def test_resolve_blocks_redirect_to_private_host(mocker, caplog):
     mocker.patch("parsing.requests.get", return_value=mock_resp)
 
     with caplog.at_level(logging.WARNING, logger="parsing"):
-        result = UrlResolver().resolve("https://example.com/start")
+        result = resolver.resolve("https://example.com/start")
 
     assert result == "https://example.com/start"
     assert "Blocked redirect to non-public host" in caplog.text

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -4,10 +4,8 @@ import pytest
 from tavily.errors import TimeoutError as TavilyTimeoutError
 from tenacity import RetryError
 
-import parsing
-from domain import PrefixedText
 from exceptions import WebParseError
-from parsing import ExaBackend, TavilyBackend, UrlResolver, WebParser, parse_url
+from parsing import ExaBackend, TavilyBackend, UrlResolver, WebParser
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -239,21 +237,6 @@ def test_parse_resolves_url_before_extracting(mocker):
         text={"max_characters": 20000, "include_html_tags": True},
         max_age_hours=0,
     )
-
-
-def test_parse_url_delegates_to_web_parser(mocker):
-    """Test parse_url routes to the module-level web_parser singleton."""
-    mock_result = PrefixedText(text="hello", prefix="🌐")
-    mock_parse = mocker.patch.object(
-        parsing.web_parser,
-        "parse",
-        return_value=mock_result,
-    )
-
-    result = parse_url("https://example.com/start")
-
-    assert result is mock_result
-    mock_parse.assert_called_once_with("https://example.com/start")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -283,6 +283,20 @@ def test_check_quota_sleeps_when_per_minute_limited(mocker):
     mock_sleep.assert_called_once_with(7.5)
 
 
+def test_tracer_shutdown_flushes_the_client(mocker):
+    """Tracer.shutdown flushes buffered spans when Langfuse is configured."""
+    mock_client = mocker.MagicMock()
+
+    Tracer(mock_client).shutdown()
+
+    mock_client.shutdown.assert_called_once_with()
+
+
+def test_tracer_shutdown_is_a_noop_when_langfuse_disabled():
+    """Tracer.shutdown does nothing when tracing is not configured."""
+    Tracer(None).shutdown()
+
+
 def test_observe_message_noop_when_langfuse_disabled(mocker):
     """observe_message is a no-op context manager when Langfuse is not configured."""
     mock_propagate = mocker.patch("services.propagate_attributes")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,36 +1,28 @@
 import pytest
+from limits import parse as parse_rate_limit
 from limits.util import WindowStats
 
-import services as services_module
 from exceptions import LimitExceededError
-from services import (
-    check_quota,
-    get_file_with_retry,
-    get_remaining_quota,
-    observe_message,
-    resolve_mime_type,
-    send_answer,
-    upload_and_wait_for_file,
-)
+from services import GeminiHelper, Messenger, QuotaManager, Tracer
 
 
 @pytest.mark.parametrize("entities", [[], [{"type": "bold"}]])
 def test__reply_with_retry_forwards_entities(mocker, entities):
     """Test _reply_with_retry forwards entities (empty or not) to bot.reply_to."""
-    mock_bot = mocker.patch("services.bot")
+    mock_bot = mocker.MagicMock()
     mock_msg = mocker.MagicMock()
 
-    services_module.messenger._reply_with_retry(mock_msg, "hello", entities=entities)
+    Messenger(mock_bot)._reply_with_retry(mock_msg, "hello", entities=entities)
 
     mock_bot.reply_to.assert_called_once_with(mock_msg, "hello", entities=entities)
 
 
 def test_get_file_with_retry_success(mocker):
     """Test get_file_with_retry retrieves file info."""
-    mock_bot = mocker.patch("services.bot")
+    mock_bot = mocker.MagicMock()
     mock_bot.get_file.return_value = "mock_file"
 
-    result = get_file_with_retry("id123")
+    result = Messenger(mock_bot).get_file_with_retry("id123")
 
     assert result == "mock_file"
     mock_bot.get_file.assert_called_once_with("id123")
@@ -47,10 +39,11 @@ def test_send_answer_single_chunk(mocker):
         return_value=[("text", [mock_entity])],
     )
 
-    mock_reply = mocker.patch.object(services_module.messenger, "_reply_with_retry")
+    messenger = Messenger(mocker.MagicMock())
+    mock_reply = mocker.patch.object(messenger, "_reply_with_retry")
     mock_msg = mocker.MagicMock()
 
-    send_answer(mock_msg, "short answer")
+    messenger.send_answer(mock_msg, "short answer")
 
     mock_convert.assert_called_once_with("short answer")
     mock_split.assert_called_once_with("text", [], max_utf16_len=4096)
@@ -61,18 +54,20 @@ def test_send_answer_multi_chunk(mocker):
     """Test send_answer with a long message (multiple chunks)."""
     mocker.patch("services.convert", return_value=("text", []))
     mocker.patch("services.split_entities", return_value=[("part1", []), ("part2", [])])
-    mock_reply = mocker.patch.object(services_module.messenger, "_reply_with_retry")
     mocker.patch("services.time.sleep")
 
+    messenger = Messenger(mocker.MagicMock())
+    mock_reply = mocker.patch.object(messenger, "_reply_with_retry")
     mock_msg = mocker.MagicMock()
-    send_answer(mock_msg, "long answer")
+
+    messenger.send_answer(mock_msg, "long answer")
 
     assert mock_reply.call_count == 2
 
 
 def test_upload_and_wait_for_file_happy(mocker):
     """Test uploading file to Gemini when it's immediately ACTIVE."""
-    mock_client = mocker.patch("services.gemini_client")
+    mock_client = mocker.MagicMock()
     mock_file = mocker.MagicMock()
     mock_file.name = "name"
     mock_file.state = "ACTIVE"
@@ -81,7 +76,7 @@ def test_upload_and_wait_for_file_happy(mocker):
 
     mock_client.files.upload.return_value = mock_file
 
-    result = upload_and_wait_for_file("path", "audio/ogg", 1)
+    result = GeminiHelper(mock_client).upload_and_wait_for_file("path", "audio/ogg", 1)
 
     assert result == mock_file
     mock_client.files.upload.assert_called_once()
@@ -89,7 +84,7 @@ def test_upload_and_wait_for_file_happy(mocker):
 
 def test_upload_and_wait_for_file_polling(mocker):
     """Test uploading file to Gemini with polling (PROCESSING -> ACTIVE)."""
-    mock_client = mocker.patch("services.gemini_client")
+    mock_client = mocker.MagicMock()
     mock_sleep = mocker.patch("services.time.sleep")
 
     mock_file_proc = mocker.MagicMock()
@@ -105,7 +100,7 @@ def test_upload_and_wait_for_file_polling(mocker):
     mock_client.files.upload.return_value = mock_file_proc
     mock_client.files.get.return_value = mock_file_active
 
-    result = upload_and_wait_for_file("path", "audio/ogg", 1)
+    result = GeminiHelper(mock_client).upload_and_wait_for_file("path", "audio/ogg", 1)
 
     assert result == mock_file_active
     mock_sleep.assert_called_once_with(1)
@@ -114,46 +109,48 @@ def test_upload_and_wait_for_file_polling(mocker):
 
 def test_upload_and_wait_for_file_failed(mocker):
     """Test upload_and_wait_for_file raises ValueError on FAILED state."""
-    mock_client = mocker.patch("services.gemini_client")
+    mock_client = mocker.MagicMock()
     mock_file = mocker.MagicMock()
     mock_file.name = "name"
     mock_file.state = "FAILED"
     mock_client.files.upload.return_value = mock_file
 
     with pytest.raises(ValueError, match="FAILED"):
-        upload_and_wait_for_file("path", "audio/ogg", 1)
+        GeminiHelper(mock_client).upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
-def test_resolve_mime_type_uses_mimetypes_guess():
+def test_resolve_mime_type_uses_mimetypes_guess(mocker):
     """resolve_mime_type maps known extensions via the stdlib mimetypes database."""
-    assert resolve_mime_type("document.pdf") == "application/pdf"
-    assert resolve_mime_type("data.csv") == "text/csv"
-    assert resolve_mime_type("text.rtf") == "application/rtf"
-    assert resolve_mime_type("audio.ogg") == "audio/ogg"
-    assert resolve_mime_type("audio.opus") == "audio/ogg"
-    assert resolve_mime_type("audio.mp3") == "audio/mpeg"
-    assert resolve_mime_type("video.mp4") == "video/mp4"
+    gemini_helper = GeminiHelper(mocker.MagicMock())
+    assert gemini_helper.resolve_mime_type("document.pdf") == "application/pdf"
+    assert gemini_helper.resolve_mime_type("data.csv") == "text/csv"
+    assert gemini_helper.resolve_mime_type("text.rtf") == "application/rtf"
+    assert gemini_helper.resolve_mime_type("audio.ogg") == "audio/ogg"
+    assert gemini_helper.resolve_mime_type("audio.opus") == "audio/ogg"
+    assert gemini_helper.resolve_mime_type("audio.mp3") == "audio/mpeg"
+    assert gemini_helper.resolve_mime_type("video.mp4") == "video/mp4"
 
 
-def test_resolve_mime_type_defaults_for_unknown_extension():
+def test_resolve_mime_type_defaults_for_unknown_extension(mocker):
     """resolve_mime_type falls back to octet-stream for extensions mimetypes cannot map.
 
     Uses .zzz rather than .bin: mimetypes resolves .bin to application/octet-stream
     itself, so it never reaches the default and leaves that branch uncovered.
     """
-    assert resolve_mime_type("mystery.zzz") == "application/octet-stream"
-    assert resolve_mime_type("no_extension") == "application/octet-stream"
+    gemini_helper = GeminiHelper(mocker.MagicMock())
+    assert gemini_helper.resolve_mime_type("mystery.zzz") == "application/octet-stream"
+    assert gemini_helper.resolve_mime_type("no_extension") == "application/octet-stream"
 
 
 def test_upload_and_wait_for_file_name_none(mocker):
     """upload_and_wait_for_file raises AttributeError when upload returns no name."""
-    mock_client = mocker.patch("services.gemini_client")
+    mock_client = mocker.MagicMock()
     mock_file = mocker.MagicMock()
     mock_file.name = None
     mock_client.files.upload.return_value = mock_file
 
     with pytest.raises(AttributeError):
-        upload_and_wait_for_file("path", "audio/ogg", 1)
+        GeminiHelper(mock_client).upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
 def test_upload_and_wait_for_file_name_none_after_polling(mocker):
@@ -162,7 +159,7 @@ def test_upload_and_wait_for_file_name_none_after_polling(mocker):
     The pre-loop check only sees the upload response; callers cast .name on the
     returned object, so the polled result must be validated too.
     """
-    mock_client = mocker.patch("services.gemini_client")
+    mock_client = mocker.MagicMock()
     mocker.patch("services.time.sleep")
 
     mock_file_proc = mocker.MagicMock()
@@ -179,12 +176,12 @@ def test_upload_and_wait_for_file_name_none_after_polling(mocker):
     mock_client.files.get.return_value = mock_file_done
 
     with pytest.raises(AttributeError):
-        upload_and_wait_for_file("path", "audio/ogg", 1)
+        GeminiHelper(mock_client).upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
 def test_upload_and_wait_for_file_missing_uri(mocker):
     """upload_and_wait_for_file raises AttributeError when uri or mime_type is None."""
-    mock_client = mocker.patch("services.gemini_client")
+    mock_client = mocker.MagicMock()
     mock_file = mocker.MagicMock()
     mock_file.name = "name"
     mock_file.state = "ACTIVE"
@@ -192,74 +189,86 @@ def test_upload_and_wait_for_file_missing_uri(mocker):
     mock_client.files.upload.return_value = mock_file
 
     with pytest.raises(AttributeError):
-        upload_and_wait_for_file("path", "audio/ogg", 1)
+        GeminiHelper(mock_client).upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
 def test_get_remaining_quota(mocker):
     """get_remaining_quota returns remaining count from window stats."""
-    mocker.patch(
-        "services.rate_limiter.get_window_stats",
-        return_value=WindowStats(reset_time=9999999999.0, remaining=7),
+    mock_rate_limiter = mocker.MagicMock()
+    mock_rate_limiter.get_window_stats.return_value = WindowStats(
+        reset_time=9999999999.0,
+        remaining=7,
     )
+    quota_manager = QuotaManager(mock_rate_limiter, parse_rate_limit("5 per minute"))
 
-    result = get_remaining_quota(user_id=123, daily_limit=10)
+    result = quota_manager.get_remaining_quota(user_id=123, daily_limit=10)
 
     assert result == 7
 
 
 def test_check_quota_raises_immediately_when_daily_limit_zero(mocker):
     """check_quota raises LimitExceededError without touching Redis when limit is 0."""
-    mock_hit = mocker.patch("services.rate_limiter.hit")
+    mock_rate_limiter = mocker.MagicMock()
+    quota_manager = QuotaManager(mock_rate_limiter, parse_rate_limit("5 per minute"))
 
     with pytest.raises(LimitExceededError):
-        check_quota(user_id=1, daily_limit=0)
+        quota_manager.check_quota(user_id=1, daily_limit=0)
 
-    mock_hit.assert_not_called()
+    mock_rate_limiter.hit.assert_not_called()
 
 
 def test_get_remaining_quota_returns_zero_when_daily_limit_zero(mocker):
     """get_remaining_quota returns 0 without touching Redis when limit is 0."""
-    mock_stats = mocker.patch("services.rate_limiter.get_window_stats")
+    mock_rate_limiter = mocker.MagicMock()
+    quota_manager = QuotaManager(mock_rate_limiter, parse_rate_limit("5 per minute"))
 
-    result = get_remaining_quota(user_id=1, daily_limit=0)
+    result = quota_manager.get_remaining_quota(user_id=1, daily_limit=0)
 
     assert result == 0
-    mock_stats.assert_not_called()
+    mock_rate_limiter.get_window_stats.assert_not_called()
 
 
 def test_check_quota_uses_per_user_redis_key(mocker):
     """check_quota hits the Redis key scoped to the user (RPD:{user_id})."""
-    mock_hit = mocker.patch("services.rate_limiter.hit", return_value=True)
+    mock_rate_limiter = mocker.MagicMock()
+    mock_rate_limiter.hit.return_value = True
+    quota_manager = QuotaManager(mock_rate_limiter, parse_rate_limit("5 per minute"))
 
-    result = check_quota(user_id=456, daily_limit=5)
+    result = quota_manager.check_quota(user_id=456, daily_limit=5)
 
     assert result is True
-    assert mock_hit.call_args_list[0].args[1] == "RPD:456"
+    assert mock_rate_limiter.hit.call_args_list[0].args[1] == "RPD:456"
 
 
 def test_check_quota_raises_when_daily_redis_counter_exhausted(mocker):
     """check_quota raises LimitExceededError when the daily counter is exhausted."""
-    mocker.patch("services.rate_limiter.hit", return_value=False)
+    mock_rate_limiter = mocker.MagicMock()
+    mock_rate_limiter.hit.return_value = False
+    quota_manager = QuotaManager(mock_rate_limiter, parse_rate_limit("5 per minute"))
 
     with pytest.raises(LimitExceededError):
-        check_quota(user_id=789, daily_limit=3)
+        quota_manager.check_quota(user_id=789, daily_limit=3)
 
 
 def test_check_quota_sleeps_when_per_minute_limited(mocker):
     """check_quota sleeps until the window resets and retries the per-minute hit."""
     fixed_now = 1_000_000.0
     mocker.patch("services.time.time", return_value=fixed_now)
-    mocker.patch(
-        "services.rate_limiter.hit",
-        side_effect=[True, False, True],  # daily passes, per-minute blocked, retry ok
-    )
-    mocker.patch(
-        "services.rate_limiter.get_window_stats",
-        return_value=WindowStats(reset_time=fixed_now + 7.5, remaining=0),
-    )
     mock_sleep = mocker.patch("services.time.sleep")
 
-    result = check_quota(user_id=321, daily_limit=5)
+    mock_rate_limiter = mocker.MagicMock()
+    mock_rate_limiter.hit.side_effect = [
+        True,
+        False,
+        True,
+    ]  # daily passes, per-minute blocked, retry ok
+    mock_rate_limiter.get_window_stats.return_value = WindowStats(
+        reset_time=fixed_now + 7.5,
+        remaining=0,
+    )
+    quota_manager = QuotaManager(mock_rate_limiter, parse_rate_limit("5 per minute"))
+
+    result = quota_manager.check_quota(user_id=321, daily_limit=5)
 
     assert result is True
     mock_sleep.assert_called_once_with(7.5)
@@ -267,10 +276,9 @@ def test_check_quota_sleeps_when_per_minute_limited(mocker):
 
 def test_observe_message_noop_when_langfuse_disabled(mocker):
     """observe_message is a no-op context manager when Langfuse is not configured."""
-    mocker.patch("services.langfuse_client", None)
     mock_propagate = mocker.patch("services.propagate_attributes")
 
-    with observe_message(user_id=42, content_type="voice"):
+    with Tracer(None).observe_message(user_id=42, content_type="voice"):
         pass
 
     mock_propagate.assert_not_called()
@@ -278,10 +286,10 @@ def test_observe_message_noop_when_langfuse_disabled(mocker):
 
 def test_observe_message_opens_trace_when_langfuse_enabled(mocker):
     """observe_message opens a root span attributed to the user and content type."""
-    mock_client = mocker.patch("services.langfuse_client")
+    mock_client = mocker.MagicMock()
     mock_propagate = mocker.patch("services.propagate_attributes")
 
-    with observe_message(user_id=42, content_type="voice"):
+    with Tracer(mock_client).observe_message(user_id=42, content_type="voice"):
         pass
 
     mock_client.start_as_current_observation.assert_called_once_with(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -192,6 +192,15 @@ def test_upload_and_wait_for_file_missing_uri(mocker):
         GeminiHelper(mock_client).upload_and_wait_for_file("path", "audio/ogg", 1)
 
 
+def test_delete_file_forwards_name_to_client(mocker):
+    """Test delete_file passes the file name through to the client's files.delete."""
+    mock_client = mocker.MagicMock()
+
+    GeminiHelper(mock_client).delete_file("files/mock123")
+
+    mock_client.files.delete.assert_called_once_with(name="files/mock123")
+
+
 def test_get_remaining_quota(mocker):
     """get_remaining_quota returns remaining count from window stats."""
     mock_rate_limiter = mocker.MagicMock()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,5 +1,7 @@
 import pytest
 from limits import parse as parse_rate_limit
+from limits.storage import MemoryStorage
+from limits.strategies import FixedWindowRateLimiter
 from limits.util import WindowStats
 
 from exceptions import LimitExceededError
@@ -257,6 +259,40 @@ def test_check_quota_raises_when_daily_redis_counter_exhausted(mocker):
 
     with pytest.raises(LimitExceededError):
         quota_manager.check_quota(user_id=789, daily_limit=3)
+
+
+def test_check_quota_precheck_rejects_an_exhausted_daily_window():
+    """The quantity=0 pre-check rejects once the real daily window is spent.
+
+    Driven by a real FixedWindowRateLimiter rather than a mock: the bug this
+    guards against lived in the limiter's semantics, where hit(cost=0)
+    increments by nothing and so reports a spent window as still open.
+    """
+    quota_manager = QuotaManager(
+        FixedWindowRateLimiter(MemoryStorage()),
+        parse_rate_limit("100 per minute"),
+    )
+
+    assert quota_manager.check_quota(user_id=42, daily_limit=2, quantity=0) is True
+    assert quota_manager.check_quota(user_id=42, daily_limit=2, quantity=1) is True
+    assert quota_manager.check_quota(user_id=42, daily_limit=2, quantity=1) is True
+
+    assert quota_manager.get_remaining_quota(user_id=42, daily_limit=2) == 0
+    with pytest.raises(LimitExceededError):
+        quota_manager.check_quota(user_id=42, daily_limit=2, quantity=0)
+
+
+def test_check_quota_precheck_consumes_nothing():
+    """The quantity=0 pre-check leaves the daily budget untouched."""
+    quota_manager = QuotaManager(
+        FixedWindowRateLimiter(MemoryStorage()),
+        parse_rate_limit("100 per minute"),
+    )
+
+    for _ in range(5):
+        assert quota_manager.check_quota(user_id=7, daily_limit=3, quantity=0) is True
+
+    assert quota_manager.get_remaining_quota(user_id=7, daily_limit=3) == 3
 
 
 def test_check_quota_sleeps_when_per_minute_limited(mocker):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,7 +1,6 @@
 from types import SimpleNamespace
 
 import pytest
-from pydantic_ai import UploadedFile
 from pydantic_ai.exceptions import ModelHTTPError
 from telebot.types import File
 from tenacity import RetryError
@@ -10,33 +9,50 @@ import summary as summary_module
 from config import ModelSpec
 from domain import PrefixedText
 from exceptions import FetchTranscriptError, LimitExceededError
-from summary import (
-    format_prefixed_summary,
-    summarize,
-    summarize_text,
-    summarize_with_document,
-    summarize_with_file,
-)
+from summary import Summarizer, format_prefixed_summary
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_summarizer(mocker):
+    """Return (summarizer, fakes) with every collaborator injected as a MagicMock."""
+    fakes = SimpleNamespace(
+        quota_manager=mocker.MagicMock(),
+        gemini_helper=mocker.MagicMock(),
+        llm_client=mocker.MagicMock(),
+        downloader=mocker.MagicMock(),
+        audio_transcriber=mocker.MagicMock(),
+        yt_transcriber=mocker.MagicMock(),
+    )
+    summarizer = Summarizer(
+        fakes.quota_manager,
+        fakes.gemini_helper,
+        fakes.llm_client,
+        fakes.downloader,
+        fakes.audio_transcriber,
+        fakes.yt_transcriber,
+    )
+    return summarizer, fakes
 
 
 def test_summarize_with_file_upload_and_model_call(mocker):
     """Test the complete summarize_with_file flow with the file API and model mocked."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("services.gemini_client", mock_client)
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.gemini_helper.resolve_mime_type.return_value = "audio/ogg"
     mock_uploaded_file = SimpleNamespace(
         name="files/mock123",
         uri="https://generativelanguage.googleapis.com/v1beta/files/mock123",
         mime_type="audio/ogg",
         state="ACTIVE",
     )
-    mock_client.files.upload.return_value = mock_uploaded_file
-    mock_run = mocker.patch(
-        "summary.run_model",
-        return_value="This is a mocked summary of the file.",
-    )
+    fakes.gemini_helper.upload_and_wait_for_file.return_value = mock_uploaded_file
+    fakes.llm_client.build_uploaded_file.return_value = "uploaded-file-sentinel"
+    fakes.llm_client.run.return_value = "This is a mocked summary of the file."
 
-    result = summarize_with_file(
+    result = summarizer.summarize_with_file(
         file="test_audio.ogg",
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -47,37 +63,40 @@ def test_summarize_with_file_upload_and_model_call(mocker):
     )
 
     assert result == "This is a mocked summary of the file."
-    mock_client.files.upload.assert_called_once_with(
+    fakes.gemini_helper.upload_and_wait_for_file.assert_called_once_with(
         file="test_audio.ogg",
-        config={"mime_type": "audio/ogg"},
+        mime_type="audio/ogg",
+        sleep_time=10,
     )
-    mock_client.files.delete.assert_called_once_with(name="files/mock123")
-    call_kwargs = mock_run.call_args.kwargs
+    fakes.gemini_helper.delete_file.assert_called_once_with("files/mock123")
+    fakes.llm_client.build_uploaded_file.assert_called_once_with(
+        model_id="gemini-3.5-flash-lite",
+        file=mock_uploaded_file,
+    )
+    call_kwargs = fakes.llm_client.run.call_args.kwargs
     assert call_kwargs["model_id"] == "gemini-3.5-flash-lite"
     assert call_kwargs["target_language"] == "English"
     assert call_kwargs["thinking_level"] == "MINIMAL"
     prompt, uploaded = call_kwargs["content"]
     assert "detailed summary" in prompt
-    assert isinstance(uploaded, UploadedFile)
-    assert uploaded.file_id == mock_uploaded_file.uri
+    assert uploaded == "uploaded-file-sentinel"
 
 
 def test_summarize_with_file_retries_on_empty_response(mocker):
     """Test summarize_with_file raises RetryError on repeated empty model responses."""
-    mocker.patch("summary.check_quota", return_value=True)
+    summarizer, fakes = _make_summarizer(mocker)
     mocker.patch("tenacity.nap.time.sleep")
+    fakes.quota_manager.check_quota.return_value = True
     mock_audio_file = SimpleNamespace(
         name="files/mock123",
         uri="https://mock.uri",
         mime_type="audio/ogg",
     )
-    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("services.gemini_client", mock_client)
-    mocker.patch("summary.run_model", side_effect=AttributeError)
+    fakes.gemini_helper.upload_and_wait_for_file.return_value = mock_audio_file
+    fakes.llm_client.run.side_effect = AttributeError
 
     with pytest.raises(RetryError):
-        summarize_with_file(
+        summarizer.summarize_with_file(
             file="test_audio.ogg",
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -90,10 +109,11 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
 
 def test_summarize_text_from_transcript(mocker):
     """Test summarize_text feeds a transcript to the model."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.run_model", return_value="Transcript summary.")
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.llm_client.run.return_value = "Transcript summary."
 
-    result = summarize_text(
+    result = summarizer.summarize_text(
         text="Hello world. This is a transcript.",
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -113,10 +133,11 @@ def test_format_prefixed_summary_preserves_blank_line():
 
 def test_summarize_text_from_webpage(mocker):
     """Test summarize_text sends pre-parsed webpage content as a plain prompt."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mock_run = mocker.patch("summary.run_model", return_value="Webpage summary.")
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.llm_client.run.return_value = "Webpage summary."
 
-    result = summarize_text(
+    result = summarizer.summarize_text(
         text="Parsed page content.",
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -127,7 +148,7 @@ def test_summarize_text_from_webpage(mocker):
     )
 
     assert result == "Webpage summary."
-    call_kwargs = mock_run.call_args.kwargs
+    call_kwargs = fakes.llm_client.run.call_args.kwargs
     # A bare string, not a content list: the text path stays provider-agnostic.
     assert isinstance(call_kwargs["content"], str)
     assert "Parsed page content." in call_kwargs["content"]
@@ -136,12 +157,14 @@ def test_summarize_text_from_webpage(mocker):
 
 def test_summarize_with_file_upload_failure(mocker):
     """Test summarize_with_file raises when file upload fails."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mock_services_client = mocker.patch("services.gemini_client")
-    mock_services_client.files.upload.side_effect = Exception("Upload failed")
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.gemini_helper.upload_and_wait_for_file.side_effect = Exception(
+        "Upload failed",
+    )
 
     with pytest.raises(Exception, match="Upload failed"):
-        summarize_with_file(
+        summarizer.summarize_with_file(
             file="test_audio.ogg",
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -154,19 +177,17 @@ def test_summarize_with_file_upload_failure(mocker):
 
 def test_summarize_model_api_exception(mocker):
     """Test summarize_text raises RetryError when the provider returns an error."""
-    mocker.patch("summary.check_quota", return_value=True)
+    summarizer, fakes = _make_summarizer(mocker)
     mocker.patch("tenacity.nap.time.sleep")
-    mocker.patch(
-        "summary.run_model",
-        side_effect=ModelHTTPError(
-            status_code=400,
-            model_name="gemini-3.5-flash-lite",
-            body={"error": {"message": "Model unavailable"}},
-        ),
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.llm_client.run.side_effect = ModelHTTPError(
+        status_code=400,
+        model_name="gemini-3.5-flash-lite",
+        body={"error": {"message": "Model unavailable"}},
     )
 
     with pytest.raises(RetryError):
-        summarize_text(
+        summarizer.summarize_text(
             text="Hello",
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -178,26 +199,29 @@ def test_summarize_model_api_exception(mocker):
 
 
 def test_summarize_with_document_polling(mocker):
-    """Test summarize_with_document with PROCESSING polling loop."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
-    mocker.patch("summary.clean_up")
-    mocker.patch("services.time.sleep")
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("services.gemini_client", mock_client)
-    mock_file_proc = SimpleNamespace(state="PROCESSING", name="files/doc123")
+    """Test summarize_with_document reaches the model with the uploaded file.
+
+    Gemini's PROCESSING -> ACTIVE polling loop lives inside GeminiHelper (an
+    injected collaborator here) and is covered by
+    tests/test_services.py::test_upload_and_wait_for_file_polling; this test
+    only proves Summarizer wires the uploaded file's uri/mime_type through to
+    the model call and deletes it afterward.
+    """
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.downloader.download_tg.return_value = "temp_doc.pdf"
     mock_file_active = SimpleNamespace(
         state="ACTIVE",
         name="files/doc123",
         uri="https://mock.uri",
         mime_type="application/pdf",
     )
-    mock_client.files.upload.return_value = mock_file_proc
-    mock_client.files.get.return_value = mock_file_active
-    mock_run = mocker.patch("summary.run_model", return_value="Document summary")
+    fakes.gemini_helper.upload_and_wait_for_file.return_value = mock_file_active
+    fakes.llm_client.build_uploaded_file.return_value = "uploaded-file-sentinel"
+    fakes.llm_client.run.return_value = "Document summary"
     mock_tg_file = mocker.MagicMock()
 
-    result = summarize_with_document(
+    result = summarizer.summarize_with_document(
         file=mock_tg_file,
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -209,27 +233,26 @@ def test_summarize_with_document_polling(mocker):
     )
 
     assert result == "Document summary"
-    mock_client.files.delete.assert_called_once_with(name="files/doc123")
-    _, uploaded = mock_run.call_args.kwargs["content"]
-    assert isinstance(uploaded, UploadedFile)
-    assert uploaded.file_id == "https://mock.uri"
-    assert uploaded.media_type == "application/pdf"
+    fakes.gemini_helper.delete_file.assert_called_once_with("files/doc123")
+    _, uploaded = fakes.llm_client.run.call_args.kwargs["content"]
+    assert uploaded == "uploaded-file-sentinel"
+    fakes.llm_client.build_uploaded_file.assert_called_once_with(
+        model_id="gemini-3.5-flash-lite",
+        file=mock_file_active,
+    )
 
 
 def test_summarize_with_document_cleans_up_on_failed_processing(mocker):
     """Test summarize_with_document cleans up the downloaded file on failure."""
-    mocker.patch("summary.check_quota", return_value=True)
+    summarizer, fakes = _make_summarizer(mocker)
     mocker.patch("tenacity.nap.time.sleep")
-    mocker.patch("services.time.sleep")
-    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.downloader.download_tg.return_value = "temp_doc.pdf"
     mock_clean_up = mocker.patch("summary.clean_up")
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("services.gemini_client", mock_client)
-    mock_failed_file = SimpleNamespace(state="FAILED", name="files/doc123")
-    mock_client.files.upload.return_value = mock_failed_file
+    fakes.gemini_helper.upload_and_wait_for_file.side_effect = ValueError("FAILED")
 
     with pytest.raises(ValueError, match="FAILED"):
-        summarize_with_document(
+        summarizer.summarize_with_document(
             file=mocker.MagicMock(),
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -245,19 +268,16 @@ def test_summarize_with_document_cleans_up_on_failed_processing(mocker):
 
 def test_summarize_youtube_always_attempts_transcript(mocker):
     """get_yt_transcript is always called for YouTube URLs (no user toggle)."""
+    summarizer, fakes = _make_summarizer(mocker)
     url = "https://youtube.com/watch?v=123"
-    mocker.patch("summary.check_quota", return_value=True)
-    mock_get_transcript = mocker.patch(
-        "summary.get_yt_transcript",
-        return_value=SimpleNamespace(text="YT Transcript", prefix="📹"),
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.yt_transcriber.get_transcript.return_value = SimpleNamespace(
+        text="YT Transcript",
+        prefix="📹",
     )
-    mocker.patch.object(
-        summary_module.summarizer,
-        "summarize_text",
-        return_value="Summary",
-    )
+    mocker.patch.object(summarizer, "summarize_text", return_value="Summary")
 
-    summarize(
+    summarizer.summarize(
         data=url,
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -267,24 +287,25 @@ def test_summarize_youtube_always_attempts_transcript(mocker):
         thinking_level="MINIMAL",
     )
 
-    mock_get_transcript.assert_called_once_with(url)
+    fakes.yt_transcriber.get_transcript.assert_called_once_with(url)
 
 
 def test_summarize_youtube_direct_transcript(mocker):
     """Test summarize() using direct YouTube transcript (📹 prefix)."""
+    summarizer, fakes = _make_summarizer(mocker)
     url = "https://youtube.com/watch?v=123"
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch(
-        "summary.get_yt_transcript",
-        return_value=SimpleNamespace(text="YT Transcript content", prefix="📹"),
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.yt_transcriber.get_transcript.return_value = SimpleNamespace(
+        text="YT Transcript content",
+        prefix="📹",
     )
     mock_sum_transcript = mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_text",
         return_value="- first point\n- second point",
     )
 
-    result = summarize(
+    result = summarizer.summarize(
         data=url,
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -309,19 +330,20 @@ def test_summarize_youtube_direct_transcript(mocker):
 
 def test_summarize_youtube_fallback_transcript_uses_fallback_prefix(mocker):
     """Test fallback YouTube transcript summaries use the 📺 prefix."""
+    summarizer, fakes = _make_summarizer(mocker)
     url = "https://youtube.com/watch?v=123"
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch(
-        "summary.get_yt_transcript",
-        return_value=SimpleNamespace(text="YT Transcript content", prefix="📺"),
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.yt_transcriber.get_transcript.return_value = SimpleNamespace(
+        text="YT Transcript content",
+        prefix="📺",
     )
     mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_text",
         return_value="- first point\n- second point",
     )
 
-    result = summarize(
+    result = summarizer.summarize(
         data=url,
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -336,27 +358,19 @@ def test_summarize_youtube_fallback_transcript_uses_fallback_prefix(mocker):
 
 def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
     """Test transcript summary retry errors do not trigger audio fallback paths."""
+    summarizer, fakes = _make_summarizer(mocker)
     url = "https://youtube.com/watch?v=123"
     retry_error = RetryError(mocker.MagicMock())
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch(
-        "summary.get_yt_transcript",
-        return_value=SimpleNamespace(text="YT Transcript content", prefix="📹"),
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.yt_transcriber.get_transcript.return_value = SimpleNamespace(
+        text="YT Transcript content",
+        prefix="📹",
     )
-    mock_download = mocker.patch("summary.download_yt")
-    mock_file_summary = mocker.patch.object(
-        summary_module.summarizer,
-        "summarize_with_file",
-    )
-    mock_transcribe = mocker.patch("summary.transcribe")
-    mocker.patch.object(
-        summary_module.summarizer,
-        "summarize_text",
-        side_effect=retry_error,
-    )
+    mock_file_summary = mocker.patch.object(summarizer, "summarize_with_file")
+    mocker.patch.object(summarizer, "summarize_text", side_effect=retry_error)
 
     with pytest.raises(RetryError):
-        summarize(
+        summarizer.summarize(
             data=url,
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -366,9 +380,9 @@ def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
             thinking_level="MINIMAL",
         )
 
-    mock_download.assert_not_called()
+    fakes.downloader.download_yt.assert_not_called()
     mock_file_summary.assert_not_called()
-    mock_transcribe.assert_not_called()
+    fakes.audio_transcriber.transcribe.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -383,19 +397,20 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(
     transcript_error,
 ):
     """Test summarize() falls back to downloading YouTube audio when transcript fetch fails."""
+    summarizer, fakes = _make_summarizer(mocker)
     url = "https://youtube.com/watch?v=123"
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.get_yt_transcript", side_effect=transcript_error)
-    mock_download = mocker.patch("summary.download_yt", return_value="downloaded.ogg")
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.yt_transcriber.get_transcript.side_effect = transcript_error
+    fakes.downloader.download_yt.return_value = "downloaded.ogg"
     mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_with_file",
         return_value="File summary",
     )
     mock_clean_up = mocker.patch("summary.clean_up")
     mock_logger = mocker.patch("summary.logger")
 
-    result = summarize(
+    result = summarizer.summarize(
         data=url,
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -406,7 +421,7 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(
     )
 
     assert result == "File summary"
-    mock_download.assert_called_once_with(url)
+    fakes.downloader.download_yt.assert_called_once_with(url)
     mock_clean_up.assert_called_once_with(file="downloaded.ogg")
     mock_logger.warning.assert_called_once_with(
         "get_yt_transcript failed, falling back to download: %s",
@@ -416,23 +431,24 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(
 
 def test_summarize_fallback_to_transcription(mocker):
     """Test summarize() fallback to transcription (📝 prefix) when file summary fails."""
-    mocker.patch("summary.check_quota", return_value=True)
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
     mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_with_file",
         side_effect=RetryError(mocker.MagicMock()),
     )
     mocker.patch("summary.generate_temporary_name", return_value="temp.ogg")
     mocker.patch("summary.compress_audio")
-    mocker.patch("summary.transcribe", return_value="Transcription text")
+    fakes.audio_transcriber.transcribe.return_value = "Transcription text"
     mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_text",
         return_value="- transcript point\n- follow-up point",
     )
     mock_clean_up = mocker.patch("summary.clean_up")
 
-    result = summarize(
+    result = summarizer.summarize(
         data="local_audio.ogg",
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -458,7 +474,8 @@ def test_summarize_routes_audio_around_a_model_that_cannot_read_it(mocker):
     No model in MODEL_SPECS is text-only today, so the registry is patched with a
     synthetic spec — this is the branch a non-audio provider would light up.
     """
-    mocker.patch("summary.check_quota", return_value=True)
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
     mocker.patch.dict(
         summary_module.MODEL_SPECS,
         {
@@ -469,21 +486,18 @@ def test_summarize_routes_audio_around_a_model_that_cannot_read_it(mocker):
             ),
         },
     )
-    mock_with_file = mocker.patch.object(
-        summary_module.summarizer,
-        "summarize_with_file",
-    )
+    mock_with_file = mocker.patch.object(summarizer, "summarize_with_file")
     mocker.patch("summary.generate_temporary_name", return_value="temp.ogg")
     mock_compress = mocker.patch("summary.compress_audio")
-    mocker.patch("summary.transcribe", return_value="Transcription text")
+    fakes.audio_transcriber.transcribe.return_value = "Transcription text"
     mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_text",
         return_value="- transcript point",
     )
     mocker.patch("summary.clean_up")
 
-    result = summarize(
+    result = summarizer.summarize(
         data="local_audio.ogg",
         model="text-only-1",
         prompt_key="basic_prompt_for_transcript",
@@ -507,7 +521,8 @@ def test_summarize_with_document_routes_audio_document_to_transcription(mocker):
     SUPPORTED_DOCUMENT_MIME_TYPES accepts audio/ogg, so the document path needs
     the same modality check as summarize().
     """
-    mocker.patch("summary.check_quota", return_value=True)
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
     mocker.patch.dict(
         summary_module.MODEL_SPECS,
         {
@@ -518,20 +533,19 @@ def test_summarize_with_document_routes_audio_document_to_transcription(mocker):
             ),
         },
     )
-    mock_download = mocker.patch("summary.download_tg", return_value="voice.ogg")
-    mock_upload = mocker.patch("summary.upload_and_wait_for_file")
+    fakes.downloader.download_tg.return_value = "voice.ogg"
     mocker.patch("summary.generate_temporary_name", return_value="temp.ogg")
     mocker.patch("summary.compress_audio")
-    mocker.patch("summary.transcribe", return_value="Transcription text")
+    fakes.audio_transcriber.transcribe.return_value = "Transcription text"
     mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_text",
         return_value="- transcript point",
     )
     mock_clean_up = mocker.patch("summary.clean_up")
     mock_tg_file = mocker.MagicMock()
 
-    result = summarize_with_document(
+    result = summarizer.summarize_with_document(
         file=mock_tg_file,
         model="text-only-1",
         prompt_key="basic_prompt_for_transcript",
@@ -543,8 +557,8 @@ def test_summarize_with_document_routes_audio_document_to_transcription(mocker):
     )
 
     assert result == "📝\n\n- transcript point"
-    mock_upload.assert_not_called()
-    mock_download.assert_called_once_with(mock_tg_file, ext=".ogg")
+    fakes.gemini_helper.upload_and_wait_for_file.assert_not_called()
+    fakes.downloader.download_tg.assert_called_once_with(mock_tg_file, ext=".ogg")
     mock_clean_up.assert_has_calls(
         [
             mocker.call(file="temp.ogg"),
@@ -555,9 +569,10 @@ def test_summarize_with_document_routes_audio_document_to_transcription(mocker):
 
 def test_summarize_fallback_cleans_up_temp_file_when_compress_fails(mocker):
     """Test summarize() cleans up the temp file even if compress_audio raises."""
-    mocker.patch("summary.check_quota", return_value=True)
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
     mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_with_file",
         side_effect=RetryError(mocker.MagicMock()),
     )
@@ -566,7 +581,7 @@ def test_summarize_fallback_cleans_up_temp_file_when_compress_fails(mocker):
     mock_clean_up = mocker.patch("summary.clean_up")
 
     with pytest.raises(RuntimeError):
-        summarize(
+        summarizer.summarize(
             data="local_audio.ogg",
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -581,17 +596,18 @@ def test_summarize_fallback_cleans_up_temp_file_when_compress_fails(mocker):
 
 def test_summarize_castro(mocker):
     """Test summarize() with Castro.fm URL."""
+    summarizer, fakes = _make_summarizer(mocker)
     url = "https://castro.fm/episode/123"
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.download_castro", return_value="downloaded.mp3")
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.downloader.download_castro.return_value = "downloaded.mp3"
     mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_with_file",
         return_value="Castro summary",
     )
     mocker.patch("summary.clean_up")
 
-    result = summarize(
+    result = summarizer.summarize(
         data=url,
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -611,16 +627,17 @@ def test_summarize_castro_www_host(mocker):
     "https://castro.fm/episode/" prefix check, so a www-prefixed link skipped
     download_castro and was passed to summarize_with_file as a file path.
     """
-    mocker.patch("summary.check_quota", return_value=True)
-    mock_download = mocker.patch("summary.download_castro", return_value="dl.mp3")
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.downloader.download_castro.return_value = "dl.mp3"
     mock_with_file = mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_with_file",
         return_value="Castro summary",
     )
     mocker.patch("summary.clean_up")
 
-    result = summarize(
+    result = summarizer.summarize(
         data="https://www.castro.fm/episode/123",
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -631,7 +648,9 @@ def test_summarize_castro_www_host(mocker):
     )
 
     assert result == "Castro summary"
-    mock_download.assert_called_once_with("https://www.castro.fm/episode/123")
+    fakes.downloader.download_castro.assert_called_once_with(
+        "https://www.castro.fm/episode/123",
+    )
     assert mock_with_file.call_args.kwargs["file"] == "dl.mp3"
 
 
@@ -641,23 +660,17 @@ def test_summarize_youtube_uppercase_host_uses_transcript(mocker):
     Regression: the old literal prefix check was case-sensitive, so an
     uppercase host bypassed the transcript path entirely.
     """
+    summarizer, fakes = _make_summarizer(mocker)
     url = "https://YouTube.com/watch?v=dQw4w9WgXcQ"
-    mocker.patch("summary.check_quota", return_value=True)
-    mock_transcript = mocker.patch(
-        "summary.get_yt_transcript",
-        return_value=PrefixedText(text="transcript text", prefix="📺"),
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.yt_transcriber.get_transcript.return_value = PrefixedText(
+        text="transcript text",
+        prefix="📺",
     )
-    mocker.patch.object(
-        summary_module.summarizer,
-        "summarize_text",
-        return_value="YT summary",
-    )
-    mock_with_file = mocker.patch.object(
-        summary_module.summarizer,
-        "summarize_with_file",
-    )
+    mocker.patch.object(summarizer, "summarize_text", return_value="YT summary")
+    mock_with_file = mocker.patch.object(summarizer, "summarize_with_file")
 
-    result = summarize(
+    result = summarizer.summarize(
         data=url,
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -668,17 +681,17 @@ def test_summarize_youtube_uppercase_host_uses_transcript(mocker):
     )
 
     assert result == "📺\n\nYT summary"
-    mock_transcript.assert_called_once_with(url)
+    fakes.yt_transcriber.get_transcript.assert_called_once_with(url)
     mock_with_file.assert_not_called()
 
 
 def test_summarize_preflight_blocks_before_download(mocker):
     """Test summarize() blocks zero-quota users before any network IO."""
-    mock_check = mocker.patch("summary.check_quota", side_effect=LimitExceededError)
-    mock_download = mocker.patch("summary.download_castro")
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.side_effect = LimitExceededError
 
     with pytest.raises(LimitExceededError):
-        summarize(
+        summarizer.summarize(
             data="https://castro.fm/episode/123",
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -688,27 +701,28 @@ def test_summarize_preflight_blocks_before_download(mocker):
             thinking_level="MINIMAL",
         )
 
-    mock_check.assert_called_once_with(user_id=1, daily_limit=0, quantity=0)
-    mock_download.assert_not_called()
+    fakes.quota_manager.check_quota.assert_called_once_with(
+        user_id=1,
+        daily_limit=0,
+        quantity=0,
+    )
+    fakes.downloader.download_castro.assert_not_called()
 
 
 def test_summarize_with_file_deletes_gemini_file_when_quota_check_fails(mocker):
     """Test summarize_with_file cleans up the uploaded Gemini file if consuming check fails."""
+    summarizer, fakes = _make_summarizer(mocker)
     mock_audio_file = SimpleNamespace(
         name="files/audio123",
         uri="https://mock.uri",
         mime_type="audio/ogg",
     )
-    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
+    fakes.gemini_helper.upload_and_wait_for_file.return_value = mock_audio_file
     mocker.patch("tenacity.nap.time.sleep")
-    mock_client = mocker.patch("summary.gemini_client")
-    mock_check = mocker.patch(
-        "summary.check_quota",
-        side_effect=[True, LimitExceededError],
-    )
+    fakes.quota_manager.check_quota.side_effect = [True, LimitExceededError]
 
     with pytest.raises(LimitExceededError):
-        summarize_with_file(
+        summarizer.summarize_with_file(
             file="test_audio.ogg",
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -718,19 +732,27 @@ def test_summarize_with_file_deletes_gemini_file_when_quota_check_fails(mocker):
             thinking_level="MINIMAL",
         )
 
-    assert mock_check.call_count == 2
-    mock_check.assert_any_call(user_id=1, daily_limit=5, quantity=0)
-    mock_check.assert_any_call(user_id=1, daily_limit=5, quantity=1)
-    mock_client.files.delete.assert_called_with(name="files/audio123")
+    assert fakes.quota_manager.check_quota.call_count == 2
+    fakes.quota_manager.check_quota.assert_any_call(
+        user_id=1,
+        daily_limit=5,
+        quantity=0,
+    )
+    fakes.quota_manager.check_quota.assert_any_call(
+        user_id=1,
+        daily_limit=5,
+        quantity=1,
+    )
+    fakes.gemini_helper.delete_file.assert_called_with("files/audio123")
 
 
 def test_summarize_with_document_preflight_blocks_before_download(mocker):
     """Test summarize_with_document blocks zero-quota users before download or upload."""
-    mock_check = mocker.patch("summary.check_quota", side_effect=LimitExceededError)
-    mock_download = mocker.patch("summary.download_tg")
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.side_effect = LimitExceededError
 
     with pytest.raises(LimitExceededError):
-        summarize_with_document(
+        summarizer.summarize_with_document(
             file=mocker.MagicMock(),
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -741,25 +763,29 @@ def test_summarize_with_document_preflight_blocks_before_download(mocker):
             thinking_level="MINIMAL",
         )
 
-    mock_check.assert_called_once_with(user_id=1, daily_limit=0, quantity=0)
-    mock_download.assert_not_called()
+    fakes.quota_manager.check_quota.assert_called_once_with(
+        user_id=1,
+        daily_limit=0,
+        quantity=0,
+    )
+    fakes.downloader.download_tg.assert_not_called()
 
 
 def test_summarize_with_file_logs_warning_on_delete_failure(mocker):
     """Test summarize_with_file logs a warning when Gemini file deletion fails but still returns the result."""
-    mocker.patch("summary.check_quota", return_value=True)
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
     mock_audio_file = SimpleNamespace(
         name="files/audio123",
         uri="https://mock.uri",
         mime_type="audio/ogg",
     )
-    mocker.patch("summary.upload_and_wait_for_file", return_value=mock_audio_file)
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("summary.run_model", return_value="summary text")
-    mock_client.files.delete.side_effect = Exception("delete failed")
+    fakes.gemini_helper.upload_and_wait_for_file.return_value = mock_audio_file
+    fakes.llm_client.run.return_value = "summary text"
+    fakes.gemini_helper.delete_file.side_effect = Exception("delete failed")
     mock_logger = mocker.patch("summary.logger")
 
-    result = summarize_with_file(
+    result = summarizer.summarize_with_file(
         file="test_audio.ogg",
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -770,18 +796,19 @@ def test_summarize_with_file_logs_warning_on_delete_failure(mocker):
     )
 
     assert result == "summary text"
-    mock_client.files.delete.assert_called_once_with(name="files/audio123")
+    fakes.gemini_helper.delete_file.assert_called_once_with("files/audio123")
     mock_logger.warning.assert_called_once()
 
 
 def test_summarize_text_raises_on_empty_response(mocker):
     """Test summarize_text raises RetryError on repeated empty model responses."""
-    mocker.patch("summary.check_quota", return_value=True)
+    summarizer, fakes = _make_summarizer(mocker)
     mocker.patch("tenacity.nap.time.sleep")
-    mocker.patch("summary.run_model", side_effect=AttributeError)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.llm_client.run.side_effect = AttributeError
 
     with pytest.raises(RetryError):
-        summarize_text(
+        summarizer.summarize_text(
             text="Hello world",
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -792,21 +819,24 @@ def test_summarize_text_raises_on_empty_response(mocker):
         )
 
 
-def test_summarize_with_document_raises_when_upload_name_none(mocker):
-    """Test summarize_with_document raises RetryError and skips file delete when upload name is None."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
+def test_summarize_with_document_raises_when_upload_metadata_incomplete(mocker):
+    """Test summarize_with_document raises RetryError and skips delete on bad metadata.
+
+    Which field was missing — name, uri or mime_type — is GeminiHelper's
+    concern, covered by tests/test_services.py::test_upload_and_wait_for_file_*.
+    All three surface here as one AttributeError, so this proves the only thing
+    Summarizer decides: it becomes a RetryError, and delete_file is never called
+    because document_file_name was never assigned.
+    """
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.downloader.download_tg.return_value = "temp_doc.pdf"
     mocker.patch("summary.clean_up")
     mocker.patch("tenacity.nap.time.sleep")
-    mocker.patch("services.time.sleep")
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("services.gemini_client", mock_client)
-    mock_file = mocker.MagicMock()
-    mock_file.name = None
-    mock_client.files.upload.return_value = mock_file
+    fakes.gemini_helper.upload_and_wait_for_file.side_effect = AttributeError
 
     with pytest.raises(RetryError):
-        summarize_with_document(
+        summarizer.summarize_with_document(
             file=mocker.MagicMock(),
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -817,89 +847,26 @@ def test_summarize_with_document_raises_when_upload_name_none(mocker):
             thinking_level="MINIMAL",
         )
 
-    mock_client.files.delete.assert_not_called()
-
-
-def test_summarize_with_document_raises_when_uri_none(mocker):
-    """Test summarize_with_document raises RetryError when uri is None."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
-    mocker.patch("summary.clean_up")
-    mocker.patch("tenacity.nap.time.sleep")
-    mocker.patch("services.time.sleep")
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("services.gemini_client", mock_client)
-    mock_file = SimpleNamespace(
-        state="ACTIVE",
-        name="files/doc123",
-        uri=None,
-        mime_type="application/pdf",
-    )
-    mock_client.files.upload.return_value = mock_file
-
-    with pytest.raises(RetryError):
-        summarize_with_document(
-            file=mocker.MagicMock(),
-            model="gemini-3.5-flash-lite",
-            prompt_key="basic_prompt_for_transcript",
-            target_language="English",
-            mime_type="application/pdf",
-            user_id=123,
-            daily_limit=10,
-            thinking_level="MINIMAL",
-        )
-
-
-def test_summarize_with_document_raises_when_mime_type_none(mocker):
-    """Test summarize_with_document raises RetryError when mime_type is None."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
-    mocker.patch("summary.clean_up")
-    mocker.patch("tenacity.nap.time.sleep")
-    mocker.patch("services.time.sleep")
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("services.gemini_client", mock_client)
-    mock_file = SimpleNamespace(
-        state="ACTIVE",
-        name="files/doc123",
-        uri="https://mock.uri",
-        mime_type=None,
-    )
-    mock_client.files.upload.return_value = mock_file
-
-    with pytest.raises(RetryError):
-        summarize_with_document(
-            file=mocker.MagicMock(),
-            model="gemini-3.5-flash-lite",
-            prompt_key="basic_prompt_for_transcript",
-            target_language="English",
-            mime_type="application/pdf",
-            user_id=123,
-            daily_limit=10,
-            thinking_level="MINIMAL",
-        )
+    fakes.gemini_helper.delete_file.assert_not_called()
 
 
 def test_summarize_with_document_raises_on_empty_response(mocker):
     """Test summarize_with_document raises RetryError when the model returns nothing."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.downloader.download_tg.return_value = "temp_doc.pdf"
     mocker.patch("summary.clean_up")
     mocker.patch("tenacity.nap.time.sleep")
-    mocker.patch("services.time.sleep")
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("services.gemini_client", mock_client)
-    mock_file = SimpleNamespace(
+    fakes.gemini_helper.upload_and_wait_for_file.return_value = SimpleNamespace(
         state="ACTIVE",
         name="files/doc123",
         uri="https://mock.uri",
         mime_type="application/pdf",
     )
-    mock_client.files.upload.return_value = mock_file
-    mocker.patch("summary.run_model", side_effect=AttributeError)
+    fakes.llm_client.run.side_effect = AttributeError
 
     with pytest.raises(RetryError):
-        summarize_with_document(
+        summarizer.summarize_with_document(
             file=mocker.MagicMock(),
             model="gemini-3.5-flash-lite",
             prompt_key="basic_prompt_for_transcript",
@@ -913,24 +880,21 @@ def test_summarize_with_document_raises_on_empty_response(mocker):
 
 def test_summarize_with_document_logs_warning_on_delete_failure(mocker):
     """Test summarize_with_document logs a warning when Gemini file deletion fails but still returns the result."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mocker.patch("summary.download_tg", return_value="temp_doc.pdf")
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.downloader.download_tg.return_value = "temp_doc.pdf"
     mocker.patch("summary.clean_up")
-    mocker.patch("services.time.sleep")
-    mock_client = mocker.patch("summary.gemini_client")
-    mocker.patch("services.gemini_client", mock_client)
-    mock_file = SimpleNamespace(
+    fakes.gemini_helper.upload_and_wait_for_file.return_value = SimpleNamespace(
         state="ACTIVE",
         name="files/doc123",
         uri="https://mock.uri",
         mime_type="application/pdf",
     )
-    mock_client.files.upload.return_value = mock_file
-    mocker.patch("summary.run_model", return_value="document summary")
-    mock_client.files.delete.side_effect = Exception("delete failed")
+    fakes.llm_client.run.return_value = "document summary"
+    fakes.gemini_helper.delete_file.side_effect = Exception("delete failed")
     mock_logger = mocker.patch("summary.logger")
 
-    result = summarize_with_document(
+    result = summarizer.summarize_with_document(
         file=mocker.MagicMock(),
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -942,26 +906,24 @@ def test_summarize_with_document_logs_warning_on_delete_failure(mocker):
     )
 
     assert result == "document summary"
-    mock_client.files.delete.assert_called_once_with(name="files/doc123")
+    fakes.gemini_helper.delete_file.assert_called_once_with("files/doc123")
     mock_logger.warning.assert_called_once()
 
 
 def test_summarize_with_telegram_file(mocker):
     """Test summarize() downloads a Telegram File object before summarizing."""
-    mocker.patch("summary.check_quota", return_value=True)
-    mock_download_tg = mocker.patch(
-        "summary.download_tg",
-        return_value="downloaded.ogg",
-    )
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.downloader.download_tg.return_value = "downloaded.ogg"
     mocker.patch.object(
-        summary_module.summarizer,
+        summarizer,
         "summarize_with_file",
         return_value="Telegram file summary",
     )
     mocker.patch("summary.clean_up")
     mock_tg_file = mocker.MagicMock(spec=File)
 
-    result = summarize(
+    result = summarizer.summarize(
         data=mock_tg_file,
         model="gemini-3.5-flash-lite",
         prompt_key="basic_prompt_for_transcript",
@@ -972,4 +934,4 @@ def test_summarize_with_telegram_file(mocker):
     )
 
     assert result == "Telegram file summary"
-    mock_download_tg.assert_called_once_with(mock_tg_file, ext=".ogg")
+    fakes.downloader.download_tg.assert_called_once_with(mock_tg_file, ext=".ogg")

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -267,7 +267,7 @@ def test_summarize_with_document_cleans_up_on_failed_processing(mocker):
 
 
 def test_summarize_youtube_always_attempts_transcript(mocker):
-    """get_yt_transcript is always called for YouTube URLs (no user toggle)."""
+    """get_transcript is always called for YouTube URLs (no user toggle)."""
     summarizer, fakes = _make_summarizer(mocker)
     url = "https://youtube.com/watch?v=123"
     fakes.quota_manager.check_quota.return_value = True
@@ -424,7 +424,7 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(
     fakes.downloader.download_yt.assert_called_once_with(url)
     mock_clean_up.assert_called_once_with(file="downloaded.ogg")
     mock_logger.warning.assert_called_once_with(
-        "get_yt_transcript failed, falling back to download: %s",
+        "get_transcript failed, falling back to download: %s",
         mocker.ANY,
     )
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -24,27 +24,43 @@ from transcription import (
     AudioTranscriber,
     YouTubeTranscriber,
     YtDlpBackend,
-    get_yt_transcript,
 )
 
 
-def test_yt_transcriber_wires_api_as_primary():
-    """Test the default transcriber uses the API as primary and yt-dlp as fallback."""
+def _make_transcriber():
+    """Return (transcriber, primary, fallback) wired to freshly constructed backends.
+
+    Callers patch fetch/fetch_via_api/fetch_via_ytdlp on the returned backends
+    so orchestration tests never touch the network or the module singletons.
+    """
+    primary = ApiBackend()
+    fallback = YtDlpBackend()
+    return YouTubeTranscriber(primary, fallback), primary, fallback
+
+
+def test_shim_transcriber_wires_api_as_primary():
+    """Test the module-level shim uses the API as primary and yt-dlp as fallback.
+
+    main.py still runs on the shim rather than the container, so its ordering
+    decides which prefix a summary carries. Delete with the shim (STG-135); the
+    container's own wiring is covered by tests/test_container.py.
+    """
     assert isinstance(transcription.yt_transcriber._primary, ApiBackend)
     assert isinstance(transcription.yt_transcriber._fallback, YtDlpBackend)
 
 
 def test_get_yt_transcript_uses_api_primary(mocker):
     """Test get_yt_transcript uses the API first and does not touch yt-dlp on success."""
+    transcriber, primary, fallback = _make_transcriber()
     mock_api = mocker.patch.object(
-        transcription.api_backend,
+        primary,
         "fetch_via_api",
         return_value="from api",
     )
-    mock_ytdlp = mocker.patch.object(transcription.ytdlp_backend, "fetch")
+    mock_ytdlp = mocker.patch.object(fallback, "fetch")
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-    result = get_yt_transcript(url)
+    result = transcriber.get_transcript(url)
 
     assert result == PrefixedText(text="from api", prefix="📺")
     mock_api.assert_called_once_with("dQw4w9WgXcQ")
@@ -65,18 +81,19 @@ def test_get_yt_transcript_falls_back_to_ytdlp(mocker, url):
     Parametrized across URL formats to confirm each resolves to the same
     video_id that is handed to the yt-dlp backend.
     """
+    transcriber, primary, fallback = _make_transcriber()
     mocker.patch.object(
-        transcription.api_backend,
+        primary,
         "fetch_via_api",
         side_effect=TranscriptsDisabled("dQw4w9WgXcQ"),
     )
     mock_ytdlp = mocker.patch.object(
-        transcription.ytdlp_backend,
+        fallback,
         "fetch_via_ytdlp",
         return_value="from fallback",
     )
 
-    result = get_yt_transcript(url)
+    result = transcriber.get_transcript(url)
 
     assert result == PrefixedText(text="from fallback", prefix="📹")
     mock_ytdlp.assert_called_once_with(url)
@@ -88,19 +105,20 @@ def test_get_yt_transcript_falls_back_on_unexpected_primary_error(mocker):
     A primary failure outside the known transcript-exception types (e.g. a raw
     network error) must still trigger the fallback rather than escaping.
     """
+    transcriber, primary, fallback = _make_transcriber()
     mocker.patch.object(
-        transcription.api_backend,
+        primary,
         "fetch_via_api",
         side_effect=ConnectionError("network down"),
     )
     mock_ytdlp = mocker.patch.object(
-        transcription.ytdlp_backend,
+        fallback,
         "fetch_via_ytdlp",
         return_value="from fallback",
     )
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-    result = get_yt_transcript(url)
+    result = transcriber.get_transcript(url)
 
     assert result == PrefixedText(text="from fallback", prefix="📹")
     mock_ytdlp.assert_called_once_with(url)
@@ -108,19 +126,20 @@ def test_get_yt_transcript_falls_back_on_unexpected_primary_error(mocker):
 
 def test_get_yt_transcript_falls_back_on_empty_primary(mocker):
     """Test get_yt_transcript falls back when the primary returns an empty transcript."""
+    transcriber, primary, fallback = _make_transcriber()
     mocker.patch.object(
-        transcription.api_backend,
+        primary,
         "fetch_via_api",
         return_value="   \n  ",
     )
     mock_ytdlp = mocker.patch.object(
-        transcription.ytdlp_backend,
+        fallback,
         "fetch_via_ytdlp",
         return_value="from fallback",
     )
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-    result = get_yt_transcript(url)
+    result = transcriber.get_transcript(url)
 
     assert result == PrefixedText(text="from fallback", prefix="📹")
     mock_ytdlp.assert_called_once_with(url)
@@ -128,47 +147,50 @@ def test_get_yt_transcript_falls_back_on_empty_primary(mocker):
 
 def test_get_yt_transcript_both_backends_fail_raises_error(mocker):
     """Test get_yt_transcript raises FetchTranscriptError chained from the fallback failure."""
+    transcriber, primary, fallback = _make_transcriber()
     api_error = TranscriptsDisabled("dQw4w9WgXcQ")
     ytdlp_error = DownloadError("no subs")
     mocker.patch.object(
-        transcription.api_backend,
+        primary,
         "fetch_via_api",
         side_effect=api_error,
     )
     mocker.patch.object(
-        transcription.ytdlp_backend,
+        fallback,
         "fetch_via_ytdlp",
         side_effect=ytdlp_error,
     )
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with pytest.raises(FetchTranscriptError) as exc_info:
-        get_yt_transcript(url)
+        transcriber.get_transcript(url)
 
     assert exc_info.value.__cause__ is ytdlp_error
 
 
 def test_get_yt_transcript_both_empty_raises_error(mocker):
     """Test get_yt_transcript raises FetchTranscriptError when both backends return empty."""
-    mocker.patch.object(transcription.api_backend, "fetch_via_api", return_value="")
+    transcriber, primary, fallback = _make_transcriber()
+    mocker.patch.object(primary, "fetch_via_api", return_value="")
     mocker.patch.object(
-        transcription.ytdlp_backend,
+        fallback,
         "fetch_via_ytdlp",
         return_value="  ",
     )
 
     url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with pytest.raises(FetchTranscriptError, match="Both transcript backends failed"):
-        get_yt_transcript(url)
+        transcriber.get_transcript(url)
 
 
 def test_get_yt_transcript_unknown_url(mocker):
     """Test get_yt_transcript raises ValueError for unknown URL formats."""
-    mock_api = mocker.patch.object(transcription.api_backend, "fetch")
-    mock_ytdlp = mocker.patch.object(transcription.ytdlp_backend, "fetch")
+    transcriber, primary, fallback = _make_transcriber()
+    mock_api = mocker.patch.object(primary, "fetch")
+    mock_ytdlp = mocker.patch.object(fallback, "fetch")
 
     with pytest.raises(ValueError, match="Unknown URL"):
-        get_yt_transcript("https://example.com/not-youtube")
+        transcriber.get_transcript("https://example.com/not-youtube")
 
     mock_api.assert_not_called()
     mock_ytdlp.assert_not_called()
@@ -192,7 +214,7 @@ def test_fetch_via_api_falls_back_to_other_languages(mocker):
 
     mock_formatter.return_value.format_transcript.return_value = "Hola"
 
-    result = transcription.api_backend.fetch_via_api("dQw4w9WgXcQ")
+    result = ApiBackend().fetch_via_api("dQw4w9WgXcQ")
 
     assert result == "Hola"
     # Verify it was called twice, once without languages, once with languages
@@ -300,6 +322,9 @@ def test_vtt_to_text_keeps_nonconsecutive_duplicates(tmp_path):
 
 def test_fetch_via_api_uses_proxy_when_configured(mocker):
     """Test fetch_via_api passes GenericProxyConfig when PROXY is set."""
+    # get_proxy() reads config.PROXIES, which python-dotenv backfills from the
+    # developer's real .env (conftest.py never sets PROXY) — patch it so the
+    # test result does not depend on what happens to be in that file.
     mocker.patch("transcription.get_proxy", return_value="http://proxy:8080")
     mock_proxy_cfg = mocker.patch("transcription.GenericProxyConfig")
     mock_ytt = mocker.patch("transcription.YouTubeTranscriptApi")
@@ -308,7 +333,7 @@ def test_fetch_via_api_uses_proxy_when_configured(mocker):
     ).return_value.format_transcript.return_value = "Hello"
     mock_ytt.return_value.fetch.return_value = []
 
-    result = transcription.api_backend.fetch_via_api("vid")
+    result = ApiBackend().fetch_via_api("vid")
 
     assert result == "Hello"
     mock_proxy_cfg.assert_called_once_with(https_url="http://proxy:8080")
@@ -317,7 +342,6 @@ def test_fetch_via_api_uses_proxy_when_configured(mocker):
 
 def test_fetch_via_ytdlp_download_error_logged_and_retried(mocker, tmp_path):
     """Test fetch_via_ytdlp retries DownloadError from yt-dlp twice then raises RetryError."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
@@ -330,7 +354,7 @@ def test_fetch_via_ytdlp_download_error_logged_and_retried(mocker, tmp_path):
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(RetryError):
-        transcription.ytdlp_backend.fetch_via_ytdlp(
+        YtDlpBackend().fetch_via_ytdlp(
             "https://www.youtube.com/watch?v=test",
         )
 
@@ -347,7 +371,6 @@ def test_fetch_via_ytdlp_unexpected_error_wrapped_and_retried(
     tmp_path,
 ):
     """Test fetch_via_ytdlp wraps non-DownloadError exceptions and retries."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
@@ -360,7 +383,7 @@ def test_fetch_via_ytdlp_unexpected_error_wrapped_and_retried(
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(RetryError):
-        transcription.ytdlp_backend.fetch_via_ytdlp(
+        YtDlpBackend().fetch_via_ytdlp(
             "https://www.youtube.com/watch?v=test",
         )
 
@@ -374,7 +397,6 @@ def test_fetch_via_ytdlp_unexpected_error_wrapped_and_retried(
 
 def test_fetch_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp_path):
     """Test fetch_via_ytdlp preserves original cause through RetryError on exhaustion."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
@@ -387,7 +409,7 @@ def test_fetch_via_ytdlp_unexpected_error_preserves_cause(mocker, tmp_path):
     ctx.download.side_effect = original_exc
 
     with pytest.raises(RetryError) as exc_info:
-        transcription.ytdlp_backend.fetch_via_ytdlp(
+        YtDlpBackend().fetch_via_ytdlp(
             "https://www.youtube.com/watch?v=test",
         )
 
@@ -401,7 +423,6 @@ def test_fetch_via_ytdlp_probe_download_error_logged_and_retried(
     tmp_path,
 ):
     """Test fetch_via_ytdlp retries probe DownloadError twice then raises RetryError."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
@@ -410,7 +431,7 @@ def test_fetch_via_ytdlp_probe_download_error_logged_and_retried(
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(RetryError):
-        transcription.ytdlp_backend.fetch_via_ytdlp(
+        YtDlpBackend().fetch_via_ytdlp(
             "https://www.youtube.com/watch?v=test",
         )
 
@@ -428,7 +449,6 @@ def test_fetch_via_ytdlp_probe_unexpected_error_wrapped_and_retried(
     tmp_path,
 ):
     """Test fetch_via_ytdlp wraps and retries unexpected errors from extract_info."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
@@ -438,7 +458,7 @@ def test_fetch_via_ytdlp_probe_unexpected_error_wrapped_and_retried(
     mock_logger = mocker.patch("transcription.logger")
 
     with pytest.raises(RetryError) as exc_info:
-        transcription.ytdlp_backend.fetch_via_ytdlp(
+        YtDlpBackend().fetch_via_ytdlp(
             "https://www.youtube.com/watch?v=test",
         )
 
@@ -456,8 +476,10 @@ def test_fetch_via_ytdlp_probe_unexpected_error_wrapped_and_retried(
 
 def test_fetch_via_ytdlp_succeeds_on_second_attempt(mocker, tmp_path):
     """Test fetch_via_ytdlp returns transcript when first probe fails but second succeeds."""
+    # Fixed name kept: the vtt fixture below is written under this name by
+    # MockYDL.download(), so the name must be known before the call for the
+    # production glob to find it — fetch_via_ytdlp never returns the temp name.
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("time.sleep")
 
@@ -488,12 +510,15 @@ def test_fetch_via_ytdlp_succeeds_on_second_attempt(mocker, tmp_path):
 
     mocker.patch("transcription.YoutubeDL", MockYDL)
 
-    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+    result = YtDlpBackend().fetch_via_ytdlp(
         "https://www.youtube.com/watch?v=test",
     )
 
     assert result == "Hello"
     assert MockYDL.attempt == 2
+    # Real clean_up runs (Path.cwd is patched to tmp_path above): the vtt
+    # fixture should be gone rather than merely asserting clean_up was called.
+    assert not vtt_path.exists()
 
 
 def test_fetch_via_api_propagates_non_retryable_error(mocker):
@@ -503,7 +528,7 @@ def test_fetch_via_api_propagates_non_retryable_error(mocker):
     mock_ytt.return_value.fetch.side_effect = TranscriptsDisabled("vid")
 
     with pytest.raises(TranscriptsDisabled):
-        transcription.api_backend.fetch_via_api("vid")
+        ApiBackend().fetch_via_api("vid")
 
 
 @pytest.mark.parametrize(
@@ -524,7 +549,7 @@ def test_fetch_via_api_retries_on_retryable_exception(mocker, exc):
     mock_ytt.return_value.fetch.side_effect = exc
 
     with pytest.raises(RetryError):
-        transcription.api_backend.fetch_via_api("vid")
+        ApiBackend().fetch_via_api("vid")
 
     assert mock_ytt.return_value.fetch.call_count == 2
 
@@ -532,7 +557,6 @@ def test_fetch_via_api_retries_on_retryable_exception(mocker, exc):
 def test_fetch_via_ytdlp_non_english_fallback(mocker, tmp_path):
     """Test fetch_via_ytdlp requests the available language when no English is offered."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
 
     vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
     vtt_path = tmp_path / "fake-uuid.fr.vtt"
@@ -560,18 +584,18 @@ def test_fetch_via_ytdlp_non_english_fallback(mocker, tmp_path):
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+    result = YtDlpBackend().fetch_via_ytdlp(
         "https://www.youtube.com/watch?v=test",
     )
 
     assert result == "Bonjour"
     assert download_calls == [["fr"]]
+    assert not vtt_path.exists()
 
 
 def test_fetch_via_ytdlp_prefers_english_when_available(mocker, tmp_path):
     """Test fetch_via_ytdlp picks English even when other languages are present."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
 
     vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHello\n"
     vtt_path = tmp_path / "fake-uuid.en.vtt"
@@ -599,12 +623,13 @@ def test_fetch_via_ytdlp_prefers_english_when_available(mocker, tmp_path):
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+    result = YtDlpBackend().fetch_via_ytdlp(
         "https://www.youtube.com/watch?v=test",
     )
 
     assert result == "Hello"
     assert download_calls == [["en"]]
+    assert not vtt_path.exists()
 
 
 def test_fetch_via_ytdlp_manual_prefers_original_language_over_first_key(
@@ -618,7 +643,6 @@ def test_fetch_via_ytdlp_manual_prefers_original_language_over_first_key(
     than the first dict key (which is insertion-order dependent).
     """
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
 
     vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nGuten Tag\n"
     vtt_path = tmp_path / "fake-uuid.de.vtt"
@@ -651,12 +675,13 @@ def test_fetch_via_ytdlp_manual_prefers_original_language_over_first_key(
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+    result = YtDlpBackend().fetch_via_ytdlp(
         "https://www.youtube.com/watch?v=test",
     )
 
     assert result == "Guten Tag"
     assert download_calls == [["de"]]
+    assert not vtt_path.exists()
 
 
 def test_fetch_via_ytdlp_auto_captions_uses_original_language(
@@ -670,7 +695,6 @@ def test_fetch_via_ytdlp_auto_captions_uses_original_language(
     language (info["language"]) rather than the translated "en" track.
     """
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
 
     vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
     vtt_path = tmp_path / "fake-uuid.fr.vtt"
@@ -702,12 +726,13 @@ def test_fetch_via_ytdlp_auto_captions_uses_original_language(
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+    result = YtDlpBackend().fetch_via_ytdlp(
         "https://www.youtube.com/watch?v=test",
     )
 
     assert result == "Bonjour"
     assert download_calls == [["fr"]]
+    assert not vtt_path.exists()
 
 
 def test_fetch_via_ytdlp_auto_captions_prefers_orig_key_when_language_missing(
@@ -720,7 +745,6 @@ def test_fetch_via_ytdlp_auto_captions_prefers_orig_key_when_language_missing(
     exists in automatic_captions, that key should be preferred over the first dict key.
     """
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
 
     vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHallo\n"
     vtt_path = tmp_path / "fake-uuid.de-orig.vtt"
@@ -752,12 +776,13 @@ def test_fetch_via_ytdlp_auto_captions_prefers_orig_key_when_language_missing(
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+    result = YtDlpBackend().fetch_via_ytdlp(
         "https://www.youtube.com/watch?v=test",
     )
 
     assert result == "Hallo"
     assert download_calls == [["de-orig"]]
+    assert not vtt_path.exists()
 
 
 def test_fetch_via_ytdlp_auto_captions_falls_back_to_first_key(
@@ -770,7 +795,6 @@ def test_fetch_via_ytdlp_auto_captions_falls_back_to_first_key(
     the first key in the dict is used as a last resort.
     """
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
 
     vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHola\n"
     vtt_path = tmp_path / "fake-uuid.es.vtt"
@@ -802,12 +826,13 @@ def test_fetch_via_ytdlp_auto_captions_falls_back_to_first_key(
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+    result = YtDlpBackend().fetch_via_ytdlp(
         "https://www.youtube.com/watch?v=test",
     )
 
     assert result == "Hola"
     assert download_calls == [["es"]]
+    assert not vtt_path.exists()
 
 
 def test_fetch_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_path):
@@ -818,7 +843,6 @@ def test_fetch_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_path):
     video's original-language automatic captions rather than requesting "live_chat".
     """
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
 
     vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
     vtt_path = tmp_path / "fake-uuid.fr.vtt"
@@ -850,24 +874,24 @@ def test_fetch_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_path):
     mocker.patch("transcription.YoutubeDL", MockYDL)
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
 
-    result = transcription.ytdlp_backend.fetch_via_ytdlp(
+    result = YtDlpBackend().fetch_via_ytdlp(
         "https://www.youtube.com/watch?v=test",
     )
 
     assert result == "Bonjour"
     assert download_calls == [["fr"]]
+    assert not vtt_path.exists()
 
 
 def test_fetch_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path):
     """Test fetch_via_ytdlp raises without calling download when no subtitles exist."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
     ctx.extract_info.return_value = {"subtitles": {}, "automatic_captions": {}}
 
     with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
-        transcription.ytdlp_backend.fetch_via_ytdlp(
+        YtDlpBackend().fetch_via_ytdlp(
             "https://www.youtube.com/watch?v=test",
         )
 
@@ -876,14 +900,13 @@ def test_fetch_via_ytdlp_no_subtitles_skips_download(mocker, tmp_path):
 
 def test_fetch_via_ytdlp_extract_info_none_raises(mocker, tmp_path):
     """Test fetch_via_ytdlp raises when extract_info returns None."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
     ctx.extract_info.return_value = None
 
     with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
-        transcription.ytdlp_backend.fetch_via_ytdlp(
+        YtDlpBackend().fetch_via_ytdlp(
             "https://www.youtube.com/watch?v=test",
         )
 
@@ -895,9 +918,12 @@ def test_fetch_via_ytdlp_vtt_read_error_raises_download_error(
     tmp_path,
 ):
     """Test fetch_via_ytdlp converts vtt_to_text OSError into DownloadError."""
+    # Fixed name kept: the vtt fixture below is pre-created on disk before the
+    # call, so the name must be known ahead of time (see the comment on
+    # test_fetch_via_ytdlp_succeeds_on_second_attempt for why it can't be
+    # obtained after the fact).
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-    mocker.patch("transcription.clean_up")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
     ctx.extract_info.return_value = {
@@ -905,20 +931,23 @@ def test_fetch_via_ytdlp_vtt_read_error_raises_download_error(
         "automatic_captions": {},
     }
     # create the vtt file so the glob finds it, but vtt_to_text raises OSError
-    (tmp_path / "fake-uuid.en.vtt").write_text("WEBVTT\n", encoding="utf-8")
+    vtt_path = tmp_path / "fake-uuid.en.vtt"
+    vtt_path.write_text("WEBVTT\n", encoding="utf-8")
     mocker.patch.object(YtDlpBackend, "_vtt_to_text", side_effect=OSError("disk full"))
 
     with pytest.raises(DownloadError, match="Failed to read downloaded VTT file"):
-        transcription.ytdlp_backend.fetch_via_ytdlp(
+        YtDlpBackend().fetch_via_ytdlp(
             "https://www.youtube.com/watch?v=test",
         )
+
+    # Real clean_up runs (Path.cwd is patched to tmp_path above): the vtt
+    # fixture should be gone rather than merely asserting clean_up was called.
+    assert not vtt_path.exists()
 
 
 def test_fetch_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_path):
     """Test fetch_via_ytdlp raises when download writes no vtt file."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-    mocker.patch("transcription.clean_up")
     mock_ydl_cls = mocker.patch("transcription.YoutubeDL")
     ctx = mock_ydl_cls.return_value.__enter__.return_value
     ctx.extract_info.return_value = {
@@ -928,7 +957,7 @@ def test_fetch_via_ytdlp_no_vtt_after_download_raises(mocker, tmp_path):
     # download() succeeds but writes nothing to tmp_path
 
     with pytest.raises(DownloadError, match="No subtitles available via yt-dlp"):
-        transcription.ytdlp_backend.fetch_via_ytdlp(
+        YtDlpBackend().fetch_via_ytdlp(
             "https://www.youtube.com/watch?v=test",
         )
 
@@ -941,7 +970,6 @@ def test_fetch_via_ytdlp_pins_proxy_across_probe_and_download(
 ):
     """Test fetch_via_ytdlp resolves the proxy once and reuses it for both YoutubeDL instances."""
     mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-    mocker.patch("transcription.clean_up")
     mocker.patch("transcription.Path.cwd", return_value=tmp_path)
     mocker.patch("transcription.get_proxy", return_value="http://proxy.example:8080")
 
@@ -958,7 +986,7 @@ def test_fetch_via_ytdlp_pins_proxy_across_probe_and_download(
         "automatic_captions": {},
     }
 
-    transcription.ytdlp_backend.fetch_via_ytdlp("https://www.youtube.com/watch?v=test")
+    YtDlpBackend().fetch_via_ytdlp("https://www.youtube.com/watch?v=test")
 
     assert mock_ydl_cls.call_count == 2
     probe_opts, download_opts = (call.args[0] for call in mock_ydl_cls.call_args_list)
@@ -971,6 +999,9 @@ def test_fetch_via_ytdlp_pins_proxy_across_probe_and_download(
         pp.get("key") == "FFmpegSubtitlesConvertor" and pp.get("format") == "vtt"
         for pp in download_opts.get("postprocessors", [])
     )
+    # Real clean_up runs (Path.cwd is patched to tmp_path above): the vtt
+    # fixture should be gone rather than merely asserting clean_up was called.
+    assert not vtt_path.exists()
 
 
 def test_transcribe_happy_path(mocker):

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -13,7 +13,6 @@ from youtube_transcript_api._errors import (
 )
 from yt_dlp.utils import DownloadError
 
-import transcription
 from domain import PrefixedText
 from exceptions import (
     FetchTranscriptError,
@@ -36,17 +35,6 @@ def _make_transcriber():
     primary = ApiBackend()
     fallback = YtDlpBackend()
     return YouTubeTranscriber(primary, fallback), primary, fallback
-
-
-def test_shim_transcriber_wires_api_as_primary():
-    """Test the module-level shim uses the API as primary and yt-dlp as fallback.
-
-    main.py still runs on the shim rather than the container, so its ordering
-    decides which prefix a summary carries. Delete with the shim (STG-135); the
-    container's own wiring is covered by tests/test_container.py.
-    """
-    assert isinstance(transcription.yt_transcriber._primary, ApiBackend)
-    assert isinstance(transcription.yt_transcriber._fallback, YtDlpBackend)
 
 
 def test_get_yt_transcript_uses_api_primary(mocker):


### PR DESCRIPTION
## **User description**
Finishes the half-done OOP migration started in #863. Every collaborator now arrives via `__init__`, wired once by a new composition root; the transitional singleton-and-alias shim is gone.

Closes STG-135.

## What changed

`src/container.py` (new) is the composition root: a frozen `Container` dataclass plus `build_container()`, which builds each collaborator once and reuses it, so the result is a single object graph rather than parallel ones. `main.build_app(container)` turns that graph into the running `BotApp`.

Ten vertical slices, one source module and its own test file each:

| Slice | Change |
|---|---|
| 1 | `Messenger`←bot, `QuotaManager`←rate_limiter, `GeminiHelper`←gemini_client, new `Tracer`←langfuse_client |
| 2 | `UserRepository`←session factory |
| 3 | `LLMClient`←gemini_client; module-level `_agent` and the `@lru_cache`'d model builder become instance state |
| 4 | `Downloader`←tg_api_token |
| 5 | `WebParser` wired into the container |
| 6 | Transcription singletons dropped from the tests |
| 7 | `Summarizer`←6 collaborators; `GeminiHelper.delete_file` added so `summary.py` holds no Gemini client |
| 8 | Handler free functions → `MessageHandlers` class ←6 collaborators |
| 9 | `main.py` → `BotApp` + `register()` + `build_app()`; `__main__` is 4 lines |
| 10 | All 12 singletons and 26 aliases deleted |

Then three commits addressing review findings — two stale references to names slice 10 deleted, a missing `user_repo` wiring assertion, and the five duplicated auth-gate lambdas in `register()` collapsed into `BotApp._authorized`.

## Why the phasing differs from the issue

The issue proposed all source changes first, then one test file per phase. That cannot stay green. The alias shim preserves *importer* patches (`mocker.patch("handlers.summarize")`), but the moment a call site becomes `self._quota.check_quota(...)`, `mocker.patch("summary.check_quota")` silently stops intercepting and the real collaborator runs — roughly 233 of 446 patch sites. A source-only phase 1 would leave the suite red, so the work shipped as vertical slices instead.

## Numbers

- 277 tests passing, 100% line coverage across all 16 `src/` modules (1117 statements, 0 missed)
- `mocker.patch("module.name")` string sites: 446 → 198
- Module-level singletons 12 → 0; alias assignments 26 → 0
- Of the 198 remaining string targets: 127 third-party/stdlib boundaries, 52 `utils` free functions, 9 module loggers, 10 `utils` internals inside `test_utils.py`
- `main.py`'s boot path is now covered — `register()`, `run()`, `shutdown()` and `build_app` were previously unreachable inside the coverage-excluded `__main__`

## Two deliberate exemptions

Both are decisions, not oversights, and both are stated in `docs/context/architecture.md`:

- **`config.py` keeps the third-party clients.** The issue explicitly permits an extended `config.py`, and moving client construction would have forced `main.py`'s decorators into a registration function several slices early. `container.py`, not `config.py`, is the composition root.
- **`database.engine` / `Session` stay module-level.** They are a factory and its engine that the container injects, not a service singleton.

`utils.py` also stays free functions — wrapping stdlib-grade helpers in a class is the over-engineering the issue warns against. 52 patch sites remain there by design.

## Reviewer notes

- The migration is mechanical: every deleted module-level name (`parse_url`, `send_answer`, `check_quota`, `transcribe`, `get_yt_transcript`, …) was a one-line delegation to the method now called directly. Handler registration order, all eight `message_handler` kwargs, and every user-facing reply string are unchanged.
- `pyproject.toml` gains `tests` as an import root in two places — pytest's `pythonpath` so `tests/helpers.py` resolves, and ruff's `src` so isort files it as first-party.
- Live smoke test was run against the real bot after slice 9: it boots, registers 8 handlers, and answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized application setup for more consistent service behavior.
  * Updated message handling, downloads, transcription, summarization, and tracing components.
  * Improved startup, shutdown, cleanup, authorization, and quota-handling behavior.

* **Documentation**
  * Updated architecture and style guidance for the revised application structure.

* **Tests**
  * Expanded coverage for application setup, message routing, authorization, persistence, cleanup, configuration, and service integrations.
  * Added integration coverage for complete application wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Complete the migration to an injected application object graph

### What Changed
- The bot now builds its collaborators once at startup and passes them into the application, message handlers, summarizer, database access, downloads, parsing, transcription, quotas, tracing, and model calls.
- Telegram commands and content handling continue to provide the same user responses, while authorization, message routing, error handling, cleanup, and tracing are managed by the running application.
- Service modules no longer create hidden shared instances; each application uses the configured clients and credentials supplied at startup.
- Tests now exercise isolated service instances and real database session factories, including cleanup of downloaded transcript files.

### Impact
`✅ One consistent service graph per bot process`
`✅ Isolated test and application clients`
`✅ Fewer hidden shared-state failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
