### PR TITLE
llm: trace only text-input model calls in Langfuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ PROXY=""
 LOG_LEVEL="ERROR"
 MODAL_TOKEN_ID="your_token"
 MODAL_TOKEN_SECRET="your_token_secret"
-# Optional: set both keys to enable Langfuse tracing of model calls.
+# Optional: set both keys to enable Langfuse tracing of text-input model calls.
 LANGFUSE_PUBLIC_KEY=""
 LANGFUSE_SECRET_KEY=""
 LANGFUSE_BASE_URL=""
@@ -63,7 +63,10 @@ LANGFUSE_BASE_URL=""
 
 `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are optional — set both to trace
 model calls to [Langfuse](https://langfuse.com); leave them unset to disable
-tracing. `LANGFUSE_BASE_URL` defaults to Langfuse Cloud (EU); use
+tracing. Only calls whose input is text (webpages and transcripts) are traced:
+audio, video and documents reach the model as a file reference, which Langfuse
+would record as token usage with no readable content. `LANGFUSE_BASE_URL`
+defaults to Langfuse Cloud (EU); use
 `https://us.cloud.langfuse.com` for the US region or your self-hosted URL.
 
 Pass in an empty string to `PROXY` for direct connection. \

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -158,23 +158,18 @@ to Gemini — return the raw model text with **no** prefix.
   startup. On shutdown `clean_up(all_downloads=True)` sweeps the rest.
 - **Settings commands** use a one-time reply keyboard + `register_next_step_handler`
   (`_prompt_choice` → `proceed_*`) and validate against the allow-lists in `config.py`.
-- **Tracing (optional), text input only.** Langfuse tracing is enabled only when
-  `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are set (`config.langfuse_client`,
-  else `None`). When on, `Agent.instrument_all()` makes pydantic-ai emit an
-  OpenTelemetry span per model call by default, which the OTel-based Langfuse SDK
-  ingests — no provider-specific instrumentor. `LLMClient` overrides that default to
-  off for any run whose content includes an `UploadedFile` (the Gemini-file path,
-  `summary.py:_summarize_uploaded_file`): pydantic-ai would serialize the file
-  pointer, not the audio bytes behind it, so Langfuse would record a generation with
-  real token usage but no content to inspect — wrong cost signal, and unusable for
-  datasets or evaluators. Only runs whose content is text (`summarize_text`, the
-  YouTube-transcript, webpage, and Replicate-rescue paths) are traced.
-  `Tracer.observe_message` (used in `BotApp.handle_message`) does not open a span
-  itself; it names and attributes whatever span the message's model calls open
-  (`trace_name="handle_message"`, tagged with the content type), via
-  `propagate_attributes`, which reads the current span and no-ops when none is
-  active. So a text request still yields one trace rooted at pydantic-ai's agent
-  span; a file-only request (audio, voice, video, video note, document) yields no
-  trace at all. `langfuse_client.shutdown()` flushes on exit. Independent of Sentry,
-  which handles error capture and logs; the Langfuse tracing is a no-op when
-  disabled.
+- **Tracing (optional), text input only.** Enabled only when `LANGFUSE_PUBLIC_KEY` and
+  `LANGFUSE_SECRET_KEY` are set (`config.langfuse_client`, else `None`).
+  `Agent.instrument_all()` then makes pydantic-ai emit an OpenTelemetry span per model
+  call, which the OTel-based Langfuse SDK ingests — no provider-specific instrumentor.
+  `LLMClient` overrides that to off for any run carrying an `UploadedFile`, because
+  pydantic-ai serializes the file pointer rather than the bytes behind it: Langfuse
+  would get real token usage with no content — a wrong cost signal, useless for
+  datasets and evaluators. **Do not re-enable it for file runs.**
+  `Tracer.observe_message` opens no span of its own, it only names and attributes
+  (`trace_name="handle_message"`, tagged with the content type) whatever spans the
+  message's model calls open. Consequences worth knowing: a media message produces no
+  trace at all; a trace spans the model call only, not the download, parse or upload
+  around it; and a retried `summarize_text` produces one trace per attempt, since
+  nothing groups them. `langfuse_client.shutdown()` flushes on exit. Independent of
+  Sentry, which handles error capture and logs.

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -53,11 +53,11 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `main.py` | `BotApp` — Telegram entry point. Command handlers + the unified `handle_message`; routes by `content_type`; top-level error → user-message mapping. `build_app(container)` wires it from the composition root and registers its handlers; the `__main__` block just calls `build_app`, `run`, `shutdown`. |
 | `handlers.py` | `MessageHandlers` — per-content-type handlers. Media validation, builds `SummaryKwargs` from the user record, picks the summarize path. |
 | `summary.py` | `Summarizer` — the core summarization orchestrator. Owns the input-type branching, assembles the message content, and calls the injected `LLMClient.run`. |
-| `llm.py` | `LLMClient` — the provider seam. Each instance holds one pydantic-ai `Agent`; model, instructions and settings are resolved per run. Provider dispatch lives in `build_model` (keyed on `config.MODEL_SPECS[...].provider`); `build_settings` currently carries only the provider-agnostic thinking level. |
+| `llm.py` | `LLMClient` — the provider seam. Each instance holds two pydantic-ai `Agent`s — one traced, one with instrumentation off for uploaded-file runs (see Tracing below) — plus a model cache; model, instructions and settings are resolved per run. Provider dispatch lives in `build_model` (keyed on `config.MODEL_SPECS[...].provider`); `build_settings` currently carries only the provider-agnostic thinking level. |
 | `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (orchestrator over `ApiBackend` primary → `YtDlpBackend` fallback, mirroring `parsing.py`'s `ParserBackend`). |
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
 | `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
-| `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (MIME, file upload/poll), `Tracer` (Langfuse root span per message). |
+| `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (MIME, file upload/poll), `Tracer` (names/tags the Langfuse trace for a message, if one is opened). |
 | `container.py` | `Container` + `build_container()` — the composition root; wires every collaborator to `config`'s clients. `Container` carries only the five roots `BotApp` holds (`bot`, `quota_manager`, `tracer`, `user_repo`, `handlers`); the rest of the graph is reached through `handlers`. |
 | `database.py` | `UserRepository` — users table access (SQLAlchemy + Postgres). |
 | `models.py` | `UsersOrm` — the single `users` table (id, approval, per-user settings, `daily_limit`). |
@@ -158,12 +158,23 @@ to Gemini — return the raw model text with **no** prefix.
   startup. On shutdown `clean_up(all_downloads=True)` sweeps the rest.
 - **Settings commands** use a one-time reply keyboard + `register_next_step_handler`
   (`_prompt_choice` → `proceed_*`) and validate against the allow-lists in `config.py`.
-- **Tracing (optional).** Langfuse tracing is enabled only when `LANGFUSE_PUBLIC_KEY`
-  and `LANGFUSE_SECRET_KEY` are set (`config.langfuse_client`, else `None`). When on,
-  `Agent.instrument_all()` makes pydantic-ai emit an OpenTelemetry span per model
-  call, which the OTel-based Langfuse SDK ingests — no provider-specific
-  instrumentor. `Tracer.observe_message` (used in `BotApp.handle_message`) wraps
-  each Telegram message in one root span attributed to the user and tagged with the
-  content type, so all model calls for a message nest under a single trace.
-  `langfuse_client.shutdown()` flushes on exit. Independent of Sentry, which handles
-  error capture and logs; the Langfuse tracing is a no-op when disabled.
+- **Tracing (optional), text input only.** Langfuse tracing is enabled only when
+  `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are set (`config.langfuse_client`,
+  else `None`). When on, `Agent.instrument_all()` makes pydantic-ai emit an
+  OpenTelemetry span per model call by default, which the OTel-based Langfuse SDK
+  ingests — no provider-specific instrumentor. `LLMClient` overrides that default to
+  off for any run whose content includes an `UploadedFile` (the Gemini-file path,
+  `summary.py:_summarize_uploaded_file`): pydantic-ai would serialize the file
+  pointer, not the audio bytes behind it, so Langfuse would record a generation with
+  real token usage but no content to inspect — wrong cost signal, and unusable for
+  datasets or evaluators. Only runs whose content is text (`summarize_text`, the
+  YouTube-transcript, webpage, and Replicate-rescue paths) are traced.
+  `Tracer.observe_message` (used in `BotApp.handle_message`) does not open a span
+  itself; it names and attributes whatever span the message's model calls open
+  (`trace_name="handle_message"`, tagged with the content type), via
+  `propagate_attributes`, which reads the current span and no-ops when none is
+  active. So a text request still yields one trace rooted at pydantic-ai's agent
+  span; a file-only request (audio, voice, video, video note, document) yields no
+  trace at all. `langfuse_client.shutdown()` flushes on exit. Independent of Sentry,
+  which handles error capture and logs; the Langfuse tracing is a no-op when
+  disabled.

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -168,8 +168,9 @@ to Gemini — return the raw model text with **no** prefix.
   datasets and evaluators. **Do not re-enable it for file runs.**
   `Tracer.observe_message` opens no span of its own, it only names and attributes
   (`trace_name="handle_message"`, tagged with the content type) whatever spans the
-  message's model calls open. Consequences worth knowing: a media message produces no
-  trace at all; a trace spans the model call only, not the download, parse or upload
-  around it; and a retried `summarize_text` produces one trace per attempt, since
-  nothing groups them. `langfuse_client.shutdown()` flushes on exit. Independent of
+  message's model calls open. Consequences worth knowing: the Gemini-file call is never
+  traced, but a media message still is when it falls through to Replicate
+  transcription, which summarizes a plain string; a trace spans the model call only,
+  not the download, parse or upload around it; and a retried `summarize_text` produces
+  one trace per attempt, since nothing groups them. `langfuse_client.shutdown()` flushes on exit. Independent of
   Sentry, which handles error capture and logs.

--- a/src/config.py
+++ b/src/config.py
@@ -124,8 +124,10 @@ ALLOWED_THINKING_LEVELS = list(THINKING_LEVEL_LABELS.keys())
 
 # Langfuse config
 # Optional: tracing is enabled only when both keys are present, so local runs
-# and tests work without Langfuse. When enabled, pydantic-ai emits an OpenTelemetry
-# span per model call, which the OTel-based Langfuse SDK ingests.
+# and tests work without Langfuse. When enabled, this is the default: pydantic-ai
+# emits an OpenTelemetry span per model call, which the OTel-based Langfuse SDK
+# ingests. `llm.LLMClient` overrides it to off for runs whose content is an
+# uploaded file, so only text-input model calls get traced.
 LANGFUSE_PUBLIC_KEY = os.environ.get("LANGFUSE_PUBLIC_KEY")
 LANGFUSE_SECRET_KEY = os.environ.get("LANGFUSE_SECRET_KEY")
 LANGFUSE_BASE_URL = os.environ.get("LANGFUSE_BASE_URL")

--- a/src/llm.py
+++ b/src/llm.py
@@ -21,17 +21,6 @@ if TYPE_CHECKING:
     from pydantic_ai.settings import ThinkingLevel
 
 
-def _is_text_only(content: str | Sequence[UserContent]) -> bool:
-    """Return whether content is text with no file parts, e.g. an UploadedFile.
-
-    Broader than `isinstance(content, str)` so a future multi-part text prompt
-    stays traced.
-    """
-    if isinstance(content, str):
-        return True
-    return all(isinstance(part, str) for part in content)
-
-
 class LLMClient:
     """Provider-agnostic entry point for every summarization model call."""
 
@@ -48,6 +37,13 @@ class LLMClient:
         self._untraced_agent: Agent[None, str] = Agent()
         self._untraced_agent.instrument = False
         self._models: dict[str, Model] = {}
+
+    @staticmethod
+    def _is_text_only(content: str | Sequence[UserContent]) -> bool:
+        """Broader than `isinstance(content, str)`: a multi-part text prompt counts."""
+        if isinstance(content, str):
+            return True
+        return all(isinstance(part, str) for part in content)
 
     def build_model(self, model_id: str) -> Model:
         """Return the pydantic-ai model for a registered id, shared across calls."""
@@ -127,7 +123,7 @@ class LLMClient:
         instructions = dedent(
             SYSTEM_INSTRUCTION.format(language=target_language),
         ).strip()
-        agent = self._agent if _is_text_only(content) else self._untraced_agent
+        agent = self._agent if self._is_text_only(content) else self._untraced_agent
         result = agent.run_sync(
             content,
             model=self.build_model(model_id),

--- a/src/llm.py
+++ b/src/llm.py
@@ -38,9 +38,9 @@ class LLMClient:
     def __init__(self, client: genai.Client) -> None:
         """Store the injected Gemini client and this client's model cache."""
         self._client = client
-        # A single agent serves every call: pydantic-ai takes the model, the
-        # instructions and the settings per run, so nothing here is model-,
-        # language- or user-specific.
+        # Neither agent is model-, language- or user-specific: pydantic-ai takes
+        # the model, the instructions and the settings per run. They differ only
+        # in whether instrumentation is on.
         self._agent: Agent[None, str] = Agent()
         # Runs that carry an UploadedFile go through an agent with instrumentation
         # off: pydantic-ai would record the file pointer as the input, producing a

--- a/src/llm.py
+++ b/src/llm.py
@@ -21,6 +21,17 @@ if TYPE_CHECKING:
     from pydantic_ai.settings import ThinkingLevel
 
 
+def _is_text_only(content: str | Sequence[UserContent]) -> bool:
+    """Return whether content is text with no file parts, e.g. an UploadedFile.
+
+    Broader than `isinstance(content, str)` so a future multi-part text prompt
+    stays traced.
+    """
+    if isinstance(content, str):
+        return True
+    return all(isinstance(part, str) for part in content)
+
+
 class LLMClient:
     """Provider-agnostic entry point for every summarization model call."""
 
@@ -31,6 +42,11 @@ class LLMClient:
         # instructions and the settings per run, so nothing here is model-,
         # language- or user-specific.
         self._agent: Agent[None, str] = Agent()
+        # Runs that carry an UploadedFile go through an agent with instrumentation
+        # off: pydantic-ai would record the file pointer as the input, producing a
+        # Langfuse generation with token usage but no content behind it.
+        self._untraced_agent: Agent[None, str] = Agent()
+        self._untraced_agent.instrument = False
         self._models: dict[str, Model] = {}
 
     def build_model(self, model_id: str) -> Model:
@@ -111,7 +127,8 @@ class LLMClient:
         instructions = dedent(
             SYSTEM_INSTRUCTION.format(language=target_language),
         ).strip()
-        result = self._agent.run_sync(
+        agent = self._agent if _is_text_only(content) else self._untraced_agent
+        result = agent.run_sync(
             content,
             model=self.build_model(model_id),
             instructions=instructions,

--- a/src/services.py
+++ b/src/services.py
@@ -205,11 +205,9 @@ class Tracer:
     def observe_message(self, user_id: int, content_type: str) -> Generator[None]:
         """Name and attribute whatever trace one Telegram message produces.
 
-        Does not open a root span itself: `LLMClient` instruments only
-        text-content runs, so a message that only reaches an uploaded-file run
-        opens no span, and `propagate_attributes` — which reads the current span,
-        a no-op `NonRecordingSpan` when none is active — has nothing to name or
-        tag. A no-op when Langfuse is not configured.
+        Opens no span itself, so a message whose model calls all carry an
+        uploaded file — which `LLMClient` leaves uninstrumented — produces no
+        trace at all. A no-op when Langfuse is not configured.
         """
         if self._client is None:
             yield

--- a/src/services.py
+++ b/src/services.py
@@ -190,7 +190,7 @@ class GeminiHelper:
 
 
 class Tracer:
-    """Groups all model calls for one Telegram message into a single Langfuse trace."""
+    """Names and attributes whatever Langfuse spans one Telegram message produces."""
 
     def __init__(self, client: Langfuse | None) -> None:
         """Store the injected Langfuse client (None when tracing is disabled)."""
@@ -203,17 +203,20 @@ class Tracer:
 
     @contextmanager
     def observe_message(self, user_id: int, content_type: str) -> Generator[None]:
-        """Group all model calls for one Telegram message into a single trace.
+        """Name and attribute whatever trace one Telegram message produces.
 
-        Opens a Langfuse root span attributed to the user and tagged with the
-        message content type, so the generation spans emitted by pydantic-ai nest
-        under one trace. A no-op when Langfuse is not configured.
+        Does not open a root span itself: `LLMClient` instruments only
+        text-content runs, so a message that only reaches an uploaded-file run
+        opens no span, and `propagate_attributes` — which reads the current span,
+        a no-op `NonRecordingSpan` when none is active — has nothing to name or
+        tag. A no-op when Langfuse is not configured.
         """
         if self._client is None:
             yield
             return
-        with (
-            self._client.start_as_current_observation(name="handle_message"),
-            propagate_attributes(user_id=str(user_id), tags=[content_type]),
+        with propagate_attributes(
+            trace_name="handle_message",
+            user_id=str(user_id),
+            tags=[content_type],
         ):
             yield

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -278,6 +278,9 @@ def test_run_uses_traced_agent_for_text_content(llm_client, mocker):
     )
 
     assert result == "A summary."
+    # Unset, so the agent inherits the instrument_all() default. Pinned here
+    # because switching it off would silently stop every trace.
+    assert llm_client._agent.instrument is None
     mock_run_sync.assert_called_once()
     mock_untraced_run_sync.assert_not_called()
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -256,3 +256,65 @@ def test_run_raises_on_empty_output(llm_client, mocker, output):
             target_language="English",
             thinking_level="HIGH",
         )
+
+
+def test_run_uses_traced_agent_for_text_content(llm_client, mocker):
+    """Test a plain-text run goes through the traced agent, not the untraced one."""
+    mock_run_sync = mocker.patch.object(
+        llm_client._agent,
+        "run_sync",
+        return_value=SimpleNamespace(output="A summary."),
+    )
+    mock_untraced_run_sync = mocker.patch.object(
+        llm_client._untraced_agent,
+        "run_sync",
+    )
+
+    result = llm_client.run(
+        content="Summarize this.",
+        model_id="gemini-3.5-flash",
+        target_language="English",
+        thinking_level="HIGH",
+    )
+
+    assert result == "A summary."
+    mock_run_sync.assert_called_once()
+    mock_untraced_run_sync.assert_not_called()
+
+
+def test_run_uses_untraced_agent_for_uploaded_file_content(llm_client, mocker):
+    """Test a run carrying an UploadedFile skips Langfuse via the untraced agent.
+
+    pydantic-ai would otherwise serialize the file pointer, not the bytes behind
+    it, giving Langfuse a generation with token usage but no real content.
+    """
+    file = SimpleNamespace(
+        name="files/mock123",
+        uri="https://generativelanguage.googleapis.com/v1beta/files/mock123",
+        mime_type="audio/ogg",
+    )
+    uploaded_file = llm_client.build_uploaded_file(
+        model_id="gemini-3.5-flash",
+        file=file,
+    )
+    mock_run_sync = mocker.patch.object(
+        llm_client._agent,
+        "run_sync",
+    )
+    mock_untraced_run_sync = mocker.patch.object(
+        llm_client._untraced_agent,
+        "run_sync",
+        return_value=SimpleNamespace(output="A summary."),
+    )
+
+    result = llm_client.run(
+        content=["Summarize this.", uploaded_file],
+        model_id="gemini-3.5-flash",
+        target_language="English",
+        thinking_level="HIGH",
+    )
+
+    assert result == "A summary."
+    assert llm_client._untraced_agent.instrument is False
+    mock_untraced_run_sync.assert_called_once()
+    mock_run_sync.assert_not_called()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -285,6 +285,30 @@ def test_run_uses_traced_agent_for_text_content(llm_client, mocker):
     mock_untraced_run_sync.assert_not_called()
 
 
+def test_run_uses_traced_agent_for_multipart_text_content(llm_client, mocker):
+    """Test an all-text multi-part prompt is traced, not just a bare string."""
+    mock_run_sync = mocker.patch.object(
+        llm_client._agent,
+        "run_sync",
+        return_value=SimpleNamespace(output="A summary."),
+    )
+    mock_untraced_run_sync = mocker.patch.object(
+        llm_client._untraced_agent,
+        "run_sync",
+    )
+
+    result = llm_client.run(
+        content=["Summarize this.", "Use short bullets."],
+        model_id="gemini-3.5-flash",
+        target_language="English",
+        thinking_level="HIGH",
+    )
+
+    assert result == "A summary."
+    mock_run_sync.assert_called_once()
+    mock_untraced_run_sync.assert_not_called()
+
+
 def test_run_uses_untraced_agent_for_uploaded_file_content(llm_client, mocker):
     """Test a run carrying an UploadedFile skips Langfuse via the untraced agent.
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -341,15 +341,17 @@ def test_observe_message_noop_when_langfuse_disabled(mocker):
     mock_propagate.assert_not_called()
 
 
-def test_observe_message_opens_trace_when_langfuse_enabled(mocker):
-    """observe_message opens a root span attributed to the user and content type."""
+def test_observe_message_names_and_tags_trace_when_langfuse_enabled(mocker):
+    """observe_message names and attributes the trace, without opening a span."""
     mock_client = mocker.MagicMock()
     mock_propagate = mocker.patch("services.propagate_attributes")
 
     with Tracer(mock_client).observe_message(user_id=42, content_type="voice"):
         pass
 
-    mock_client.start_as_current_observation.assert_called_once_with(
-        name="handle_message",
+    mock_client.start_as_current_observation.assert_not_called()
+    mock_propagate.assert_called_once_with(
+        trace_name="handle_message",
+        user_id="42",
+        tags=["voice"],
     )
-    mock_propagate.assert_called_once_with(user_id="42", tags=["voice"])


### PR DESCRIPTION
## Why

Every model call was traced, because `Agent.instrument_all()` turns pydantic-ai's
OpenTelemetry instrumentation on globally whenever Langfuse is configured. That is
wrong for the Gemini Files path.

In `Summarizer._summarize_uploaded_file` the model receives
`[prompt, UploadedFile(file_id=<gemini files uri>)]`. pydantic-ai serializes the
**pointer**, not the audio bytes, so Langfuse records a generation with six-figure
input-token usage and nothing behind it. Consequences:

- **Cost is wrong** — usage attributed to a request whose input was never recorded.
- **Not evaluable** — the generation shows the system instruction and a bare prompt;
  the content the model actually summarized is absent.
- **Useless for datasets** — a dataset item built from such a trace has no input.

## What changed

The gate is **the content passed to `LLMClient.run`**, not the Telegram
`content_type` — only `run` knows it, and there are exactly two call sites:

| Call site | `content` | Traced |
|---|---|---|
| `summarize_text` | `str` (webpage, YouTube transcript, Replicate transcript) | yes |
| `_summarize_uploaded_file` | `[str, UploadedFile]` | no |

- **`src/llm.py`** — a second `Agent` with `instrument = False`, selected by
  `LLMClient._is_text_only`. Two agents rather than mutating one per run: telebot
  dispatches updates on a worker pool.
- **`src/services.py`** — `Tracer.observe_message` no longer opens a root span. It
  calls `propagate_attributes(trace_name="handle_message", user_id=…, tags=[…])`,
  which needs no active span. Without this, every media message would still create an
  empty, contentless `handle_message` trace.
- **`src/config.py`** — comment only.
- Docs: `docs/context/architecture.md` (Rule 7) and the Langfuse section of `README.md`.

Gating on `content_type == "text"` was considered and rejected: it would still trace a
YouTube link that falls back to audio download, and every Castro link — the exact
broken case — while dropping the genuinely useful Replicate-transcript runs, whose
model input is plain text.

## Reviewer notes

- **A retried `summarize_text` now produces one trace per attempt.** With no wrapper
  span nothing groups the two `run_sync` calls, so an empty-response retry shows up as
  two `handle_message` traces for one message. Each trace is complete on its own;
  per-message cost no longer aggregates in one row. Fixable later with a `session_id`
  keyed on the Telegram message id if that matters.
- **A trace now covers the model call only** — not the web parse, transcript fetch or
  Gemini upload around it, and a failure before the first model call (e.g.
  `WebParseError`) produces no Langfuse record at all. Sentry still captures it. Both
  consequences are stated in `docs/context/architecture.md`.
- Expect the trace's root observation to read `invoke_agent agent` rather than
  `agent run` — that is pydantic-ai 2.21.0's instrumentation-v5 naming, not something
  this PR introduces. The **trace** still reads `handle_message`.

## Testing

- `uv run pytest --cov` — 282 passed, 100% line coverage.
- New: `test_run_uses_traced_agent_for_text_content` (also pins
  `_agent.instrument is None`, so switching it off cannot silently kill all tracing),
  `test_run_uses_untraced_agent_for_uploaded_file_content`.
- Renamed: `test_observe_message_names_and_tags_trace_when_langfuse_enabled`, now
  asserting `start_as_current_observation` is **not** called.
- **Not yet verified live** — needs real `LANGFUSE_*` keys and Telegram messages: a web
  URL should yield one trace with the page text as generation input; a voice message
  should yield no trace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that tracing applies to text-only model calls, including multipart text requests.
  * Documented that audio, video, document, and uploaded-file requests are excluded from tracing.
  * Added guidance on tracing behavior, regional endpoints, and self-hosted configurations.

* **Bug Fixes**
  * Improved tracing behavior for file-based and text-based requests.
  * Updated trace propagation to avoid creating unnecessary root spans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->