### PR TITLE
docs: note what a traced message sends to Langfuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ would record as token usage with no readable content. `LANGFUSE_BASE_URL`
 defaults to Langfuse Cloud (EU); use
 `https://us.cloud.langfuse.com` for the US region or your self-hosted URL.
 
+Tracing is off unless both keys are set. When it is on, each traced message sends the prompt, the
+extracted webpage text or transcript, the generated summary, and the Telegram user ID to your
+Langfuse project, where they are stored under that project's retention settings. If you run this bot
+for anyone other than yourself, treat that as processing their content on a third-party service — or
+point `LANGFUSE_BASE_URL` at a self-hosted instance.
+
 Pass in an empty string to `PROXY` for direct connection. \
 Or use `schema`://`username`:`password`@`proxy_address`:`port` \
 For example `https://user:password@proxy.com:1234`


### PR DESCRIPTION
## What changed

One paragraph in `README.md`, appended to the existing Langfuse section: it states that tracing is off unless both keys are set, and enumerates what a traced message actually ships — the prompt, the extracted webpage text or transcript, the generated summary, and the Telegram user ID.

## Why

The README already documented *how* to turn tracing on and *which* calls are traced, but never *what leaves the machine* when it is. That is a different exposure class from the services already in the stack: Gemini and Replicate see content transiently as part of doing the work, and Sentry receives errors rather than content. Langfuse retains full request and response content in a dashboard, keyed to a Telegram user ID. An operator running this bot for other people should be told before setting the keys.

## Reviewer notes

Docs-only — no code, no tests, no `docs/context/` change (the paragraph describes existing behavior rather than changing it). Every claim was checked against the source:

- "off unless both keys are set" → `src/config.py:135`, `langfuse_client` stays `None` and `Agent.instrument_all()` is skipped otherwise
- prompt + content + completion recorded → `Agent.instrument_all()` takes no arguments, and pydantic-ai's `InstrumentationSettings.include_content` defaults to `True`
- Telegram user ID → `src/main.py:290` passes `user.user_id` (selected by `message.from_user.id`) into `propagate_attributes(user_id=...)` at `src/services.py:231`
- "each traced message" is hedged deliberately: file-input runs stay uninstrumented via `src/llm.py:38`, which the preceding paragraph already explains

`NOTICE` needs no update — the `langfuse` SDK is MIT (`License-Expression: MIT` in 4.14.2), and that file tracks copyleft dependencies only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on Langfuse tracing behavior.
  * Documented data transmission, retention, third-party processing, and self-hosted configuration considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->