### PR TITLE
Remove dead code and collapse duplication in src and tests

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -55,7 +55,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
 | `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
 | `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (MIME, file upload/poll), `Tracer` (Langfuse root span per message). |
-| `container.py` | `Container` + `build_container()` — the composition root; wires every collaborator, including the `bot` client, to `config`'s clients. |
+| `container.py` | `Container` + `build_container()` — the composition root; wires every collaborator to `config`'s clients. `Container` carries only the five roots `BotApp` holds (`bot`, `quota_manager`, `tracer`, `user_repo`, `handlers`); the rest of the graph is reached through `handlers`. |
 | `database.py` | `UserRepository` — users table access (SQLAlchemy + Postgres). |
 | `models.py` | `UsersOrm` — the single `users` table (id, approval, per-user settings, `daily_limit`). |
 | `exceptions.py` | Domain exceptions: `LimitExceededError`, `WebParseError`, `TranscriptDownloadError`, `FetchTranscriptError`. |

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -35,6 +35,9 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
   registry (`config.MODEL_SPECS`) is what decides which provider serves a model id.
   Only Gemini models are registered today; the seam exists so adding one from another
   provider is a registry row plus a dependency extra, not a rewrite of `summary.py`.
+  More providers are planned, so the non-Google branches in `llm.py` stay even though
+  `ModelSpec.provider` is `Literal["google"]` and nothing can reach them yet — they are
+  covered by tests that fabricate a spec, and are **not** dead code to clean up.
   The Gemini Files API is still called directly (`services.GeminiHelper`), because
   base64-inlining a 20 MB Telegram file inflates it past the inline-request limit.
 - **PostgreSQL for persistent user data, Valkey for ephemeral rate-limit counters** —

--- a/src/config.py
+++ b/src/config.py
@@ -73,9 +73,11 @@ class ModelSpec:
 
     `provider` names the pydantic-ai provider the model is reached through. It
     dispatches in three places, all of which a new provider has to answer for:
-    `llm._build_model` (which raises for a provider it cannot build),
+    `llm.LLMClient.build_model` (which raises for a provider it cannot build),
     `llm.LLMClient.build_settings`, and `llm.LLMClient.build_uploaded_file`
-    (which serves the Gemini Files API only).
+    (which serves the Gemini Files API only). Only `"google"` is registered
+    today, so each non-Google branch is unreachable until the `Literal` widens
+    — they are the seam for the next provider, not dead code to remove.
     `supports_audio` is False for text-only models, which routes spoken content
     through Replicate transcription instead of a native file upload.
     """

--- a/src/container.py
+++ b/src/container.py
@@ -22,20 +22,16 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class Container:
-    """The wired-up collaborators the application runs on."""
+    """The wired-up collaborators `main.build_app` runs on.
+
+    Only the roots BotApp holds directly; everything else in the graph is reached
+    through `handlers`, which owns the collaborators it needs.
+    """
 
     bot: telebot.TeleBot
-    messenger: Messenger
     quota_manager: QuotaManager
-    gemini_helper: GeminiHelper
     tracer: Tracer
     user_repo: UserRepository
-    llm_client: LLMClient
-    downloader: Downloader
-    web_parser: WebParser
-    audio_transcriber: AudioTranscriber
-    yt_transcriber: YouTubeTranscriber
-    summarizer: Summarizer
     handlers: MessageHandlers
 
 
@@ -64,17 +60,9 @@ def build_container() -> Container:
     )
     return Container(
         bot=bot,
-        messenger=messenger,
         quota_manager=quota_manager,
-        gemini_helper=gemini_helper,
         tracer=Tracer(config.langfuse_client),
         user_repo=UserRepository(database.Session),
-        llm_client=llm_client,
-        downloader=downloader,
-        web_parser=web_parser,
-        audio_transcriber=audio_transcriber,
-        yt_transcriber=yt_transcriber,
-        summarizer=summarizer,
         handlers=MessageHandlers(
             bot,
             messenger,

--- a/src/services.py
+++ b/src/services.py
@@ -160,9 +160,12 @@ class GeminiHelper:
         self,
         file: str,
         mime_type: str,
-        sleep_time: int,
+        sleep_time: int = 10,
     ) -> types.File:
-        """Upload a file to Gemini and wait for processing to finish."""
+        """Upload a file to Gemini and wait for processing to finish.
+
+        `sleep_time` is the interval between polls of the processing state.
+        """
         uploaded = self._client.files.upload(
             file=file,
             config={"mime_type": mime_type},

--- a/src/services.py
+++ b/src/services.py
@@ -75,16 +75,17 @@ class Messenger:
     def send_answer(self, message: Message, answer: str) -> None:
         """Send a response message, splitting at Telegram's 4 096-code-unit limit."""
         text, entities = convert(answer)
-        chunks_iter = iter(split_entities(text, entities, max_utf16_len=4096))
-        current = next(chunks_iter, None)
-        while current is not None:
-            chunk_text, chunk_entities = current
-            serialized_entities = [entity.to_dict() for entity in chunk_entities]
-            self._reply_with_retry(message, chunk_text, entities=serialized_entities)
-            next_chunk = next(chunks_iter, None)
-            if next_chunk is not None:
+        for index, (chunk_text, chunk_entities) in enumerate(
+            split_entities(text, entities, max_utf16_len=4096),
+        ):
+            # Pace the follow-up chunks; Telegram throttles back-to-back sends.
+            if index:
                 time.sleep(1)
-            current = next_chunk
+            self._reply_with_retry(
+                message,
+                chunk_text,
+                entities=[entity.to_dict() for entity in chunk_entities],
+            )
 
 
 class QuotaManager:
@@ -99,8 +100,13 @@ class QuotaManager:
         self._rate_limiter = rate_limiter
         self._per_minute_rate = per_minute_rate
 
-    def check_quota(self, user_id: int, daily_limit: int, quantity: int = 1) -> bool:
-        """Enforce rate limits; raise if daily exceeded; sleep on per-minute."""
+    def check_quota(self, user_id: int, daily_limit: int, quantity: int = 1) -> None:
+        """Enforce rate limits; raise if daily exceeded; sleep on per-minute.
+
+        Raises:
+            LimitExceededError: If the user's daily budget is already spent.
+
+        """
         if daily_limit <= 0:
             msg = "The daily limit for requests has been exceeded"
             raise LimitExceededError(msg)
@@ -126,7 +132,6 @@ class QuotaManager:
                 MINUTE_LIMIT_KEY,
             )
             time.sleep(max(0.0, stats.reset_time - time.time()))
-        return True
 
     def get_remaining_quota(self, user_id: int, daily_limit: int) -> int:
         """Return remaining daily requests for a user without consuming quota."""

--- a/src/summary.py
+++ b/src/summary.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from textwrap import dedent
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, cast
 
 from curl_cffi.requests.exceptions import ConnectionError as CurlConnectionError
 from curl_cffi.requests.exceptions import SSLError as CurlSSLError
@@ -38,9 +38,6 @@ tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 
 class Summarizer:
     """Generates model-backed summaries from audio, video, documents, and URLs."""
-
-    # How long to wait between polls of the provider's file-processing state.
-    _UPLOAD_POLL_SECONDS: ClassVar[int] = 10
 
     def __init__(
         self,
@@ -80,7 +77,6 @@ class Summarizer:
         uploaded = self._gemini_helper.upload_and_wait_for_file(
             file=file,
             mime_type=mime_type,
-            sleep_time=self._UPLOAD_POLL_SECONDS,
         )
         uploaded_name = cast("str", uploaded.name)
         try:
@@ -133,10 +129,11 @@ class Summarizer:
         """Summarize audio content by uploading it to the provider's file API.
 
         Raises:
-            AttributeError: If the model returns an empty response, or the upload
-                helper reports incomplete file metadata.
             ValueError: If the provider reports a failed processing state.
-            RetryError: If transient model or network errors persist after retries.
+            RetryError: If transient model or network errors persist, or the
+                model keeps returning an empty response, or the upload helper
+                keeps reporting incomplete file metadata. Those three surface as
+                `AttributeError`, which the decorator retries and then wraps.
 
         """
         self._quota_manager.check_quota(
@@ -177,8 +174,9 @@ class Summarizer:
         """Summarize already-extracted text (a transcript or webpage content).
 
         Raises:
-            AttributeError: If the model returns an empty response.
-            RetryError: If transient model or network errors persist after retries.
+            RetryError: If transient model errors persist, or the model keeps
+                returning an empty response — the `AttributeError` that stands
+                for it is retried and then wrapped, never re-raised.
 
         """
         prompt = (f"{dedent(PROMPTS[prompt_key])} {text}").strip()
@@ -227,10 +225,10 @@ class Summarizer:
         transcription path instead, and so carry the 📝 prefix.
 
         Raises:
-            AttributeError: If the provider returns incomplete file metadata, or
-                the model returns an empty response.
             ValueError: If the document processing fails on the provider's side.
-            RetryError: If the operation fails after all retry attempts.
+            RetryError: If the operation fails after all retry attempts —
+                including incomplete file metadata and an empty model response,
+                which arrive as a retried, then wrapped, `AttributeError`.
 
         """
         self._quota_manager.check_quota(

--- a/src/summary.py
+++ b/src/summary.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from textwrap import dedent
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from curl_cffi.requests.exceptions import ConnectionError as CurlConnectionError
 from curl_cffi.requests.exceptions import SSLError as CurlSSLError
@@ -39,6 +39,9 @@ tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 class Summarizer:
     """Generates model-backed summaries from audio, video, documents, and URLs."""
 
+    # How long to wait between polls of the provider's file-processing state.
+    _UPLOAD_POLL_SECONDS: ClassVar[int] = 10
+
     def __init__(
         self,
         quota_manager: QuotaManager,
@@ -55,6 +58,58 @@ class Summarizer:
         self._downloader = downloader
         self._audio_transcriber = audio_transcriber
         self._yt_transcriber = yt_transcriber
+
+    def _summarize_uploaded_file(
+        self,
+        file: str,
+        mime_type: str,
+        model: str,
+        prompt_key: str,
+        target_language: str,
+        user_id: int,
+        daily_limit: int,
+        thinking_level: str,
+    ) -> str:
+        """Upload a local file to the provider, summarize it, then delete the upload.
+
+        Shared by the audio and document paths; the caller owns `file` on disk,
+        has already run the non-consuming quota pre-check, and carries the
+        `@retry` this runs under — so this method must stay undecorated.
+        """
+        prompt = dedent(PROMPTS[prompt_key]).strip()
+        uploaded = self._gemini_helper.upload_and_wait_for_file(
+            file=file,
+            mime_type=mime_type,
+            sleep_time=self._UPLOAD_POLL_SECONDS,
+        )
+        uploaded_name = cast("str", uploaded.name)
+        try:
+            self._quota_manager.check_quota(
+                user_id=user_id,
+                daily_limit=daily_limit,
+                quantity=1,
+            )
+            return self._llm_client.run(
+                content=[
+                    prompt,
+                    self._llm_client.build_uploaded_file(
+                        model_id=model,
+                        file=uploaded,
+                    ),
+                ],
+                model_id=model,
+                target_language=target_language,
+                thinking_level=thinking_level,
+            )
+        finally:
+            try:
+                self._gemini_helper.delete_file(uploaded_name)
+            except Exception as e:
+                logger.warning(
+                    "Failed to delete Gemini file %s: %s",
+                    uploaded_name,
+                    e,
+                )
 
     @retry(
         stop=stop_after_attempt(2),
@@ -74,7 +129,6 @@ class Summarizer:
         user_id: int,
         daily_limit: int,
         thinking_level: str,
-        sleep_time: int = 10,
     ) -> str:
         """Summarize audio content by uploading it to the provider's file API.
 
@@ -90,41 +144,16 @@ class Summarizer:
             daily_limit=daily_limit,
             quantity=0,
         )
-        prompt = dedent(PROMPTS[prompt_key]).strip()
-        mime_type = self._gemini_helper.resolve_mime_type(file)
-        audio_file = self._gemini_helper.upload_and_wait_for_file(
+        return self._summarize_uploaded_file(
             file=file,
-            mime_type=mime_type,
-            sleep_time=sleep_time,
+            mime_type=self._gemini_helper.resolve_mime_type(file),
+            model=model,
+            prompt_key=prompt_key,
+            target_language=target_language,
+            user_id=user_id,
+            daily_limit=daily_limit,
+            thinking_level=thinking_level,
         )
-        audio_file_name = cast("str", audio_file.name)
-        try:
-            self._quota_manager.check_quota(
-                user_id=user_id,
-                daily_limit=daily_limit,
-                quantity=1,
-            )
-            return self._llm_client.run(
-                content=[
-                    prompt,
-                    self._llm_client.build_uploaded_file(
-                        model_id=model,
-                        file=audio_file,
-                    ),
-                ],
-                model_id=model,
-                target_language=target_language,
-                thinking_level=thinking_level,
-            )
-        finally:
-            try:
-                self._gemini_helper.delete_file(audio_file_name)
-            except Exception as e:
-                logger.warning(
-                    "Failed to delete Gemini file %s: %s",
-                    audio_file_name,
-                    e,
-                )
 
     @retry(
         stop=stop_after_attempt(2),
@@ -191,7 +220,6 @@ class Summarizer:
         user_id: int,
         daily_limit: int,
         thinking_level: str,
-        sleep_time: int = 10,
     ) -> str:
         """Summarize document content by uploading it to the provider's file API.
 
@@ -205,14 +233,12 @@ class Summarizer:
             RetryError: If the operation fails after all retry attempts.
 
         """
-        data: str | None = None
-        document_file_name: str | None = None
+        self._quota_manager.check_quota(
+            user_id=user_id,
+            daily_limit=daily_limit,
+            quantity=0,
+        )
         if mime_type.startswith("audio/") and not MODEL_SPECS[model].supports_audio:
-            self._quota_manager.check_quota(
-                user_id=user_id,
-                daily_limit=daily_limit,
-                quantity=0,
-            )
             data = self._downloader.download_tg(file, ext=".ogg")
             try:
                 return self._summarize_via_transcription(
@@ -226,50 +252,20 @@ class Summarizer:
                 )
             finally:
                 clean_up(file=data)
+        data = self._downloader.download_tg(file)
         try:
-            self._quota_manager.check_quota(
-                user_id=user_id,
-                daily_limit=daily_limit,
-                quantity=0,
-            )
-            data = self._downloader.download_tg(file)
-            prompt = dedent(PROMPTS[prompt_key]).strip()
-            document_file = self._gemini_helper.upload_and_wait_for_file(
+            return self._summarize_uploaded_file(
                 file=data,
                 mime_type=mime_type,
-                sleep_time=sleep_time,
-            )
-            document_file_name = document_file.name
-            self._quota_manager.check_quota(
+                model=model,
+                prompt_key=prompt_key,
+                target_language=target_language,
                 user_id=user_id,
                 daily_limit=daily_limit,
-                quantity=1,
-            )
-            summary = self._llm_client.run(
-                content=[
-                    prompt,
-                    self._llm_client.build_uploaded_file(
-                        model_id=model,
-                        file=document_file,
-                    ),
-                ],
-                model_id=model,
-                target_language=target_language,
                 thinking_level=thinking_level,
             )
         finally:
-            if document_file_name is not None:
-                try:
-                    self._gemini_helper.delete_file(document_file_name)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to delete Gemini file %s: %s",
-                        document_file_name,
-                        e,
-                    )
-            if data is not None:
-                clean_up(file=data)
-        return summary
+            clean_up(file=data)
 
     def summarize(
         self,

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -5,7 +5,7 @@ import re
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 from urllib.parse import parse_qs, urlsplit
 
 from defusedxml.ElementTree import ParseError
@@ -52,6 +52,9 @@ tenacity_logger = cast("tenacity_utils.LoggerProtocol", logger)
 class AudioTranscriber:
     """Transcribes audio files via the Replicate WhisperX model."""
 
+    # How long to wait between polls of the prediction's status.
+    _POLL_SECONDS: ClassVar[int] = 10
+
     def __init__(self, client: replicate_lib.Client) -> None:
         """Store the injected Replicate client."""
         self._client = client
@@ -63,7 +66,7 @@ class AudioTranscriber:
         before_sleep=before_sleep_log(tenacity_logger, log_level=logging.WARNING),
         reraise=False,
     )
-    def transcribe(self, file: str, sleep_time: int = 10) -> str:
+    def transcribe(self, file: str) -> str:
         """Transcribe an audio file with the WhisperX model on Replicate.
 
         Raises:
@@ -82,7 +85,7 @@ class AudioTranscriber:
             if prediction.status in ("failed", "canceled"):
                 raise ModelError(prediction)
             prediction.reload()
-            time.sleep(sleep_time)
+            time.sleep(self._POLL_SECONDS)
         if prediction.output is None:
             raise ModelError(prediction)
         segments = prediction.output.get("segments")

--- a/src/utils.py
+++ b/src/utils.py
@@ -77,7 +77,6 @@ def compress_audio(input_file: str, output_file: str) -> None:
         ],
         check=True,
         capture_output=False,
-        text=True,
     )
 
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -12,51 +12,49 @@ from transcription import ApiBackend, AudioTranscriber, YouTubeTranscriber, YtDl
 
 
 def test_build_container_returns_wired_container():
-    """build_container wires each collaborator to config's actual clients."""
+    """build_container wires each collaborator to config's actual clients.
+
+    The container exposes only what BotApp holds; the rest of the graph is
+    reached through `handlers`, so that is what the traversal below follows.
+    """
     container = build_container()
 
     assert isinstance(container, Container)
     assert container.bot is config.bot
-    assert isinstance(container.messenger, Messenger)
     assert isinstance(container.quota_manager, QuotaManager)
-    assert isinstance(container.gemini_helper, GeminiHelper)
     assert isinstance(container.tracer, Tracer)
     assert isinstance(container.user_repo, UserRepository)
-    assert isinstance(container.llm_client, LLMClient)
-    assert isinstance(container.downloader, Downloader)
-    assert isinstance(container.web_parser, WebParser)
-    assert isinstance(container.audio_transcriber, AudioTranscriber)
-    assert isinstance(container.yt_transcriber, YouTubeTranscriber)
-    assert isinstance(container.summarizer, Summarizer)
     assert isinstance(container.handlers, MessageHandlers)
 
-    assert container.messenger._bot is config.bot
     assert container.quota_manager._rate_limiter is config.rate_limiter
     assert container.quota_manager._per_minute_rate is config.per_minute_rate
-    assert container.gemini_helper._client is config.gemini_client
     assert container.tracer._client is config.langfuse_client
     assert container.user_repo._session_factory is database.Session
-    assert container.llm_client._client is config.gemini_client
-    assert container.downloader._tg_api_token is config.TG_API_TOKEN
-    assert container.web_parser._primary._client is config.exa_client
-    assert container.web_parser._fallback._client is config.tavily_client
-    assert container.audio_transcriber._client is config.replicate_client
-    assert isinstance(container.yt_transcriber._primary, ApiBackend)
-    assert isinstance(container.yt_transcriber._fallback, YtDlpBackend)
 
-    # The summarizer's collaborators must be the container's own instances,
-    # not freshly constructed duplicates, so the object graph is genuinely one.
-    assert container.summarizer._quota_manager is container.quota_manager
-    assert container.summarizer._gemini_helper is container.gemini_helper
-    assert container.summarizer._llm_client is container.llm_client
-    assert container.summarizer._downloader is container.downloader
-    assert container.summarizer._audio_transcriber is container.audio_transcriber
-    assert container.summarizer._yt_transcriber is container.yt_transcriber
+    handlers = container.handlers
+    assert handlers._bot is config.bot
+    assert isinstance(handlers._messenger, Messenger)
+    assert handlers._messenger._bot is config.bot
+    assert isinstance(handlers._web_parser, WebParser)
+    assert handlers._web_parser._primary._client is config.exa_client
+    assert handlers._web_parser._fallback._client is config.tavily_client
+    assert isinstance(handlers._downloader, Downloader)
+    assert handlers._downloader._tg_api_token is config.TG_API_TOKEN
 
-    # The handlers' collaborators must be the container's own instances too.
-    assert container.handlers._bot is config.bot
-    assert container.handlers._messenger is container.messenger
-    assert container.handlers._summarizer is container.summarizer
-    assert container.handlers._web_parser is container.web_parser
-    assert container.handlers._quota_manager is container.quota_manager
-    assert container.handlers._downloader is container.downloader
+    summarizer = handlers._summarizer
+    assert isinstance(summarizer, Summarizer)
+    assert isinstance(summarizer._gemini_helper, GeminiHelper)
+    assert summarizer._gemini_helper._client is config.gemini_client
+    assert isinstance(summarizer._llm_client, LLMClient)
+    assert summarizer._llm_client._client is config.gemini_client
+    assert isinstance(summarizer._audio_transcriber, AudioTranscriber)
+    assert summarizer._audio_transcriber._client is config.replicate_client
+    assert isinstance(summarizer._yt_transcriber, YouTubeTranscriber)
+    assert isinstance(summarizer._yt_transcriber._primary, ApiBackend)
+    assert isinstance(summarizer._yt_transcriber._fallback, YtDlpBackend)
+
+    # The shared collaborators must be one instance across the graph, not
+    # freshly constructed duplicates, so the object graph is genuinely one.
+    assert summarizer._quota_manager is container.quota_manager
+    assert summarizer._downloader is handlers._downloader
+    assert handlers._quota_manager is container.quota_manager

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,14 +1,6 @@
-from domain import PrefixedText, format_prefixed_summary
+from domain import format_prefixed_summary
 
 
 def test_format_prefixed_summary_preserves_blank_line():
     """Test prefixed summaries always include exactly one blank line."""
     assert format_prefixed_summary("📹", "\n- one\n- two\n") == "📹\n\n- one\n- two"
-
-
-def test_prefixed_text_pairs_content_with_its_source_prefix():
-    """Test PrefixedText carries the extracted text and its display prefix."""
-    result = PrefixedText(text="content", prefix="🌐")
-
-    assert result.text == "content"
-    assert result.prefix == "🌐"

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,14 @@
+from domain import PrefixedText, format_prefixed_summary
+
+
+def test_format_prefixed_summary_preserves_blank_line():
+    """Test prefixed summaries always include exactly one blank line."""
+    assert format_prefixed_summary("📹", "\n- one\n- two\n") == "📹\n\n- one\n- two"
+
+
+def test_prefixed_text_pairs_content_with_its_source_prefix():
+    """Test PrefixedText carries the extracted text and its display prefix."""
+    result = PrefixedText(text="content", prefix="🌐")
+
+    assert result.text == "content"
+    assert result.prefix == "🌐"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -7,11 +7,55 @@ from yt_dlp.utils import DownloadError
 
 from download import Downloader
 
+_AUDIO_ONLY_INFO = {
+    "formats": [
+        {
+            "format_id": "139",
+            "acodec": "mp4a.40.5",
+            "vcodec": "none",
+            "abr": 49,
+            "tbr": 49,
+        },
+    ],
+}
+
 
 @pytest.fixture
 def downloader():
     """Downloader instance wired to a fixed test token."""
     return Downloader("TEST_TOKEN")
+
+
+def _arrange_failing_yt_download(mocker, unlink_side_effect=None):
+    """Drive download_yt to a DownloadError on both attempts, leaving one partial.
+
+    The temp name is pinned so the glob pattern is known ahead of the call, and
+    the YoutubeDL contexts alternate extract_info/download across both attempts.
+
+    Returns:
+        (mock_cwd, partial) — the patched Path.cwd and the leftover file mock.
+
+    """
+    mock_ydl = mocker.patch("download.YoutubeDL")
+    mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
+    mocker.patch("time.sleep")  # suppress tenacity wait between retries
+
+    info_ydl = mocker.MagicMock()
+    info_ydl.extract_info.return_value = _AUDIO_ONLY_INFO
+    download_ydl = mocker.MagicMock()
+    download_ydl.download.side_effect = DownloadError("boom")
+    mock_ydl.side_effect = [
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
+        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
+    ]
+
+    partial = mocker.MagicMock(spec=Path)
+    partial.unlink.side_effect = unlink_side_effect
+    mock_cwd = mocker.patch("download.Path.cwd")
+    mock_cwd.return_value.glob.return_value = [partial]
+    return mock_cwd, partial
 
 
 def test_download_tg_happy_path(mocker, downloader):
@@ -149,37 +193,7 @@ def test_download_yt_extract_info_returns_none(mocker, downloader):
 
 def test_download_yt_removes_partials_on_download_error(mocker, downloader):
     """Test download_yt deletes yt-dlp partial files when the download fails."""
-    mock_ydl = mocker.patch("download.YoutubeDL")
-    # Fixed name kept: the glob assertion below checks the exact pattern built
-    # from the output stem, which must be known ahead of the call.
-    mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
-    mocker.patch("time.sleep")  # suppress tenacity wait between retries
-
-    info_ydl = mocker.MagicMock()
-    info_ydl.extract_info.return_value = {
-        "formats": [
-            {
-                "format_id": "139",
-                "acodec": "mp4a.40.5",
-                "vcodec": "none",
-                "abr": 49,
-                "tbr": 49,
-            },
-        ],
-    }
-    download_ydl = mocker.MagicMock()
-    download_ydl.download.side_effect = DownloadError("boom")
-    # extract_info + download contexts alternate across the two retry attempts.
-    mock_ydl.side_effect = [
-        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
-        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
-        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
-        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
-    ]
-
-    partial = mocker.MagicMock(spec=Path)
-    mock_cwd = mocker.patch("download.Path.cwd")
-    mock_cwd.return_value.glob.return_value = [partial]
+    mock_cwd, partial = _arrange_failing_yt_download(mocker)
 
     with pytest.raises(RetryError):
         downloader.download_yt("https://youtube.com/watch?v=123")
@@ -190,36 +204,7 @@ def test_download_yt_removes_partials_on_download_error(mocker, downloader):
 
 def test_download_yt_unlink_oserror_does_not_hide_download_error(mocker, downloader):
     """Test that an OSError from unlink is suppressed and DownloadError still propagates."""
-    mock_ydl = mocker.patch("download.YoutubeDL")
-    # Fixed name kept: matches the pre-created partial file's expected stem.
-    mocker.patch("download.generate_temporary_name", return_value="temp_yt.mp3")
-    mocker.patch("time.sleep")
-
-    info_ydl = mocker.MagicMock()
-    info_ydl.extract_info.return_value = {
-        "formats": [
-            {
-                "format_id": "139",
-                "acodec": "mp4a.40.5",
-                "vcodec": "none",
-                "abr": 49,
-                "tbr": 49,
-            },
-        ],
-    }
-    download_ydl = mocker.MagicMock()
-    download_ydl.download.side_effect = DownloadError("boom")
-    mock_ydl.side_effect = [
-        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
-        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
-        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),
-        mocker.MagicMock(__enter__=mocker.MagicMock(return_value=download_ydl)),
-    ]
-
-    partial = mocker.MagicMock(spec=Path)
-    partial.unlink.side_effect = PermissionError("locked")
-    mock_cwd = mocker.patch("download.Path.cwd")
-    mock_cwd.return_value.glob.return_value = [partial]
+    _arrange_failing_yt_download(mocker, unlink_side_effect=PermissionError("locked"))
 
     # PermissionError from unlink must not surface; RetryError wraps DownloadError.
     with pytest.raises(RetryError):
@@ -231,17 +216,7 @@ def test_download_yt_keeps_file_on_success(mocker, downloader):
     mock_ydl = mocker.patch("download.YoutubeDL")
 
     info_ydl = mocker.MagicMock()
-    info_ydl.extract_info.return_value = {
-        "formats": [
-            {
-                "format_id": "139",
-                "acodec": "mp4a.40.5",
-                "vcodec": "none",
-                "abr": 49,
-                "tbr": 49,
-            },
-        ],
-    }
+    info_ydl.extract_info.return_value = _AUDIO_ONLY_INFO
     download_ydl = mocker.MagicMock()
     mock_ydl.side_effect = [
         mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -7,17 +7,24 @@ from yt_dlp.utils import DownloadError
 
 from download import Downloader
 
-_AUDIO_ONLY_INFO = {
-    "formats": [
-        {
-            "format_id": "139",
-            "acodec": "mp4a.40.5",
-            "vcodec": "none",
-            "abr": 49,
-            "tbr": 49,
-        },
-    ],
-}
+
+def _audio_only_info():
+    """Return a fresh single-audio-format extract_info payload.
+
+    A function, not a module constant: yt-dlp callers commonly annotate the info
+    dict in place, so a shared object would leak state between tests.
+    """
+    return {
+        "formats": [
+            {
+                "format_id": "139",
+                "acodec": "mp4a.40.5",
+                "vcodec": "none",
+                "abr": 49,
+                "tbr": 49,
+            },
+        ],
+    }
 
 
 @pytest.fixture
@@ -41,7 +48,7 @@ def _arrange_failing_yt_download(mocker, unlink_side_effect=None):
     mocker.patch("time.sleep")  # suppress tenacity wait between retries
 
     info_ydl = mocker.MagicMock()
-    info_ydl.extract_info.return_value = _AUDIO_ONLY_INFO
+    info_ydl.extract_info.return_value = _audio_only_info()
     download_ydl = mocker.MagicMock()
     download_ydl.download.side_effect = DownloadError("boom")
     mock_ydl.side_effect = [
@@ -216,7 +223,7 @@ def test_download_yt_keeps_file_on_success(mocker, downloader):
     mock_ydl = mocker.patch("download.YoutubeDL")
 
     info_ydl = mocker.MagicMock()
-    info_ydl.extract_info.return_value = _AUDIO_ONLY_INFO
+    info_ydl.extract_info.return_value = _audio_only_info()
     download_ydl = mocker.MagicMock()
     mock_ydl.side_effect = [
         mocker.MagicMock(__enter__=mocker.MagicMock(return_value=info_ydl)),

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -192,6 +192,9 @@ def test_handle_media_rejects_file_over_the_telegram_cap(
     getattr(handlers, handler_name)(msg, mocker.MagicMock())
 
     fakes.bot.reply_to.assert_called_once_with(msg, "File is too big.")
+    # The cap exists because Telegram's getFile refuses files above it, so the
+    # guard has to short-circuit before the fetch, not just before summarizing.
+    fakes.messenger.get_file_with_retry.assert_not_called()
     fakes.summarizer.summarize.assert_not_called()
 
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -8,7 +8,6 @@ from domain import PrefixedText
 from exceptions import LimitExceededError, WebParseError
 from handlers import MessageHandlers
 from helpers import make_app
-from utils import classify_url
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -168,22 +167,46 @@ def test_process_message_content_sends_textless_fallback(message_factory, mocker
     fakes.bot.send_message.assert_called_once_with(msg.chat.id, "No text to process.")
 
 
-def test_handle_audio_file_too_large(message_factory, mocker):
-    """Test that audio files over 20MB are rejected."""
-    msg = message_factory(content_type="audio")
-    msg.audio.file_size = 25_000_000
+# Every media handler funnels its size check through the one _fetch_media guard,
+# so the four content types share a single test rather than one apiece.
+@pytest.mark.parametrize(
+    ("content_type", "handler_name"),
+    [
+        ("audio", "handle_audio"),
+        ("voice", "handle_voice"),
+        ("video", "handle_video"),
+        ("video_note", "handle_video_note"),
+    ],
+)
+def test_handle_media_rejects_file_over_the_telegram_cap(
+    message_factory,
+    mocker,
+    content_type,
+    handler_name,
+):
+    """Test each media handler rejects a file above Telegram's 20MB getFile cap."""
+    msg = message_factory(content_type=content_type)
+    getattr(msg, content_type).file_size = 21 * 1024 * 1024
     handlers, fakes = _make_handlers(mocker)
-    user = mocker.MagicMock()
 
-    handlers.handle_audio(msg, user)
+    getattr(handlers, handler_name)(msg, mocker.MagicMock())
 
     fakes.bot.reply_to.assert_called_once_with(msg, "File is too big.")
     fakes.summarizer.summarize.assert_not_called()
 
 
-def test_handle_audio_happy_path(message_factory, mocker):
-    """Test successful audio file processing."""
-    msg = message_factory(content_type="audio")
+@pytest.mark.parametrize(
+    ("content_type", "handler_name"),
+    [("audio", "handle_audio"), ("voice", "handle_voice")],
+)
+def test_handle_media_summarizes_the_fetched_file(
+    message_factory,
+    mocker,
+    content_type,
+    handler_name,
+):
+    """Test audio and voice hand the fetched Telegram file straight to summarize."""
+    msg = message_factory(content_type=content_type)
     handlers, fakes = _make_handlers(mocker)
     user = mocker.MagicMock(
         approved=True,
@@ -194,7 +217,7 @@ def test_handle_audio_happy_path(message_factory, mocker):
     mock_file = mocker.MagicMock(spec=types.File)
     fakes.messenger.get_file_with_retry.return_value = mock_file
 
-    handlers.handle_audio(msg, user)
+    getattr(handlers, handler_name)(msg, user)
 
     assert fakes.summarizer.summarize.call_args.kwargs["data"] == mock_file
 
@@ -222,55 +245,6 @@ def test_handle_url_unsupported_pattern(message_factory, mocker):
 
     fakes.bot.send_message.assert_called_once_with(msg.chat.id, "No data to proceed.")
     fakes.summarizer.summarize_text.assert_not_called()
-
-
-def test_classify_url_uppercase_youtube_host():
-    """Test classify_url normalises uppercase YouTube hostnames to 'youtube'."""
-    assert classify_url("https://YOUTU.BE/dQw4w9WgXcQ") == "youtube"
-    assert classify_url("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "youtube"
-
-
-def test_classify_url_strips_www_prefix():
-    """Test classify_url routes www-prefixed media hosts to their media kind.
-
-    Regression: routing used to be duplicated, and the second classifier matched
-    three literal lowercase prefixes. A www-prefixed Castro or youtu.be link was
-    classified as media here, then failed the second check and reached the
-    Gemini file upload with the URL string as its file path.
-    """
-    assert classify_url("https://www.castro.fm/episode/123") == "castro"
-    assert classify_url("https://www.youtu.be/dQw4w9WgXcQ") == "youtube"
-
-
-def test_classify_url_castro_non_episode_path_is_web():
-    """Test classify_url only treats Castro /episode/ paths as media."""
-    assert classify_url("https://castro.fm/about") == "web"
-
-
-def test_classify_url_malformed_no_host():
-    """Test classify_url returns None for URLs with no parseable hostname."""
-    assert classify_url("https://") is None
-
-
-def test_classify_url_rejects_non_http_scheme():
-    """Test classify_url returns None for non-http(s) schemes."""
-    assert classify_url("ftp://example.com/file.txt") is None
-
-
-def test_classify_url_returns_none_for_unparseable_authority():
-    """Test classify_url returns None when urlsplit rejects the authority.
-
-    urlsplit raises ValueError on bracket-malformed hosts. Left uncaught it
-    escapes handle_url's kind check and reaches handle_message's catch-all, so
-    the user sees "Unexpected: ValueError" instead of "No data to proceed.".
-    """
-    assert classify_url("https://[") is None
-    assert classify_url("http://[::1") is None
-
-
-def test_classify_url_http_youtube_is_web():
-    """Test classify_url only treats https media hosts as media."""
-    assert classify_url("http://youtube.com/watch?v=dQw4w9WgXcQ") == "web"
 
 
 def test_handle_url_youtube_pattern(message_factory, mocker):
@@ -352,36 +326,6 @@ def test_handle_url_web_parse_error_skips_summarize(message_factory, mocker):
     fakes.summarizer.summarize_text.assert_not_called()
 
 
-def test_handle_voice_happy_path(message_factory, mocker):
-    """Test successful voice message processing."""
-    msg = message_factory(content_type="voice")
-    handlers, fakes = _make_handlers(mocker)
-    user = mocker.MagicMock(
-        approved=True,
-        summarizing_model="model",
-        prompt_key_for_summary="prompt",
-        target_language="English",
-    )
-    mock_file = mocker.MagicMock(spec=types.File)
-    fakes.messenger.get_file_with_retry.return_value = mock_file
-
-    handlers.handle_voice(msg, user)
-
-    assert fakes.summarizer.summarize.call_args.kwargs["data"] == mock_file
-
-
-def test_handle_voice_too_big(message_factory, mocker):
-    """Test voice message rejection when file exceeds limit (20MB)."""
-    msg = message_factory(content_type="voice")
-    msg.voice.file_size = 21 * 1024 * 1024
-    handlers, fakes = _make_handlers(mocker)
-    user = mocker.MagicMock()
-
-    handlers.handle_voice(msg, user)
-
-    fakes.bot.reply_to.assert_called_once_with(msg, "File is too big.")
-
-
 def test_handle_voice_missing_info(message_factory, mocker):
     """Test voice message rejection when voice attribute is missing."""
     msg = message_factory(content_type="text")
@@ -395,9 +339,18 @@ def test_handle_voice_missing_info(message_factory, mocker):
     fakes.bot.reply_to.assert_called_once_with(msg, "No voice message found.")
 
 
-def test_handle_video_happy_path_cleans_up_download(message_factory, mocker):
-    """Test video processing cleans up the downloaded temporary file."""
-    msg = message_factory(content_type="video")
+@pytest.mark.parametrize(
+    ("content_type", "handler_name"),
+    [("video", "handle_video"), ("video_note", "handle_video_note")],
+)
+def test_handle_video_like_cleans_up_both_temp_files(
+    message_factory,
+    mocker,
+    content_type,
+    handler_name,
+):
+    """Test video and video note both clean up the download and the compressed copy."""
+    msg = message_factory(content_type=content_type)
     handlers, fakes = _make_handlers(mocker)
     user = mocker.MagicMock(
         approved=True,
@@ -413,33 +366,7 @@ def test_handle_video_happy_path_cleans_up_download(message_factory, mocker):
     fakes.summarizer.summarize.return_value = "summary"
     mock_clean_up = mocker.patch("handlers.clean_up")
 
-    handlers.handle_video(msg, user)
-
-    assert mock_clean_up.call_args_list == [
-        mocker.call(file="downloaded.mp4"),
-        mocker.call(file="compressed.ogg"),
-    ]
-
-
-def test_handle_video_note_happy_path_cleans_up_download(message_factory, mocker):
-    """Test video note processing cleans up the downloaded temporary file."""
-    msg = message_factory(content_type="video_note")
-    handlers, fakes = _make_handlers(mocker)
-    user = mocker.MagicMock(
-        approved=True,
-        summarizing_model="model",
-        prompt_key_for_summary="prompt",
-        target_language="English",
-    )
-    mock_file = mocker.MagicMock(spec=types.File)
-    fakes.messenger.get_file_with_retry.return_value = mock_file
-    fakes.downloader.download_tg.return_value = "downloaded.mp4"
-    mocker.patch("handlers.generate_temporary_name", return_value="compressed.ogg")
-    mocker.patch("handlers.compress_audio")
-    fakes.summarizer.summarize.return_value = "summary"
-    mock_clean_up = mocker.patch("handlers.clean_up")
-
-    handlers.handle_video_note(msg, user)
+    getattr(handlers, handler_name)(msg, user)
 
     assert mock_clean_up.call_args_list == [
         mocker.call(file="downloaded.mp4"),
@@ -479,30 +406,6 @@ def test_handle_video_cleans_up_compressed_file_when_summarize_raises(
         mocker.call(file="downloaded.mp4"),
         mocker.call(file="compressed.ogg"),
     ]
-
-
-def test_handle_video_note_file_too_large(message_factory, mocker):
-    """Test video note rejection when file exceeds 20MB limit."""
-    msg = message_factory(content_type="video_note")
-    msg.video_note.file_size = 21 * 1024 * 1024
-    handlers, fakes = _make_handlers(mocker)
-    user = mocker.MagicMock()
-
-    handlers.handle_video_note(msg, user)
-
-    fakes.bot.reply_to.assert_called_once_with(msg, "File is too big.")
-
-
-def test_handle_video_file_too_large(message_factory, mocker):
-    """Test video rejection when file exceeds 20MB limit."""
-    msg = message_factory(content_type="video")
-    msg.video.file_size = 21 * 1024 * 1024
-    handlers, fakes = _make_handlers(mocker)
-    user = mocker.MagicMock()
-
-    handlers.handle_video(msg, user)
-
-    fakes.bot.reply_to.assert_called_once_with(msg, "File is too big.")
 
 
 def test_handle_message_limit_exceeded(message_factory, mocker):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -245,9 +245,8 @@ def test_check_quota_uses_per_user_redis_key(mocker):
     mock_rate_limiter.hit.return_value = True
     quota_manager = QuotaManager(mock_rate_limiter, parse_rate_limit("5 per minute"))
 
-    result = quota_manager.check_quota(user_id=456, daily_limit=5)
+    quota_manager.check_quota(user_id=456, daily_limit=5)
 
-    assert result is True
     assert mock_rate_limiter.hit.call_args_list[0].args[1] == "RPD:456"
 
 
@@ -273,9 +272,9 @@ def test_check_quota_precheck_rejects_an_exhausted_daily_window():
         parse_rate_limit("100 per minute"),
     )
 
-    assert quota_manager.check_quota(user_id=42, daily_limit=2, quantity=0) is True
-    assert quota_manager.check_quota(user_id=42, daily_limit=2, quantity=1) is True
-    assert quota_manager.check_quota(user_id=42, daily_limit=2, quantity=1) is True
+    quota_manager.check_quota(user_id=42, daily_limit=2, quantity=0)
+    quota_manager.check_quota(user_id=42, daily_limit=2, quantity=1)
+    quota_manager.check_quota(user_id=42, daily_limit=2, quantity=1)
 
     assert quota_manager.get_remaining_quota(user_id=42, daily_limit=2) == 0
     with pytest.raises(LimitExceededError):
@@ -290,7 +289,7 @@ def test_check_quota_precheck_consumes_nothing():
     )
 
     for _ in range(5):
-        assert quota_manager.check_quota(user_id=7, daily_limit=3, quantity=0) is True
+        quota_manager.check_quota(user_id=7, daily_limit=3, quantity=0)
 
     assert quota_manager.get_remaining_quota(user_id=7, daily_limit=3) == 3
 
@@ -313,9 +312,8 @@ def test_check_quota_sleeps_when_per_minute_limited(mocker):
     )
     quota_manager = QuotaManager(mock_rate_limiter, parse_rate_limit("5 per minute"))
 
-    result = quota_manager.check_quota(user_id=321, daily_limit=5)
+    quota_manager.check_quota(user_id=321, daily_limit=5)
 
-    assert result is True
     mock_sleep.assert_called_once_with(7.5)
 
 

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -37,6 +37,22 @@ def _make_summarizer(mocker):
     return summarizer, fakes
 
 
+def test_only_the_public_entry_points_carry_retry():
+    """Lock the retry topology: the shared helper must stay undecorated.
+
+    Both callers of _summarize_uploaded_file are themselves @retry-wrapped, so a
+    decorator here would nest a second layer. On a mixed failure sequence — one
+    the inner predicate skips and the outer retries, then one the inner retries —
+    the upload and its consuming quota check would run three times instead of
+    two, and Gemini bills failed calls. No behavioral test catches this: for a
+    single repeated exception type both topologies produce identical counts.
+    """
+    assert not hasattr(Summarizer._summarize_uploaded_file, "retry")
+    assert hasattr(Summarizer.summarize_with_file, "retry")
+    assert hasattr(Summarizer.summarize_with_document, "retry")
+    assert hasattr(Summarizer.summarize_text, "retry")
+
+
 def test_summarize_with_file_upload_and_model_call(mocker):
     """Test the complete summarize_with_file flow with the file API and model mocked."""
     summarizer, fakes = _make_summarizer(mocker)
@@ -66,7 +82,6 @@ def test_summarize_with_file_upload_and_model_call(mocker):
     fakes.gemini_helper.upload_and_wait_for_file.assert_called_once_with(
         file="test_audio.ogg",
         mime_type="audio/ogg",
-        sleep_time=10,
     )
     fakes.gemini_helper.delete_file.assert_called_once_with("files/mock123")
     fakes.llm_client.build_uploaded_file.assert_called_once_with(

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -9,7 +9,7 @@ import summary as summary_module
 from config import ModelSpec
 from domain import PrefixedText
 from exceptions import FetchTranscriptError, LimitExceededError
-from summary import Summarizer, format_prefixed_summary
+from summary import Summarizer
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -107,32 +107,12 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
         )
 
 
-def test_summarize_text_from_transcript(mocker):
-    """Test summarize_text feeds a transcript to the model."""
-    summarizer, fakes = _make_summarizer(mocker)
-    fakes.quota_manager.check_quota.return_value = True
-    fakes.llm_client.run.return_value = "Transcript summary."
-
-    result = summarizer.summarize_text(
-        text="Hello world. This is a transcript.",
-        model="gemini-3.5-flash-lite",
-        prompt_key="basic_prompt_for_transcript",
-        target_language="English",
-        user_id=123,
-        daily_limit=10,
-        thinking_level="MINIMAL",
-    )
-
-    assert result == "Transcript summary."
-
-
-def test_format_prefixed_summary_preserves_blank_line():
-    """Test prefixed summaries always include exactly one blank line."""
-    assert format_prefixed_summary("📹", "\n- one\n- two\n") == "📹\n\n- one\n- two"
-
-
 def test_summarize_text_from_webpage(mocker):
-    """Test summarize_text sends pre-parsed webpage content as a plain prompt."""
+    """Test summarize_text sends pre-parsed webpage content as a plain prompt.
+
+    The transcript paths reach the model through this same method, so this
+    covers them too — only the caller differs.
+    """
     summarizer, fakes = _make_summarizer(mocker)
     fakes.quota_manager.check_quota.return_value = True
     fakes.llm_client.run.return_value = "Webpage summary."
@@ -266,38 +246,17 @@ def test_summarize_with_document_cleans_up_on_failed_processing(mocker):
     mock_clean_up.assert_called_once_with(file="temp_doc.pdf")
 
 
-def test_summarize_youtube_always_attempts_transcript(mocker):
-    """get_transcript is always called for YouTube URLs (no user toggle)."""
-    summarizer, fakes = _make_summarizer(mocker)
-    url = "https://youtube.com/watch?v=123"
-    fakes.quota_manager.check_quota.return_value = True
-    fakes.yt_transcriber.get_transcript.return_value = SimpleNamespace(
-        text="YT Transcript",
-        prefix="📹",
-    )
-    mocker.patch.object(summarizer, "summarize_text", return_value="Summary")
-
-    summarizer.summarize(
-        data=url,
-        model="gemini-3.5-flash-lite",
-        prompt_key="basic_prompt_for_transcript",
-        target_language="English",
-        user_id=123,
-        daily_limit=10,
-        thinking_level="MINIMAL",
-    )
-
-    fakes.yt_transcriber.get_transcript.assert_called_once_with(url)
-
-
-def test_summarize_youtube_direct_transcript(mocker):
-    """Test summarize() using direct YouTube transcript (📹 prefix)."""
+# 📺 is the youtube_transcript_api primary, 📹 the yt-dlp fallback. Summarizer
+# does not pick either — it passes through whatever the transcriber reports.
+@pytest.mark.parametrize("prefix", ["📺", "📹"])
+def test_summarize_youtube_transcript_carries_the_backend_prefix(mocker, prefix):
+    """Test summarize() always tries the transcript and keeps its source prefix."""
     summarizer, fakes = _make_summarizer(mocker)
     url = "https://youtube.com/watch?v=123"
     fakes.quota_manager.check_quota.return_value = True
     fakes.yt_transcriber.get_transcript.return_value = SimpleNamespace(
         text="YT Transcript content",
-        prefix="📹",
+        prefix=prefix,
     )
     mock_sum_transcript = mocker.patch.object(
         summarizer,
@@ -315,8 +274,8 @@ def test_summarize_youtube_direct_transcript(mocker):
         thinking_level="MINIMAL",
     )
 
-    assert result.startswith("📹")
-    assert result == "📹\n\n- first point\n- second point"
+    assert result == f"{prefix}\n\n- first point\n- second point"
+    fakes.yt_transcriber.get_transcript.assert_called_once_with(url)
     mock_sum_transcript.assert_called_once_with(
         text="YT Transcript content",
         model="gemini-3.5-flash-lite",
@@ -326,34 +285,6 @@ def test_summarize_youtube_direct_transcript(mocker):
         daily_limit=10,
         thinking_level="MINIMAL",
     )
-
-
-def test_summarize_youtube_fallback_transcript_uses_fallback_prefix(mocker):
-    """Test fallback YouTube transcript summaries use the 📺 prefix."""
-    summarizer, fakes = _make_summarizer(mocker)
-    url = "https://youtube.com/watch?v=123"
-    fakes.quota_manager.check_quota.return_value = True
-    fakes.yt_transcriber.get_transcript.return_value = SimpleNamespace(
-        text="YT Transcript content",
-        prefix="📺",
-    )
-    mocker.patch.object(
-        summarizer,
-        "summarize_text",
-        return_value="- first point\n- second point",
-    )
-
-    result = summarizer.summarize(
-        data=url,
-        model="gemini-3.5-flash-lite",
-        prompt_key="basic_prompt_for_transcript",
-        target_language="English",
-        user_id=123,
-        daily_limit=10,
-        thinking_level="MINIMAL",
-    )
-
-    assert result == "📺\n\n- first point\n- second point"
 
 
 def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -26,6 +26,47 @@ from transcription import (
 )
 
 
+def _install_mock_ydl(mocker, tmp_path, info, vtt_name, vtt_text):
+    """Patch YoutubeDL with a stub that probes `info` and writes one vtt file.
+
+    Pins the temp basename so the fixture file can be named before the call —
+    fetch_via_ytdlp never returns it — and points Path.cwd at tmp_path so the
+    production glob and the real clean_up both operate there.
+
+    Returns:
+        The list each download() call appends its requested `subtitleslangs` to.
+
+    """
+    download_calls: list[list[str]] = []
+    vtt_path = tmp_path / vtt_name
+
+    class MockYDL:
+        def __init__(self, opts: dict) -> None:
+            self.opts = opts
+
+        def __enter__(self) -> MockYDL:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def extract_info(self, url: str, download: bool = True) -> dict:
+            return info
+
+        def download(self, url_list: list[str]) -> int:
+            download_calls.append(self.opts.get("subtitleslangs", []))
+            vtt_path.write_text(
+                f"WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n{vtt_text}\n",
+                encoding="utf-8",
+            )
+            return 0
+
+    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
+    mocker.patch("transcription.YoutubeDL", MockYDL)
+    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
+    return download_calls, vtt_path
+
+
 def _make_transcriber():
     """Return (transcriber, primary, fallback) wired to freshly constructed backends.
 
@@ -542,332 +583,104 @@ def test_fetch_via_api_retries_on_retryable_exception(mocker, exc):
     assert mock_ytt.return_value.fetch.call_count == 2
 
 
-def test_fetch_via_ytdlp_non_english_fallback(mocker, tmp_path):
-    """Test fetch_via_ytdlp requests the available language when no English is offered."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-
-    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
-    vtt_path = tmp_path / "fake-uuid.fr.vtt"
-    download_calls: list[list[str]] = []
-
-    class MockYDL:
-        def __init__(self, opts: object) -> None:
-            self.opts = opts
-
-        def __enter__(self) -> MockYDL:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def extract_info(self, url: str, download: bool = True) -> dict:
-            return {"subtitles": {"fr": [{}]}, "automatic_captions": {}}
-
-        def download(self, url_list: list[str]) -> int:
-            langs = self.opts.get("subtitleslangs", [])
-            download_calls.append(langs)
-            vtt_path.write_text(vtt_content, encoding="utf-8")
-            return 0
-
-    mocker.patch("transcription.YoutubeDL", MockYDL)
-    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-
-    result = YtDlpBackend().fetch_via_ytdlp(
-        "https://www.youtube.com/watch?v=test",
-    )
-
-    assert result == "Bonjour"
-    assert download_calls == [["fr"]]
-    assert not vtt_path.exists()
-
-
-def test_fetch_via_ytdlp_prefers_english_when_available(mocker, tmp_path):
-    """Test fetch_via_ytdlp picks English even when other languages are present."""
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-
-    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHello\n"
-    vtt_path = tmp_path / "fake-uuid.en.vtt"
-    download_calls: list[list[str]] = []
-
-    class MockYDL:
-        def __init__(self, opts: object) -> None:
-            self.opts = opts
-
-        def __enter__(self) -> MockYDL:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def extract_info(self, url: str, download: bool = True) -> dict:
-            return {"subtitles": {"fr": [{}], "en": [{}]}, "automatic_captions": {}}
-
-        def download(self, url_list: list[str]) -> int:
-            langs = self.opts.get("subtitleslangs", [])
-            download_calls.append(langs)
-            vtt_path.write_text(vtt_content, encoding="utf-8")
-            return 0
-
-    mocker.patch("transcription.YoutubeDL", MockYDL)
-    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-
-    result = YtDlpBackend().fetch_via_ytdlp(
-        "https://www.youtube.com/watch?v=test",
-    )
-
-    assert result == "Hello"
-    assert download_calls == [["en"]]
-    assert not vtt_path.exists()
-
-
-def test_fetch_via_ytdlp_manual_prefers_original_language_over_first_key(
-    mocker,
-    tmp_path,
-):
-    """Test manual-subtitle branch prefers info['language'] when no English track exists.
-
-    When a video has multiple manual subtitle languages but none is English, the
-    selection should prefer the video's original language (info['language']) rather
-    than the first dict key (which is insertion-order dependent).
-    """
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-
-    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nGuten Tag\n"
-    vtt_path = tmp_path / "fake-uuid.de.vtt"
-    download_calls: list[list[str]] = []
-
-    class MockYDL:
-        def __init__(self, opts: object) -> None:
-            self.opts = opts
-
-        def __enter__(self) -> MockYDL:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def extract_info(self, url: str, download: bool = True) -> dict:
-            # "fr" comes first in the dict, but the video's original language is "de"
-            return {
+# Track selection, in the order fetch_via_ytdlp applies it: genuine manual
+# subtitles win (English first, else the video's original language, else the
+# first key), and only if there are none do automatic captions apply the same
+# preference — with a "*-orig" key standing in for a missing info["language"],
+# since auto-captions list machine translations for ~every language. yt-dlp
+# also lists a "live_chat" pseudo-track that is not convertible to vtt.
+@pytest.mark.parametrize(
+    ("info", "vtt_name", "expected_langs", "expected_text"),
+    [
+        pytest.param(
+            {"subtitles": {"fr": [{}]}, "automatic_captions": {}},
+            "fake-uuid.fr.vtt",
+            ["fr"],
+            "Bonjour",
+            id="manual-sole-language",
+        ),
+        pytest.param(
+            {"subtitles": {"fr": [{}], "en": [{}]}, "automatic_captions": {}},
+            "fake-uuid.en.vtt",
+            ["en"],
+            "Hello",
+            id="manual-prefers-english",
+        ),
+        pytest.param(
+            {
                 "subtitles": {"fr": [{}], "de": [{}]},
                 "automatic_captions": {},
                 "language": "de",
-            }
-
-        def download(self, url_list: list[str]) -> int:
-            langs = self.opts.get("subtitleslangs", [])
-            download_calls.append(langs)
-            vtt_path.write_text(vtt_content, encoding="utf-8")
-            return 0
-
-    mocker.patch("transcription.YoutubeDL", MockYDL)
-    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-
-    result = YtDlpBackend().fetch_via_ytdlp(
-        "https://www.youtube.com/watch?v=test",
-    )
-
-    assert result == "Guten Tag"
-    assert download_calls == [["de"]]
-    assert not vtt_path.exists()
-
-
-def test_fetch_via_ytdlp_auto_captions_uses_original_language(
-    mocker,
-    tmp_path,
-):
-    """Test fetch_via_ytdlp requests the original language, not translated English.
-
-    automatic_captions list machine translations (incl. "en") for ~every language,
-    so for a non-English video with no manual subs we must request the original
-    language (info["language"]) rather than the translated "en" track.
-    """
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-
-    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
-    vtt_path = tmp_path / "fake-uuid.fr.vtt"
-    download_calls: list[list[str]] = []
-
-    class MockYDL:
-        def __init__(self, opts: object) -> None:
-            self.opts = opts
-
-        def __enter__(self) -> MockYDL:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def extract_info(self, url: str, download: bool = True) -> dict:
-            return {
+            },
+            "fake-uuid.de.vtt",
+            ["de"],
+            "Guten Tag",
+            id="manual-prefers-original-over-first-key",
+        ),
+        pytest.param(
+            {
                 "subtitles": {},
                 "automatic_captions": {"en": [{}], "fr": [{}]},
                 "language": "fr",
-            }
-
-        def download(self, url_list: list[str]) -> int:
-            langs = self.opts.get("subtitleslangs", [])
-            download_calls.append(langs)
-            vtt_path.write_text(vtt_content, encoding="utf-8")
-            return 0
-
-    mocker.patch("transcription.YoutubeDL", MockYDL)
-    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-
-    result = YtDlpBackend().fetch_via_ytdlp(
-        "https://www.youtube.com/watch?v=test",
-    )
-
-    assert result == "Bonjour"
-    assert download_calls == [["fr"]]
-    assert not vtt_path.exists()
-
-
-def test_fetch_via_ytdlp_auto_captions_prefers_orig_key_when_language_missing(
-    mocker,
-    tmp_path,
-):
-    """Test auto-captions branch picks the *-orig key when info['language'] is absent.
-
-    When no info['language'] is available (or it isn't in auto) but a '*-orig' key
-    exists in automatic_captions, that key should be preferred over the first dict key.
-    """
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-
-    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHallo\n"
-    vtt_path = tmp_path / "fake-uuid.de-orig.vtt"
-    download_calls: list[list[str]] = []
-
-    class MockYDL:
-        def __init__(self, opts: object) -> None:
-            self.opts = opts
-
-        def __enter__(self) -> MockYDL:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def extract_info(self, url: str, download: bool = True) -> dict:
-            # no 'language' key; auto has a '*-orig' key that should be preferred
-            return {
+            },
+            "fake-uuid.fr.vtt",
+            ["fr"],
+            "Bonjour",
+            id="auto-prefers-original-over-translated-english",
+        ),
+        pytest.param(
+            {
                 "subtitles": {},
                 "automatic_captions": {"en": [{}], "de-orig": [{}], "fr": [{}]},
-            }
-
-        def download(self, url_list: list[str]) -> int:
-            langs = self.opts.get("subtitleslangs", [])
-            download_calls.append(langs)
-            vtt_path.write_text(vtt_content, encoding="utf-8")
-            return 0
-
-    mocker.patch("transcription.YoutubeDL", MockYDL)
-    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-
-    result = YtDlpBackend().fetch_via_ytdlp(
-        "https://www.youtube.com/watch?v=test",
-    )
-
-    assert result == "Hallo"
-    assert download_calls == [["de-orig"]]
-    assert not vtt_path.exists()
-
-
-def test_fetch_via_ytdlp_auto_captions_falls_back_to_first_key(
-    mocker,
-    tmp_path,
-):
-    """Test auto-captions branch falls back to first key when no language or *-orig key.
-
-    When info['language'] is absent and no '*-orig' key exists in automatic_captions,
-    the first key in the dict is used as a last resort.
-    """
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-
-    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHola\n"
-    vtt_path = tmp_path / "fake-uuid.es.vtt"
-    download_calls: list[list[str]] = []
-
-    class MockYDL:
-        def __init__(self, opts: object) -> None:
-            self.opts = opts
-
-        def __enter__(self) -> MockYDL:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def extract_info(self, url: str, download: bool = True) -> dict:
-            # no 'language' key, no '*-orig' key → must fall back to first key ("es")
-            return {
-                "subtitles": {},
-                "automatic_captions": {"es": [{}], "fr": [{}]},
-            }
-
-        def download(self, url_list: list[str]) -> int:
-            langs = self.opts.get("subtitleslangs", [])
-            download_calls.append(langs)
-            vtt_path.write_text(vtt_content, encoding="utf-8")
-            return 0
-
-    mocker.patch("transcription.YoutubeDL", MockYDL)
-    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-
-    result = YtDlpBackend().fetch_via_ytdlp(
-        "https://www.youtube.com/watch?v=test",
-    )
-
-    assert result == "Hola"
-    assert download_calls == [["es"]]
-    assert not vtt_path.exists()
-
-
-def test_fetch_via_ytdlp_ignores_live_chat_pseudo_track(mocker, tmp_path):
-    """Test fetch_via_ytdlp skips the "live_chat" subtitles entry.
-
-    yt-dlp lists a "live_chat" key under subtitles for live-stream replays; it is
-    not a real subtitle track. It must be ignored so selection falls through to the
-    video's original-language automatic captions rather than requesting "live_chat".
-    """
-    mocker.patch("transcription.generate_temporary_name", return_value="fake-uuid")
-
-    vtt_content = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nBonjour\n"
-    vtt_path = tmp_path / "fake-uuid.fr.vtt"
-    download_calls: list[list[str]] = []
-
-    class MockYDL:
-        def __init__(self, opts: object) -> None:
-            self.opts = opts
-
-        def __enter__(self) -> MockYDL:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def extract_info(self, url: str, download: bool = True) -> dict:
-            return {
+            },
+            "fake-uuid.de-orig.vtt",
+            ["de-orig"],
+            "Hallo",
+            id="auto-prefers-orig-key-when-language-missing",
+        ),
+        pytest.param(
+            {"subtitles": {}, "automatic_captions": {"es": [{}], "fr": [{}]}},
+            "fake-uuid.es.vtt",
+            ["es"],
+            "Hola",
+            id="auto-falls-back-to-first-key",
+        ),
+        pytest.param(
+            {
                 "subtitles": {"live_chat": [{}]},
                 "automatic_captions": {"fr": [{}]},
                 "language": "fr",
-            }
-
-        def download(self, url_list: list[str]) -> int:
-            langs = self.opts.get("subtitleslangs", [])
-            download_calls.append(langs)
-            vtt_path.write_text(vtt_content, encoding="utf-8")
-            return 0
-
-    mocker.patch("transcription.YoutubeDL", MockYDL)
-    mocker.patch("transcription.Path.cwd", return_value=tmp_path)
-
-    result = YtDlpBackend().fetch_via_ytdlp(
-        "https://www.youtube.com/watch?v=test",
+            },
+            "fake-uuid.fr.vtt",
+            ["fr"],
+            "Bonjour",
+            id="ignores-live-chat-pseudo-track",
+        ),
+    ],
+)
+def test_fetch_via_ytdlp_selects_subtitle_track(
+    mocker,
+    tmp_path,
+    info,
+    vtt_name,
+    expected_langs,
+    expected_text,
+):
+    """Test fetch_via_ytdlp requests the right subtitle track for each track mix."""
+    download_calls, vtt_path = _install_mock_ydl(
+        mocker,
+        tmp_path,
+        info,
+        vtt_name,
+        expected_text,
     )
 
-    assert result == "Bonjour"
-    assert download_calls == [["fr"]]
+    result = YtDlpBackend().fetch_via_ytdlp("https://www.youtube.com/watch?v=test")
+
+    assert result == expected_text
+    assert download_calls == [expected_langs]
+    # Real clean_up runs (Path.cwd is patched to tmp_path): the vtt fixture
+    # should be gone rather than merely asserting clean_up was called.
     assert not vtt_path.exists()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,56 @@
 from pathlib import Path
 
 from config import PROTECTED_FILES
-from utils import clean_up, compress_audio, generate_temporary_name
+from utils import classify_url, clean_up, compress_audio, generate_temporary_name
+
+
+def test_classify_url_uppercase_youtube_host():
+    """Test classify_url normalises uppercase YouTube hostnames to 'youtube'."""
+    assert classify_url("https://YOUTU.BE/dQw4w9WgXcQ") == "youtube"
+    assert classify_url("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ") == "youtube"
+
+
+def test_classify_url_strips_www_prefix():
+    """Test classify_url routes www-prefixed media hosts to their media kind.
+
+    Regression: routing used to be duplicated, and the second classifier matched
+    three literal lowercase prefixes. A www-prefixed Castro or youtu.be link was
+    classified as media in handlers, then failed the second check and reached the
+    Gemini file upload with the URL string as its file path.
+    """
+    assert classify_url("https://www.castro.fm/episode/123") == "castro"
+    assert classify_url("https://www.youtu.be/dQw4w9WgXcQ") == "youtube"
+
+
+def test_classify_url_castro_non_episode_path_is_web():
+    """Test classify_url only treats Castro /episode/ paths as media."""
+    assert classify_url("https://castro.fm/about") == "web"
+
+
+def test_classify_url_malformed_no_host():
+    """Test classify_url returns None for URLs with no parseable hostname."""
+    assert classify_url("https://") is None
+
+
+def test_classify_url_rejects_non_http_scheme():
+    """Test classify_url returns None for non-http(s) schemes."""
+    assert classify_url("ftp://example.com/file.txt") is None
+
+
+def test_classify_url_returns_none_for_unparseable_authority():
+    """Test classify_url returns None when urlsplit rejects the authority.
+
+    urlsplit raises ValueError on bracket-malformed hosts. Left uncaught it
+    escapes handle_url's kind check and reaches handle_message's catch-all, so
+    the user sees "Unexpected: ValueError" instead of "No data to proceed.".
+    """
+    assert classify_url("https://[") is None
+    assert classify_url("http://[::1") is None
+
+
+def test_classify_url_http_youtube_is_web():
+    """Test classify_url only treats https media hosts as media."""
+    assert classify_url("http://youtube.com/watch?v=dQw4w9WgXcQ") == "web"
 
 
 def test_generate_temporary_name_no_ext():
@@ -49,7 +98,6 @@ def test_compress_audio_calls_ffmpeg(mocker):
         expected_args,
         check=True,
         capture_output=False,
-        text=True,
     )
 
 


### PR DESCRIPTION
Removes dead code and duplication found in a review of the source and tests. No behavior change: −309 net lines, 280 tests, 100% line and branch coverage.

## Source

- **`Container` 13 → 5 fields** — `build_app` reads five (`bot`, `quota_manager`, `tracer`, `user_repo`, `handlers`); the other eight were wiring intermediates kept alive only by their own test. They are locals now, and the graph is reached through `handlers`.
- **`_summarize_uploaded_file` extracted** — `summarize_with_file` and `summarize_with_document` duplicated the whole upload → quota → run → delete block, including two byte-identical delete-and-log `finally` clauses. The document path also lost its `data` / `document_file_name` None-tracking, which the structure now guarantees.
- **Three dead `sleep_time` parameters removed** — no caller ever passed them. The Gemini upload poll interval now defaults on `GeminiHelper.upload_and_wait_for_file`, the class that actually polls; `AudioTranscriber` keeps its own as a `ClassVar`.
- **`check_quota` → `-> None`** — it returned `True` or raised, and no caller read the result. Gains the `Raises:` block it always had in practice.
- **`send_answer`** rewritten as `enumerate` over the chunks, replacing eight lines of manual iterator bookkeeping.
- **Docstrings corrected** — all three `Raises:` blocks promised `AttributeError`, but each decorator lists it in `retry_if_exception_type` with `reraise=False`, so callers only ever see `RetryError`.
- Inert `text=True` dropped from the ffmpeg call (no-op without `capture_output`).

## Tests

- **8 hand-rolled `MockYDL` classes → 1 factory** plus a seven-case parametrized subtitle-selection test; `test_transcription.py` drops ~300 lines.
- **Media handler tests parametrized** — four size-guard tests → one, two happy paths → one, two video cleanup tests → one. All four funnel through the same `_fetch_media` guard.
- **`test_summary.py`** — two subsumed tests removed, and the two transcript-prefix tests merged. Their names were inverted: 📺 is the `youtube_transcript_api` primary and 📹 the yt-dlp fallback, but the test named "direct" asserted 📹 and the one named "fallback" asserted 📺.
- `classify_url` tests moved to `test_utils.py` where the function lives; new `test_domain.py`; shared setup helper in `test_download.py`.

## For the reviewer

- **The one real bug this refactor introduced was caught pre-commit**: extracting the shared helper left the `@retry` decorator on it instead of on `summarize_with_file`, which double-wrapped the document path. Worth knowing that **no behavioral test can see this** — for a single repeated exception type both topologies produce identical attempt counts; only a mixed sequence differs, where the extra layer would upload and consume quota three times instead of twice (Gemini bills failed calls). `test_only_the_public_entry_points_carry_retry` now pins it structurally.
- **The `llm.py` provider seam stays.** Its non-Google branches are unreachable while `ModelSpec.provider` is `Literal["google"]`, so a dead-code sweep reads them as removable. More providers are planned; that decision is now recorded in the `ModelSpec` docstring and `architecture.md`.
- **Knowingly not done:** memoizing `parse_rate_limit` in `check_quota`. Real, but a handful of regex parses per message on a private polling bot is not worth an `lru_cache`.
- `architecture.md` updated for the `Container` shape and the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved delivery of long responses with sequential message chunks and appropriate delays.
  - Standardized file-upload, document, audio-transcription, and media-processing workflows.
  - Enhanced retry handling and error reporting for incomplete or empty results.
  - Improved cleanup and validation for downloaded media and uploaded files.
  - Refined summary formatting for consistent spacing and cleaner output.

- **Documentation**
  - Clarified supported model providers, component wiring, quota behavior, and processing intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->