### PR TITLE
tracing: record the settings an evaluation needs on each trace

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -63,7 +63,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `models.py` | `UsersOrm` — the single `users` table (id, approval, per-user settings, `daily_limit`). |
 | `exceptions.py` | Domain exceptions: `LimitExceededError`, `WebParseError`, `TranscriptDownloadError`, `FetchTranscriptError`. |
 | `config.py` | All third-party clients (by design — see Cross-cutting patterns) + the `MODEL_SPECS` registry, labels, defaults, limits, constants. Side-effectful import (Sentry, logging, env). |
-| `prompts.py` | `PROMPTS` (strategy templates) + `SYSTEM_INSTRUCTION`. |
+| `prompts.py` | `PROMPTS` (strategy templates) + `SYSTEM_INSTRUCTION` + `prompt_version` (short hash over both, for trace metadata). |
 | `domain.py` | `PrefixedText` + `format_prefixed_summary` — source-provenance prefixing. |
 | `utils.py` | Proxy pick, temp-name gen, `classify_url` (shared URL routing), `compress_audio` (ffmpeg Opus 16k mono), `clean_up`. |
 | `scripts/cron.py` | Modal serverless cron — clears the bot's per-user daily request-limit counters (`RPD`) in Valkey at midnight PT, so daily budgets reset in step with Gemini's free-tier quota. |
@@ -168,13 +168,16 @@ to Gemini — return the raw model text with **no** prefix.
   datasets and evaluators. **Do not re-enable it for file runs.**
   `Tracer.observe_message` opens no span of its own, it only names and attributes
   (`trace_name="handle_message"`, tagged with the content type, plus `prompt_key`,
-  `target_language` and `thinking_level` as metadata) whatever spans the
-  message's model calls open. Those three are metadata because nothing else carries
+  `prompt_version`, `target_language` and `thinking_level` as metadata) whatever spans
+  the message's model calls open. Those are metadata because nothing else carries
   them: pydantic-ai exports only the six numeric OTel model settings, so the
-  provider-specific, string-valued thinking level never reaches a span, and the other
-  two would have to be parsed back out of the prompt wording. They exist to make a
+  provider-specific, string-valued thinking level never reaches a span, and the rest
+  would have to be parsed back out of the prompt wording. They exist to make a
   trace filterable and replayable as an evaluation dataset item; the model id needs no
-  entry, being already on the generation span. For the same reason `summarize_text`
+  entry, being already on the generation span. `prompt_version`
+  (`prompts.prompt_version`) is a short hash over `SYSTEM_INSTRUCTION` **and** the
+  strategy's own template, so the key names the strategy while the version pins the
+  wording a run actually used — editing either template moves it. For the same reason `summarize_text`
   passes the prompt and the content as two parts instead of one concatenated string
   — a multi-part text prompt is still text-only, so it stays instrumented.
   Consequences worth knowing: the Gemini-file call is never

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -177,9 +177,13 @@ to Gemini — return the raw model text with **no** prefix.
   entry, being already on the generation span. `prompt_version`
   (`prompts.prompt_version`) is a short hash over `SYSTEM_INSTRUCTION` **and** the
   strategy's own template, so the key names the strategy while the version pins the
-  wording a run actually used — editing either template moves it. For the same reason `summarize_text`
-  passes the prompt and the content as two parts instead of one concatenated string
-  — a multi-part text prompt is still text-only, so it stays instrumented.
+  wording a run actually used — editing either template moves it. For the same reason
+  `summarize_text` passes the prompt and the content as two parts instead of one
+  concatenated string — a multi-part text prompt is still text-only, so it stays
+  instrumented. Blank or whitespace-only text is the exception: it sends the prompt
+  part alone, so a trace consumer must not assume a content part is present. That case
+  is reachable — `AudioTranscriber.transcribe` returns `""` for audio WhisperX finds no
+  segments in, such as silence or music — and an empty text part is not worth sending.
   Consequences worth knowing: the Gemini-file call is never
   traced, but a media message still is when it falls through to Replicate
   transcription, which summarizes a plain string; a trace spans the model call only,

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -57,7 +57,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (orchestrator over `ApiBackend` primary → `YtDlpBackend` fallback, mirroring `parsing.py`'s `ParserBackend`). |
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
 | `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
-| `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (MIME, file upload/poll), `Tracer` (names/tags the Langfuse trace for a message, if one is opened). |
+| `services.py` | `Messenger` (Telegram send with retry + 4096-unit chunking), `QuotaManager` (rate limits), `GeminiHelper` (MIME, file upload/poll), `Tracer` (names, tags and adds settings metadata to the Langfuse trace for a message, if one is opened). |
 | `container.py` | `Container` + `build_container()` — the composition root; wires every collaborator to `config`'s clients. `Container` carries only the five roots `BotApp` holds (`bot`, `quota_manager`, `tracer`, `user_repo`, `handlers`); the rest of the graph is reached through `handlers`. |
 | `database.py` | `UserRepository` — users table access (SQLAlchemy + Postgres). |
 | `models.py` | `UsersOrm` — the single `users` table (id, approval, per-user settings, `daily_limit`). |
@@ -167,8 +167,17 @@ to Gemini — return the raw model text with **no** prefix.
   would get real token usage with no content — a wrong cost signal, useless for
   datasets and evaluators. **Do not re-enable it for file runs.**
   `Tracer.observe_message` opens no span of its own, it only names and attributes
-  (`trace_name="handle_message"`, tagged with the content type) whatever spans the
-  message's model calls open. Consequences worth knowing: the Gemini-file call is never
+  (`trace_name="handle_message"`, tagged with the content type, plus `prompt_key`,
+  `target_language` and `thinking_level` as metadata) whatever spans the
+  message's model calls open. Those three are metadata because nothing else carries
+  them: pydantic-ai exports only the six numeric OTel model settings, so the
+  provider-specific, string-valued thinking level never reaches a span, and the other
+  two would have to be parsed back out of the prompt wording. They exist to make a
+  trace filterable and replayable as an evaluation dataset item; the model id needs no
+  entry, being already on the generation span. For the same reason `summarize_text`
+  passes the prompt and the content as two parts instead of one concatenated string
+  — a multi-part text prompt is still text-only, so it stays instrumented.
+  Consequences worth knowing: the Gemini-file call is never
   traced, but a media message still is when it falls through to Replicate
   transcription, which summarizes a plain string; a trace spans the model call only,
   not the download, parse or upload around it; and a retried `summarize_text` produces

--- a/src/main.py
+++ b/src/main.py
@@ -287,7 +287,13 @@ class BotApp:
                 self._bot.send_message(message.chat.id, "You are not approved.")
                 return
 
-            with self._tracer.observe_message(user.user_id, message.content_type):
+            with self._tracer.observe_message(
+                user_id=user.user_id,
+                content_type=message.content_type,
+                prompt_key=user.prompt_key_for_summary,
+                target_language=user.target_language,
+                thinking_level=user.thinking_level,
+            ):
                 self.process_message_content(message, user)
 
         except LimitExceededError as e:

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -1,5 +1,7 @@
 # ruff: noqa: E501
 
+from hashlib import sha256
+
 PROMPTS = {
     "basic_prompt_for_transcript": """
         Produce a detailed summary of the content below.
@@ -27,3 +29,15 @@ SYSTEM_INSTRUCTION = """
     - Stay faithful to the source. Do not invent facts, speakers, timestamps, or structure that is not in the content.
     - If the content is a transcript or audio, ignore non-verbal cues such as [music] or [laughter] and treat any recognition errors or missing punctuation as artifacts — do not mention them in the output.
 """
+
+
+def prompt_version(prompt_key: str) -> str:
+    """Return a short hash pinning the wording `prompt_key` sends right now.
+
+    `SYSTEM_INSTRUCTION` is hashed in too, so editing either template moves the
+    version. On a trace the pair divides the work: `prompt_key` names the
+    strategy and survives rewordings, this pins the revision a run used — which
+    a key alone cannot, and which an evaluation comparing runs over time needs.
+    """
+    payload = f"{SYSTEM_INSTRUCTION}\0{PROMPTS[prompt_key]}"
+    return sha256(payload.encode()).hexdigest()[:12]

--- a/src/services.py
+++ b/src/services.py
@@ -202,8 +202,23 @@ class Tracer:
             self._client.shutdown()
 
     @contextmanager
-    def observe_message(self, user_id: int, content_type: str) -> Generator[None]:
+    def observe_message(
+        self,
+        user_id: int,
+        content_type: str,
+        prompt_key: str,
+        target_language: str,
+        thinking_level: str,
+    ) -> Generator[None]:
         """Name and attribute whatever trace one Telegram message produces.
+
+        The three settings go in as metadata because nothing else records them:
+        pydantic-ai exports only the six numeric OTel model settings, so the
+        thinking level — provider-specific and a string — never reaches a span,
+        and the other two would otherwise have to be parsed back out of the
+        prompt wording. Recording them keeps a trace filterable and replayable
+        as an evaluation dataset item. The model id needs no entry; it is
+        already on the generation span.
 
         Opens no span itself, so a message whose model calls all carry an
         uploaded file — which `LLMClient` leaves uninstrumented — produces no
@@ -216,5 +231,10 @@ class Tracer:
             trace_name="handle_message",
             user_id=str(user_id),
             tags=[content_type],
+            metadata={
+                "prompt_key": prompt_key,
+                "target_language": target_language,
+                "thinking_level": thinking_level,
+            },
         ):
             yield

--- a/src/services.py
+++ b/src/services.py
@@ -21,6 +21,7 @@ from tenacity import (
 
 from config import DAILY_LIMIT_KEY, MINUTE_LIMIT_KEY
 from exceptions import LimitExceededError
+from prompts import prompt_version
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -212,13 +213,13 @@ class Tracer:
     ) -> Generator[None]:
         """Name and attribute whatever trace one Telegram message produces.
 
-        The three settings go in as metadata because nothing else records them:
+        The settings go in as metadata because nothing else records them:
         pydantic-ai exports only the six numeric OTel model settings, so the
         thinking level — provider-specific and a string — never reaches a span,
-        and the other two would otherwise have to be parsed back out of the
-        prompt wording. Recording them keeps a trace filterable and replayable
-        as an evaluation dataset item. The model id needs no entry; it is
-        already on the generation span.
+        and the rest would otherwise have to be parsed back out of the prompt
+        wording. Recording them keeps a trace filterable and replayable as an
+        evaluation dataset item. The model id needs no entry; it is already on
+        the generation span.
 
         Opens no span itself, so a message whose model calls all carry an
         uploaded file — which `LLMClient` leaves uninstrumented — produces no
@@ -233,6 +234,7 @@ class Tracer:
             tags=[content_type],
             metadata={
                 "prompt_key": prompt_key,
+                "prompt_version": prompt_version(prompt_key),
                 "target_language": target_language,
                 "thinking_level": thinking_level,
             },

--- a/src/summary.py
+++ b/src/summary.py
@@ -177,7 +177,8 @@ class Summarizer:
         concatenated string, so a trace records them as separate fields — an
         evaluator can then swap either one without parsing them apart. A
         multi-part text prompt is still text-only, so this stays on
-        `LLMClient`'s instrumented agent.
+        `LLMClient`'s instrumented agent. Blank `text` drops its part instead
+        of sending an empty one.
 
         Raises:
             RetryError: If transient model errors persist, or the model keeps
@@ -186,13 +187,17 @@ class Summarizer:
 
         """
         prompt = dedent(PROMPTS[prompt_key]).strip()
+        # Silent or music-only audio gives WhisperX no segments, so the rescue
+        # path can hand us "". Sending that as its own part would put an empty
+        # text part in the request; the concatenated form used to swallow it.
+        content = [prompt, text] if text.strip() else [prompt]
         self._quota_manager.check_quota(
             user_id=user_id,
             daily_limit=daily_limit,
             quantity=1,
         )
         return self._llm_client.run(
-            content=[prompt, text],
+            content=content,
             model_id=model,
             target_language=target_language,
             thinking_level=thinking_level,

--- a/src/summary.py
+++ b/src/summary.py
@@ -173,20 +173,26 @@ class Summarizer:
     ) -> str:
         """Summarize already-extracted text (a transcript or webpage content).
 
+        The prompt and the content go in as two parts rather than one
+        concatenated string, so a trace records them as separate fields — an
+        evaluator can then swap either one without parsing them apart. A
+        multi-part text prompt is still text-only, so this stays on
+        `LLMClient`'s instrumented agent.
+
         Raises:
             RetryError: If transient model errors persist, or the model keeps
                 returning an empty response — the `AttributeError` that stands
                 for it is retried and then wrapped, never re-raised.
 
         """
-        prompt = (f"{dedent(PROMPTS[prompt_key])} {text}").strip()
+        prompt = dedent(PROMPTS[prompt_key]).strip()
         self._quota_manager.check_quota(
             user_id=user_id,
             daily_limit=daily_limit,
             quantity=1,
         )
         return self._llm_client.run(
-            content=prompt,
+            content=[prompt, text],
             model_id=model,
             target_language=target_language,
             thinking_level=thinking_level,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,40 @@
+from prompts import PROMPTS, prompt_version
+
+
+def test_prompt_version_is_a_stable_short_hex_digest():
+    """prompt_version returns the same short hex digest for repeated calls."""
+    version = prompt_version("basic_prompt_for_transcript")
+
+    assert version == prompt_version("basic_prompt_for_transcript")
+    assert len(version) == 12
+    assert int(version, 16) >= 0
+
+
+def test_prompt_version_differs_between_strategies():
+    """Each prompt strategy gets its own version."""
+    versions = {prompt_version(key) for key in PROMPTS}
+
+    assert len(versions) == len(PROMPTS)
+
+
+def test_prompt_version_moves_when_the_prompt_is_reworded(mocker):
+    """Editing a prompt template changes that key's version."""
+    before = prompt_version("basic_prompt_for_transcript")
+    mocker.patch.dict(
+        "prompts.PROMPTS",
+        {"basic_prompt_for_transcript": "Reworded."},
+    )
+
+    assert prompt_version("basic_prompt_for_transcript") != before
+
+
+def test_prompt_version_moves_when_the_system_instruction_is_reworded(mocker):
+    """Editing the shared system instruction changes every key's version.
+
+    The prompt key alone cannot express this, which is the reason the version
+    hashes both templates rather than the strategy's own text.
+    """
+    before = prompt_version("basic_prompt_for_transcript")
+    mocker.patch("prompts.SYSTEM_INSTRUCTION", "Reworded system instruction.")
+
+    assert prompt_version("basic_prompt_for_transcript") != before

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -335,7 +335,13 @@ def test_observe_message_noop_when_langfuse_disabled(mocker):
     """observe_message is a no-op context manager when Langfuse is not configured."""
     mock_propagate = mocker.patch("services.propagate_attributes")
 
-    with Tracer(None).observe_message(user_id=42, content_type="voice"):
+    with Tracer(None).observe_message(
+        user_id=42,
+        content_type="voice",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        thinking_level="HIGH",
+    ):
         pass
 
     mock_propagate.assert_not_called()
@@ -346,7 +352,13 @@ def test_observe_message_names_and_tags_trace_when_langfuse_enabled(mocker):
     mock_client = mocker.MagicMock()
     mock_propagate = mocker.patch("services.propagate_attributes")
 
-    with Tracer(mock_client).observe_message(user_id=42, content_type="voice"):
+    with Tracer(mock_client).observe_message(
+        user_id=42,
+        content_type="voice",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        thinking_level="HIGH",
+    ):
         pass
 
     mock_client.start_as_current_observation.assert_not_called()
@@ -354,4 +366,9 @@ def test_observe_message_names_and_tags_trace_when_langfuse_enabled(mocker):
         trace_name="handle_message",
         user_id="42",
         tags=["voice"],
+        metadata={
+            "prompt_key": "basic_prompt_for_transcript",
+            "target_language": "English",
+            "thinking_level": "HIGH",
+        },
     )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,6 +5,7 @@ from limits.strategies import FixedWindowRateLimiter
 from limits.util import WindowStats
 
 from exceptions import LimitExceededError
+from prompts import prompt_version
 from services import GeminiHelper, Messenger, QuotaManager, Tracer
 
 
@@ -368,6 +369,9 @@ def test_observe_message_names_and_tags_trace_when_langfuse_enabled(mocker):
         tags=["voice"],
         metadata={
             "prompt_key": "basic_prompt_for_transcript",
+            # Derived, not hardcoded: a hardcoded digest would turn every
+            # prompt edit into a failing assertion with nothing to teach.
+            "prompt_version": prompt_version("basic_prompt_for_transcript"),
             "target_language": "English",
             "thinking_level": "HIGH",
         },

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -154,6 +154,32 @@ def test_summarize_text_from_webpage(mocker):
     assert call_kwargs["model_id"] == "gemini-3.5-flash-lite"
 
 
+@pytest.mark.parametrize("blank", ["", "   \n  "])
+def test_summarize_text_drops_the_content_part_when_text_is_blank(mocker, blank):
+    """Test summarize_text sends the prompt alone rather than an empty part.
+
+    The Replicate rescue path yields "" for audio WhisperX finds no segments
+    in — silence or music — and an empty text part is not worth sending.
+    """
+    summarizer, fakes = _make_summarizer(mocker)
+    fakes.quota_manager.check_quota.return_value = True
+    fakes.llm_client.run.return_value = "Empty summary."
+
+    summarizer.summarize_text(
+        text=blank,
+        model="gemini-3.5-flash-lite",
+        prompt_key="basic_prompt_for_transcript",
+        target_language="English",
+        user_id=123,
+        daily_limit=10,
+        thinking_level="MINIMAL",
+    )
+
+    assert fakes.llm_client.run.call_args.kwargs["content"] == [
+        dedent(PROMPTS["basic_prompt_for_transcript"]).strip(),
+    ]
+
+
 def test_summarize_with_file_upload_failure(mocker):
     """Test summarize_with_file raises when file upload fails."""
     summarizer, fakes = _make_summarizer(mocker)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 from types import SimpleNamespace
 
 import pytest
@@ -9,6 +10,7 @@ import summary as summary_module
 from config import ModelSpec
 from domain import PrefixedText
 from exceptions import FetchTranscriptError, LimitExceededError
+from prompts import PROMPTS
 from summary import Summarizer
 
 # ---------------------------------------------------------------------------
@@ -123,7 +125,7 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
 
 
 def test_summarize_text_from_webpage(mocker):
-    """Test summarize_text sends pre-parsed webpage content as a plain prompt.
+    """Test summarize_text sends the prompt and the content as separate parts.
 
     The transcript paths reach the model through this same method, so this
     covers them too — only the caller differs.
@@ -144,9 +146,11 @@ def test_summarize_text_from_webpage(mocker):
 
     assert result == "Webpage summary."
     call_kwargs = fakes.llm_client.run.call_args.kwargs
-    # A bare string, not a content list: the text path stays provider-agnostic.
-    assert isinstance(call_kwargs["content"], str)
-    assert "Parsed page content." in call_kwargs["content"]
+    # Two parts, not one concatenated string: a trace has to record the prompt
+    # and the summarized content as separate fields.
+    prompt, content = call_kwargs["content"]
+    assert content == "Parsed page content."
+    assert prompt == dedent(PROMPTS["basic_prompt_for_transcript"]).strip()
     assert call_kwargs["model_id"] == "gemini-3.5-flash-lite"
 
 


### PR DESCRIPTION
Makes a Langfuse trace self-describing enough to be harvested into an evaluation dataset, so new models and thinking levels can be compared against real traffic instead of ad-hoc manual testing.

## Why

Traces recorded the model, tokens, cost, `user_id` and the content-type tag, but not the settings that decide the summary:

- **`thinking_level` was absent entirely, and unrecoverable.** pydantic-ai exports only six numeric OTel model settings (`_instrumentation.py:41`) and additionally requires `isinstance(value, float | int)`. The level travels inside `GoogleModelSettings(google_thinking_config=...)` — provider-specific and string-valued — so it never reached a span.
- **`prompt_key` and `target_language` were recoverable only by parsing prompt wording**, which breaks the moment a prompt is edited — exactly what an evaluation does.
- **The prompt and the summarized content were concatenated into one string**, so a judge could not read them as separate fields without splitting them apart again.

## What changed

**Trace metadata** — `Tracer.observe_message` takes `prompt_key`, `target_language` and `thinking_level` and forwards them through `propagate_attributes(metadata=...)`, which propagates to every child span. The call site reads them off the `user` record already loaded a few lines earlier, so there is no new lookup. The model id gets no entry: it is already on the generation span.

**`prompt_version`** — a 12-hex-char sha256 over `SYSTEM_INSTRUCTION` **and** the strategy's own template, carried next to `prompt_key`. The key names the strategy and survives rewordings; the version pins the revision a run actually used. Hashing both templates is the point: a `SYSTEM_INSTRUCTION` edit changes every summary while leaving both keys and both per-strategy templates untouched, so a version ignoring it would report "no change" across the most likely edit.

**Prompt/content split** — `summarize_text` passes `[prompt, text]` instead of `f"{prompt} {text}"`. A multi-part text prompt is still text-only per `LLMClient._is_text_only`, so the run stays on the instrumented agent and tracing is unaffected.

## Reviewer notes

- **Blank text.** The split would have sent an empty transcript as its own empty text part — `_map_user_prompt` appends every string unconditionally (`google.py:1265`), so Gemini would receive `parts: [..., {'text': ''}]`. Reachable: `AudioTranscriber.transcribe` joins WhisperX segments with no emptiness guard, so silent or music-only audio returns `""`. The third commit drops the second part when the text is blank, restoring the previous single-part shape.
- **Pre-existing, left alone.** That unguarded empty transcription in `transcription.py:94` is the underlying defect and predates this branch. Out of scope here.
- **No backfill.** Traces already ingested stay without metadata; the usable harvesting window starts at deploy.
- **File inputs unchanged.** Uploaded-file runs remain uninstrumented by design, so audio and PDF summaries are still untraced and out of dataset scope.
- **Test choice.** The `observe_message` assertions derive the expected digest by calling `prompt_version` rather than hardcoding it — a hardcoded digest would fail on every future prompt edit while asserting nothing useful.

## Verification

289 tests pass, 100% line coverage retained across every `src/` module, all pre-commit hooks green (ruff, ty, pytest). `docs/context/architecture.md` updated for the new tracing metadata and the `prompts.py` surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer tracing details, including language, thinking level, content type, and prompt version.
  * Added deterministic prompt version tracking for improved traceability.
  * Improved text summarization by separating prompts from content inputs.
* **Bug Fixes**
  * Blank or whitespace-only text is no longer sent to the model.
* **Documentation**
  * Expanded architecture documentation covering trace metadata, prompt versions, and multipart prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->