### PR TITLE
Adopt pydantic-ai thinking levels, drop gemini-3.5-flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ uv run python scripts/db.py
 uv run alembic upgrade head
 ```
 
+**Migrate before you deploy, on every release — not just the first.** Nothing runs
+Alembic for you: neither `Dockerfile` nor `compose.yaml` does, so the order is yours to
+get right. A migration that rewrites a stored setting leaves the new code reading values
+it does not accept, and settings are read on every message — so starting the new
+container first can fail every request for every user until the migration lands. The
+reverse order is safe.
+
 For developers, how to generate a migration.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -118,13 +118,6 @@ uv run python scripts/db.py
 uv run alembic upgrade head
 ```
 
-**Migrate before you deploy, on every release — not just the first.** Nothing runs
-Alembic for you: neither `Dockerfile` nor `compose.yaml` does, so the order is yours to
-get right. A migration that rewrites a stored setting leaves the new code reading values
-it does not accept, and settings are read on every message — so starting the new
-container first can fail every request for every user until the migration lands. The
-reverse order is safe.
-
 For developers, how to generate a migration.
 
 ```bash

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -47,9 +47,16 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
   wav/mp3 audio inline, while this pipeline produces Opus `.ogg`. Upstream,
   `xiaomi/mimo-v2.5` does read audio and both GPT-5.6 models do read files; matching the
   flags to the catalog without first building an inline path breaks the routing.
-- **Thinking level is coarser on OpenRouter** — its `reasoning.effort` has only
-  low/medium/high, so MINIMAL and LOW arrive as one effort where Gemini distinguishes
-  all four. A limit of that API; no normalization layer recovers it.
+- **Thinking levels are pydantic-ai's, translated by pydantic-ai** — the allow-list is
+  its `ThinkingEffort` (`minimal|low|medium|high|xhigh`), passed to the unified `thinking`
+  setting, and each provider's model maps it. This codebase owns no mapping, which is what
+  a test pinning `ALLOWED_THINKING_LEVELS` to `get_args(ThinkingEffort)` protects. Two
+  consequences: Gemini receives `include_thoughts=True`, hard-coded beside the level in
+  pydantic-ai's Google translation, so it generates thought summaries `run` discards —
+  the accepted price of owning no mapping, **do not** reintroduce `google_thinking_config`
+  to dodge it. And `xhigh` is indistinguishable from `high` on both registered providers
+  (Gemini has no XHIGH; OpenRouter's `reasoning.effort` stops at high), so it is offered
+  for a future provider, not for a difference users can feel today.
 - **PostgreSQL for persistent user data, Valkey for ephemeral rate-limit counters** —
   the two have different durability needs.
 - **Modal for serverless cron** — clears the bot's own per-user daily counters in
@@ -63,7 +70,7 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
 | `main.py` | `BotApp` — Telegram entry point. Command handlers + the unified `handle_message`; routes by `content_type`; top-level error → user-message mapping. `build_app(container)` wires it from the composition root and registers its handlers; the `__main__` block just calls `build_app`, `run`, `shutdown`. |
 | `handlers.py` | `MessageHandlers` — per-content-type handlers. Media validation, builds `SummaryKwargs` from the user record, picks the summarize path. |
 | `summary.py` | `Summarizer` — the core summarization orchestrator. Owns the input-type branching, assembles the message content, and calls the injected `LLMClient.run`. |
-| `llm.py` | `LLMClient` — the provider seam. Each instance holds two pydantic-ai `Agent`s — one traced, one with instrumentation off for uploaded-file runs (see Tracing below) — plus a model cache keyed by id across providers; model, instructions and settings are resolved per run. Provider dispatch lives in `build_model` (keyed on `config.MODEL_SPECS[...].provider`, Google and OpenRouter today); `build_settings` splits Google's `google_thinking_config` from the provider-agnostic thinking effort everything else takes. |
+| `llm.py` | `LLMClient` — the provider seam. Each instance holds two pydantic-ai `Agent`s — one traced, one with instrumentation off for uploaded-file runs (see Tracing below) — plus a model cache keyed by id across providers; model, instructions and settings are resolved per run. Provider dispatch lives in `build_model` (keyed on `config.MODEL_SPECS[...].provider`, Google and OpenRouter today); `build_settings` has no provider branch at all — every provider takes the agnostic `thinking` effort. |
 | `transcription.py` | `AudioTranscriber` (Replicate WhisperX) + `YouTubeTranscriber` (orchestrator over `ApiBackend` primary → `YtDlpBackend` fallback, mirroring `parsing.py`'s `ParserBackend`). |
 | `download.py` | `Downloader` — YouTube audio (yt-dlp→mp3), Castro (scrape→mp3), Telegram file fetch. |
 | `parsing.py` | `WebParser` — webpage text extraction, Exa primary → Tavily fallback. |
@@ -190,7 +197,7 @@ to Gemini — return the raw model text with **no** prefix.
   `prompt_version`, `target_language` and `thinking_level` as metadata) whatever spans
   the message's model calls open. Those are metadata because nothing else carries
   them: pydantic-ai exports only the six numeric OTel model settings, so the
-  provider-specific, string-valued thinking level never reaches a span, and the rest
+  string-valued thinking level never reaches a span, and the rest
   would have to be parsed back out of the prompt wording. They exist to make a
   trace filterable and replayable as an evaluation dataset item; the model id needs no
   entry, being already on the generation span. `prompt_version`

--- a/migrations/versions/12d7c48a6e14_lowercase_thinking_levels_and_default_.py
+++ b/migrations/versions/12d7c48a6e14_lowercase_thinking_levels_and_default_.py
@@ -1,0 +1,61 @@
+"""lowercase thinking levels and default gemini-3.6-flash
+
+Revision ID: 12d7c48a6e14
+Revises: 96da01ef8da4
+Create Date: 2026-08-07 10:29:41.219649
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "12d7c48a6e14"
+down_revision: Union[str, None] = "96da01ef8da4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE users SET thinking_level = lower(thinking_level)")
+    op.execute(
+        "UPDATE users SET summarizing_model = 'gemini-3.6-flash' "
+        "WHERE summarizing_model = 'gemini-3.5-flash'",
+    )
+    op.alter_column(
+        "users",
+        "summarizing_model",
+        existing_type=sa.VARCHAR(),
+        server_default="gemini-3.6-flash",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "users",
+        "thinking_level",
+        existing_type=sa.VARCHAR(),
+        server_default="medium",
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # The summarizing_model rewrite is not reversed: gemini-3.5-flash is gone
+    # from MODEL_SPECS, so restoring it would leave users on an unselectable id.
+    # Same choice as 6bb4ed473ffd, which dropped the previous legacy models.
+    op.execute("UPDATE users SET thinking_level = upper(thinking_level)")
+    op.alter_column(
+        "users",
+        "summarizing_model",
+        existing_type=sa.VARCHAR(),
+        server_default="gemini-3.5-flash-lite",
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "users",
+        "thinking_level",
+        existing_type=sa.VARCHAR(),
+        server_default="HIGH",
+        existing_nullable=False,
+    )

--- a/migrations/versions/12d7c48a6e14_lowercase_thinking_levels_and_default_.py
+++ b/migrations/versions/12d7c48a6e14_lowercase_thinking_levels_and_default_.py
@@ -44,7 +44,15 @@ def downgrade() -> None:
     # The summarizing_model rewrite is not reversed: gemini-3.5-flash is gone
     # from MODEL_SPECS, so restoring it would leave users on an unselectable id.
     # Same choice as 6bb4ed473ffd, which dropped the previous legacy models.
-    op.execute("UPDATE users SET thinking_level = upper(thinking_level)")
+    # xhigh has no counterpart in the vocabulary being restored, so a plain
+    # upper() would leave those users on XHIGH — absent from the old allow-list
+    # and rejected by Gemini, with nothing to heal it but re-picking a level.
+    # Collapse it onto HIGH, which is what pydantic-ai does going forward.
+    op.execute(
+        "UPDATE users SET thinking_level = CASE "
+        "WHEN lower(thinking_level) = 'xhigh' THEN 'HIGH' "
+        "ELSE upper(thinking_level) END",
+    )
     op.alter_column(
         "users",
         "summarizing_model",

--- a/src/config.py
+++ b/src/config.py
@@ -101,12 +101,6 @@ class ModelSpec:
 
 
 MODEL_SPECS: dict[str, ModelSpec] = {
-    "gemini-3.5-flash": ModelSpec(
-        label="Gemini 3.5 Flash",
-        provider="google",
-        supports_audio=True,
-        supports_files=True,
-    ),
     "gemini-3.6-flash": ModelSpec(
         label="Gemini 3.6 Flash",
         provider="google",
@@ -174,13 +168,18 @@ ALLOWED_MODELS_FOR_SUMMARY = list(MODEL_SPECS.keys())
 # If you change DEFAULT_MODEL_ID_FOR_SUMMARY, also change it in models.py.
 # It also serves documents whose selected model has supports_files=False, so it
 # must stay a spec with supports_files=True.
-DEFAULT_MODEL_ID_FOR_SUMMARY = "gemini-3.5-flash-lite"
-DEFAULT_THINKING_LEVEL = "HIGH"
+DEFAULT_MODEL_ID_FOR_SUMMARY = "gemini-3.6-flash"
+DEFAULT_THINKING_LEVEL = "medium"
+# The keys are pydantic-ai's `ThinkingEffort`, which every provider's model maps
+# to its own vocabulary; nothing here translates them. The values exist only to
+# give the reply keyboard readable buttons — "xhigh" has no decent title-case.
+# Ordered low to high, which is the order the keyboard shows.
 THINKING_LEVEL_LABELS: dict[str, str] = {
-    "MINIMAL": "Minimal",
-    "LOW": "Low",
-    "MEDIUM": "Medium",
-    "HIGH": "High",
+    "minimal": "Minimal",
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High",
+    "xhigh": "Extra High",
 }
 THINKING_LEVEL_LABELS_REVERSE: dict[str, str] = {
     v: k for k, v in THINKING_LEVEL_LABELS.items()

--- a/src/database.py
+++ b/src/database.py
@@ -120,7 +120,7 @@ class UserRepository:
 
     def set_thinking_level(self, user_id: int, thinking_level: str) -> bool:
         """Set the user's thinking level; False if unsupported or user unknown."""
-        normalized = thinking_level.upper()
+        normalized = thinking_level.lower()
         if normalized not in ALLOWED_THINKING_LEVELS:
             return False
         return self._update_field(user_id, "thinking_level", normalized)

--- a/src/llm.py
+++ b/src/llm.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, cast
 
 from pydantic_ai import Agent, UploadedFile
-from pydantic_ai.models.google import GoogleModel, GoogleModelSettings
+from pydantic_ai.models.google import GoogleModel
 from pydantic_ai.models.openrouter import OpenRouterModel
 from pydantic_ai.providers.google import GoogleProvider
 from pydantic_ai.settings import ModelSettings
@@ -72,28 +72,28 @@ class LLMClient:
             self._models[model_id] = model
         return self._models[model_id]
 
-    def build_settings(self, model_id: str, thinking_level: str) -> ModelSettings:
-        """Build the per-run settings, adding provider-specific options.
+    def build_settings(self, thinking_level: str) -> ModelSettings:
+        """Build the per-run settings from the agnostic thinking effort.
 
-        Google goes through `google_thinking_config` rather than the agnostic
-        `thinking` effort: the effort mapping also sets `include_thoughts`, so
-        Gemini would generate thought summaries that `run` discards. Passing the
-        level straight through keeps the request shape and stays lenient about
-        an unrecognized level, which the provider decides on rather than us.
+        Deliberately owns no mapping: `thinking_level` is a pydantic-ai
+        `ThinkingEffort`, and each provider's model translates it. Two
+        consequences worth knowing rather than rediscovering:
 
-        Every other provider takes the agnostic effort instead. OpenRouter's own
-        `reasoning.effort` has only low/medium/high, so MINIMAL and LOW reach it
-        as one effort — a limit of that API, not of this mapping.
+        Gemini receives `include_thoughts=True` — it is hard-coded alongside the
+        level in pydantic-ai's Google translation, so Gemini generates thought
+        summaries that `run` then discards. Reaching that translation any other
+        way is not possible; owning the mapping here to avoid it is what this
+        deliberately does not do.
+
+        `xhigh` is indistinguishable from `high` on both registered providers
+        (Gemini has no XHIGH; OpenRouter's `reasoning.effort` stops at high). It
+        is offered for a provider that distinguishes it, not for today.
+
+        An unrecognized level survives this call but raises `KeyError` when the
+        request is built. Only a stale `users.thinking_level` can reach that,
+        since `database.set_thinking_level`'s allow-list is the only writer.
         """
-        if MODEL_SPECS[model_id].provider == "google":
-            return GoogleModelSettings(
-                google_thinking_config={
-                    # Cast, not types.ThinkingLevel(...): an unrecognized level
-                    # stays a plain string for the provider to rule on.
-                    "thinking_level": cast("types.ThinkingLevel", thinking_level),
-                },
-            )
-        return ModelSettings(thinking=cast("ThinkingLevel", thinking_level.lower()))
+        return ModelSettings(thinking=cast("ThinkingLevel", thinking_level))
 
     def build_uploaded_file(self, model_id: str, file: types.File) -> UploadedFile:
         """Reference a file already uploaded to the provider's file API.
@@ -146,10 +146,7 @@ class LLMClient:
             content,
             model=self.build_model(model_id),
             instructions=instructions,
-            model_settings=self.build_settings(
-                model_id,
-                thinking_level=thinking_level,
-            ),
+            model_settings=self.build_settings(thinking_level=thinking_level),
         )
         if not result.output:
             raise AttributeError

--- a/src/models.py
+++ b/src/models.py
@@ -26,10 +26,10 @@ class UsersOrm(Base):
     approved: Mapped[bool] = mapped_column(server_default="False")
     target_language: Mapped[str] = mapped_column(server_default="English")
     summarizing_model: Mapped[str] = mapped_column(
-        server_default="gemini-3.5-flash-lite",
+        server_default="gemini-3.6-flash",
     )
     prompt_key_for_summary: Mapped[str] = mapped_column(
         server_default="basic_prompt_for_transcript",
     )
     daily_limit: Mapped[int] = mapped_column(server_default="0")
-    thinking_level: Mapped[str] = mapped_column(server_default="HIGH")
+    thinking_level: Mapped[str] = mapped_column(server_default="medium")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -69,10 +69,10 @@ def test_handle_myinfo(message_factory, mocker):
         user_id=123,
         approved=True,
         target_language="English",
-        summarizing_model="gemini-3.5-flash",
+        summarizing_model="gemini-3.6-flash",
         prompt_key_for_summary="basic_prompt_for_transcript",
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
     fakes.user_repo.select_user.return_value = mock_user
     fakes.quota_manager.get_remaining_quota.return_value = 7
@@ -84,7 +84,7 @@ def test_handle_myinfo(message_factory, mocker):
     assert "Target language: English" in content
     assert "Daily limit: 10" in content
     assert "Remaining quota: 7" in content
-    assert "Summarizing model: Gemini 3.5 Flash" in content
+    assert "Summarizing model: Gemini 3.6 Flash" in content
     assert "Thinking level: Minimal" in content
     assert "Prompt strategy: Detailed Summary" in content
     assert "YouTube transcript" not in content
@@ -163,7 +163,7 @@ def test_proceed_set_target_language_success(message_factory, mocker):
 
 def test_proceed_set_summarizing_model_success(message_factory, mocker):
     """Test successful model selection."""
-    msg = message_factory(content_type="text", text="Gemini 3.5 Flash")
+    msg = message_factory(content_type="text", text="Gemini 3.6 Flash")
     app, fakes = make_app(mocker)
     fakes.user_repo.set_summarizing_model.return_value = True
 
@@ -171,10 +171,10 @@ def test_proceed_set_summarizing_model_success(message_factory, mocker):
 
     fakes.user_repo.set_summarizing_model.assert_called_once_with(
         msg.from_user.id,
-        "gemini-3.5-flash",
+        "gemini-3.6-flash",
     )
     assert (
-        "The summarizing model is set to Gemini 3.5 Flash"
+        "The summarizing model is set to Gemini 3.6 Flash"
         in fakes.bot.send_message.call_args[0][1]
     )
 
@@ -205,7 +205,7 @@ def test_proceed_set_thinking_level_success(message_factory, mocker):
 
     app.proceed_set_thinking_level(msg)
 
-    fakes.user_repo.set_thinking_level.assert_called_once_with(msg.from_user.id, "HIGH")
+    fakes.user_repo.set_thinking_level.assert_called_once_with(msg.from_user.id, "high")
     assert "The thinking level is set to High" in fakes.bot.send_message.call_args[0][1]
 
 
@@ -315,7 +315,7 @@ def test_proceed_set_target_language_invalid_choice(message_factory, mocker):
         (
             "proceed_set_summarizing_model",
             "set_summarizing_model",
-            "Gemini 3.5 Flash",
+            "Gemini 3.6 Flash",
             "Failed to update summarizing model.",
         ),
         (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
 import importlib
 import logging
+from typing import get_args
+
+from pydantic_ai.settings import ThinkingEffort
 
 import config
 import utils
@@ -140,3 +143,24 @@ def test_no_model_takes_audio_without_taking_files():
         if spec.supports_audio and not spec.supports_files
     ]
     assert not broken
+
+
+def test_thinking_levels_are_pydantic_ais_vocabulary():
+    """Test the allow-list is exactly pydantic-ai's ThinkingEffort.
+
+    Nothing in this codebase translates a thinking level — each provider's model
+    does. That only holds while the offered levels are the ones pydantic-ai
+    knows: a level it does not recognize raises KeyError as the request is
+    built. Set equality, so a pydantic-ai bump that adds or drops an effort
+    fails here rather than silently leaving the keyboard out of date.
+    """
+    assert set(config.ALLOWED_THINKING_LEVELS) == set(get_args(ThinkingEffort))
+
+
+def test_default_thinking_level_is_selectable():
+    """Test the default survives the allow-list every writer validates against.
+
+    register_user seeds it directly, bypassing set_thinking_level, so a default
+    outside the allow-list would give every new user an unusable level.
+    """
+    assert config.DEFAULT_THINKING_LEVEL in config.ALLOWED_THINKING_LEVELS

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -110,9 +110,9 @@ def test_check_auth_unknown_user(user_repo):
         ("set_target_language", "English", "target_language", "English"),
         (
             "set_summarizing_model",
-            "gemini-3.5-flash",
+            "gemini-3.6-flash",
             "summarizing_model",
-            "gemini-3.5-flash",
+            "gemini-3.6-flash",
         ),
         (
             "set_prompt_strategy",
@@ -120,7 +120,7 @@ def test_check_auth_unknown_user(user_repo):
             "prompt_key_for_summary",
             "basic_prompt_for_transcript",
         ),
-        ("set_thinking_level", "high", "thinking_level", "HIGH"),
+        ("set_thinking_level", "high", "thinking_level", "high"),
     ],
 )
 def test_set_setting_persists(
@@ -164,9 +164,9 @@ def test_set_setting_rejects_unsupported(user_repo, setter, bad_value):
         ("set_target_language", "english", "target_language", "English"),
         (
             "set_summarizing_model",
-            "GEMINI-3.5-FLASH",
+            "GEMINI-3.6-FLASH",
             "summarizing_model",
-            "gemini-3.5-flash",
+            "gemini-3.6-flash",
         ),
         (
             "set_prompt_strategy",
@@ -174,6 +174,7 @@ def test_set_setting_rejects_unsupported(user_repo, setter, bad_value):
             "prompt_key_for_summary",
             "key_points_for_transcript",
         ),
+        ("set_thinking_level", "HIGH", "thinking_level", "high"),
     ],
 )
 def test_set_setting_stores_normalized_value(
@@ -219,9 +220,9 @@ def test_set_thinking_level_rejects_unknown_value(user_repo, sqlite_session_fact
     ("setter", "value"),
     [
         ("set_target_language", "English"),
-        ("set_summarizing_model", "gemini-3.5-flash"),
+        ("set_summarizing_model", "gemini-3.6-flash"),
         ("set_prompt_strategy", "key_points_for_transcript"),
-        ("set_thinking_level", "HIGH"),
+        ("set_thinking_level", "high"),
     ],
 )
 def test_set_setting_missing_user(user_repo, setter, value):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -8,6 +8,7 @@ from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.function import FunctionModel
 from pydantic_ai.models.google import GoogleModel
 from pydantic_ai.models.openrouter import OpenRouterModel
+from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.providers.openrouter import OpenRouterProvider
 from pydantic_ai.settings import ThinkingEffort
 
@@ -46,21 +47,21 @@ def test_build_model_caches_across_providers(mocker):
     """Test the cache is keyed by id alone, so both providers share one dict."""
     client = LLMClient(mocker.MagicMock(), OpenRouterProvider(api_key="mock_key"))
 
-    google = client.build_model("gemini-3.5-flash")
+    google = client.build_model("gemini-3.6-flash")
     openrouter = client.build_model("z-ai/glm-5.2")
 
-    assert client.build_model("gemini-3.5-flash") is google
+    assert client.build_model("gemini-3.6-flash") is google
     assert client.build_model("z-ai/glm-5.2") is openrouter
     assert google is not openrouter
 
 
 def test_build_model_is_cached_per_id(llm_client):
     """Test build_model reuses one model object per id, so clients are shared."""
-    assert llm_client.build_model("gemini-3.5-flash") is llm_client.build_model(
-        "gemini-3.5-flash",
-    )
-    assert llm_client.build_model("gemini-3.5-flash") is not llm_client.build_model(
+    assert llm_client.build_model("gemini-3.6-flash") is llm_client.build_model(
         "gemini-3.6-flash",
+    )
+    assert llm_client.build_model("gemini-3.6-flash") is not llm_client.build_model(
+        "gemini-3.5-flash-lite",
     )
 
 
@@ -88,66 +89,52 @@ def test_build_model_rejects_provider_without_builder(llm_client, mocker):
         llm_client.build_model("mystery-1")
 
 
-@pytest.mark.parametrize("thinking_level", ["MINIMAL", "LOW", "MEDIUM", "HIGH"])
-def test_build_settings_passes_google_thinking_level_through(
-    llm_client,
-    thinking_level,
-):
-    """Test Google gets the level verbatim, not the agnostic effort mapping."""
-    settings = llm_client.build_settings(
-        "gemini-3.5-flash",
-        thinking_level=thinking_level,
-    )
-    assert settings == {"google_thinking_config": {"thinking_level": thinking_level}}
-
-
-def test_build_settings_uses_agnostic_effort_for_other_providers(llm_client, mocker):
-    """Test a non-Google provider gets the portable `thinking` effort instead."""
-    mocker.patch.dict(
-        llm_module.MODEL_SPECS,
-        {
-            "mystery-1": ModelSpec(
-                label="Mystery 1",
-                provider="mystery",
-                supports_audio=True,
-                supports_files=True,
-            ),
-        },
-    )
-
-    assert llm_client.build_settings("mystery-1", thinking_level="LOW") == {
-        "thinking": "low",
-    }
-
-
 @pytest.mark.parametrize("thinking_level", ALLOWED_THINKING_LEVELS)
-def test_build_settings_maps_every_allowed_level_for_openrouter(
+def test_build_settings_passes_every_allowed_level_as_agnostic_effort(
     llm_client,
     thinking_level,
 ):
-    """Test each allowed level reaches OpenRouter as a valid agnostic effort.
+    """Test every allowed level becomes a valid pydantic-ai ThinkingEffort.
 
-    pydantic-ai looks the effort up in a dict on the way out, so a level it does
-    not know raises rather than being passed through as Google's does.
+    There is no per-provider branch to test: build_settings owns no mapping, so
+    the only thing it can get wrong is emitting a level pydantic-ai does not
+    know, which each provider's model looks up in a dict on the way out.
     """
-    settings = llm_client.build_settings(
-        "tencent/hy3",
-        thinking_level=thinking_level,
-    )
-    assert settings == {"thinking": thinking_level.lower()}
+    settings = llm_client.build_settings(thinking_level=thinking_level)
+
+    assert settings == {"thinking": thinking_level}
     assert settings["thinking"] in get_args(ThinkingEffort)
 
 
 def test_build_settings_does_not_reject_unknown_thinking_level(llm_client):
-    """Lock the lenient handling of a thinking level outside the allow-list.
+    """Test a level outside the allow-list survives build_settings itself.
 
-    A stale `users.thinking_level` must not blow up before the request is even
-    built — the provider decides what to do with an unrecognized level, exactly
-    as it did when the level went through `types.ThinkingLevel`. The agnostic
-    `thinking` effort would raise KeyError here.
+    It no longer survives the request: see the KeyError test below. This pins
+    where the failure is *not*, so the two together locate it exactly.
     """
-    settings = llm_client.build_settings("gemini-3.5-flash", thinking_level="INVALID")
-    assert settings["google_thinking_config"] == {"thinking_level": "INVALID"}
+    assert llm_client.build_settings(thinking_level="INVALID") == {
+        "thinking": "INVALID",
+    }
+
+
+def test_unknown_thinking_level_raises_when_the_request_is_built(llm_client):
+    """Lock where a stale `users.thinking_level` now fails, and how loudly.
+
+    Passing the level through `google_thinking_config` used to leave the ruling
+    to the provider. The agnostic effort is looked up in a dict instead, so an
+    unrecognized level raises KeyError while the request is assembled — inside
+    agent.run_sync, but *not* caught by summary.py's typed @retry decorators, so
+    it surfaces to Sentry on the first attempt rather than being retried.
+    """
+    model = llm_client.build_model("gemini-3.6-flash")
+    settings = llm_client.build_settings(thinking_level="INVALID")
+    messages = [ModelRequest(parts=[UserPromptPart(content="hello")])]
+    settings, params = model.prepare_request(settings, ModelRequestParameters())
+
+    with pytest.raises(KeyError, match="INVALID"):
+        asyncio.run(
+            model._build_content_and_config(messages, settings or {}, params),
+        )
 
 
 def test_build_uploaded_file_uses_uri_as_file_id(llm_client):
@@ -158,7 +145,7 @@ def test_build_uploaded_file_uses_uri_as_file_id(llm_client):
         mime_type="audio/ogg",
     )
 
-    part = llm_client.build_uploaded_file(model_id="gemini-3.5-flash", file=file)
+    part = llm_client.build_uploaded_file(model_id="gemini-3.6-flash", file=file)
 
     assert part.file_id == file.uri
     assert part.media_type == "audio/ogg"
@@ -214,49 +201,69 @@ def test_run_drives_a_real_agent_run(llm_client, mocker):
     def capture(messages, info):
         seen["instructions"] = messages[0].instructions
         seen["prompt"] = messages[0].parts[-1].content
-        seen["settings"] = info.model_settings
+        # Not info.model_settings: prepare_request lifts `thinking` out of the
+        # settings into the request parameters, leaving the settings empty.
+        seen["thinking"] = info.model_request_parameters.thinking
         return ModelResponse(parts=[TextPart(content="A summary.")])
 
     mocker.patch.object(
         llm_client,
         "build_model",
-        return_value=FunctionModel(capture),
+        # supports_thinking, or pydantic-ai drops the level before the model
+        # sees it — FunctionModel's default profile does not claim it.
+        return_value=FunctionModel(
+            capture,
+            profile=ModelProfile(supports_thinking=True),
+        ),
     )
 
     result = llm_client.run(
         content="Summarize this.",
         model_id="gemini-3.6-flash",
         target_language="Ukrainian",
-        thinking_level="MEDIUM",
+        thinking_level="medium",
     )
 
     assert result == "A summary."
     assert seen["prompt"] == "Summarize this."
     assert "Ukrainian" in seen["instructions"]
-    assert seen["settings"]["google_thinking_config"] == {"thinking_level": "MEDIUM"}
+    assert seen["thinking"] == "medium"
 
 
-def test_run_builds_the_expected_gemini_request_config(llm_client):
-    """Test the settings reach GenerateContentConfig in the pre-seam shape.
+@pytest.mark.parametrize(
+    ("thinking_level", "expected_level"),
+    [("high", "HIGH"), ("minimal", "MINIMAL"), ("xhigh", "HIGH")],
+)
+def test_run_builds_the_expected_gemini_request_config(
+    llm_client,
+    thinking_level,
+    expected_level,
+):
+    """Test pydantic-ai, not this codebase, translates the level for Gemini.
 
-    include_thoughts must stay unset: pydantic-ai's agnostic thinking effort
-    turns it on, which makes Gemini emit thought summaries that run() discards.
+    Gemini has no XHIGH, so xhigh collapses onto HIGH here — the reason the
+    fifth level is offered for a future provider rather than for today.
+
+    include_thoughts arrives True and cannot be turned off on this path: it is
+    hard-coded beside the level in pydantic-ai's Google translation. Gemini
+    therefore generates thought summaries that run() drops, which is the price
+    of owning no mapping. If a bump ever separates the two, this test says so.
     """
     model = llm_client.build_model("gemini-3.5-flash-lite")
-    settings = llm_client.build_settings("gemini-3.5-flash-lite", thinking_level="HIGH")
+    settings = llm_client.build_settings(thinking_level=thinking_level)
     messages = [ModelRequest(parts=[UserPromptPart(content="hello")])]
+    settings, params = model.prepare_request(settings, ModelRequestParameters())
 
     # Reaches into a GoogleModel private: it is the only way to see the real
     # GenerateContentConfig without a live call. Re-verify on a pydantic-ai bump.
     _, config = asyncio.run(
-        model._build_content_and_config(
-            messages,
-            settings,
-            ModelRequestParameters(),
-        ),
+        model._build_content_and_config(messages, settings or {}, params),
     )
 
-    assert config["thinking_config"] == {"thinking_level": "HIGH"}
+    assert config["thinking_config"] == {
+        "include_thoughts": True,
+        "thinking_level": expected_level,
+    }
     assert config["tools"] is None
     assert config["response_json_schema"] is None
 
@@ -273,7 +280,7 @@ def test_run_passes_model_and_instructions(llm_client, mocker):
         content="Summarize this.",
         model_id="gemini-3.6-flash",
         target_language="Ukrainian",
-        thinking_level="MEDIUM",
+        thinking_level="medium",
     )
 
     assert result == "A summary."
@@ -293,9 +300,9 @@ def test_run_instructions_are_dedented(llm_client, mocker):
 
     llm_client.run(
         content="Summarize this.",
-        model_id="gemini-3.5-flash",
+        model_id="gemini-3.6-flash",
         target_language="English",
-        thinking_level="HIGH",
+        thinking_level="high",
     )
 
     instructions = mock_run_sync.call_args.kwargs["instructions"]
@@ -315,9 +322,9 @@ def test_run_raises_on_empty_output(llm_client, mocker, output):
     with pytest.raises(AttributeError):
         llm_client.run(
             content="Summarize this.",
-            model_id="gemini-3.5-flash",
+            model_id="gemini-3.6-flash",
             target_language="English",
-            thinking_level="HIGH",
+            thinking_level="high",
         )
 
 
@@ -335,9 +342,9 @@ def test_run_uses_traced_agent_for_text_content(llm_client, mocker):
 
     result = llm_client.run(
         content="Summarize this.",
-        model_id="gemini-3.5-flash",
+        model_id="gemini-3.6-flash",
         target_language="English",
-        thinking_level="HIGH",
+        thinking_level="high",
     )
 
     assert result == "A summary."
@@ -362,9 +369,9 @@ def test_run_uses_traced_agent_for_multipart_text_content(llm_client, mocker):
 
     result = llm_client.run(
         content=["Summarize this.", "Use short bullets."],
-        model_id="gemini-3.5-flash",
+        model_id="gemini-3.6-flash",
         target_language="English",
-        thinking_level="HIGH",
+        thinking_level="high",
     )
 
     assert result == "A summary."
@@ -384,7 +391,7 @@ def test_run_uses_untraced_agent_for_uploaded_file_content(llm_client, mocker):
         mime_type="audio/ogg",
     )
     uploaded_file = llm_client.build_uploaded_file(
-        model_id="gemini-3.5-flash",
+        model_id="gemini-3.6-flash",
         file=file,
     )
     mock_run_sync = mocker.patch.object(
@@ -399,9 +406,9 @@ def test_run_uses_untraced_agent_for_uploaded_file_content(llm_client, mocker):
 
     result = llm_client.run(
         content=["Summarize this.", uploaded_file],
-        model_id="gemini-3.5-flash",
+        model_id="gemini-3.6-flash",
         target_language="English",
-        thinking_level="HIGH",
+        thinking_level="high",
     )
 
     assert result == "A summary."

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -341,7 +341,7 @@ def test_observe_message_noop_when_langfuse_disabled(mocker):
         content_type="voice",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
-        thinking_level="HIGH",
+        thinking_level="high",
     ):
         pass
 
@@ -358,7 +358,7 @@ def test_observe_message_names_and_tags_trace_when_langfuse_enabled(mocker):
         content_type="voice",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
-        thinking_level="HIGH",
+        thinking_level="high",
     ):
         pass
 
@@ -373,6 +373,6 @@ def test_observe_message_names_and_tags_trace_when_langfuse_enabled(mocker):
             # prompt edit into a failing assertion with nothing to teach.
             "prompt_version": prompt_version("basic_prompt_for_transcript"),
             "target_language": "English",
-            "thinking_level": "HIGH",
+            "thinking_level": "high",
         },
     )

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -77,7 +77,7 @@ def test_summarize_with_file_upload_and_model_call(mocker):
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "This is a mocked summary of the file."
@@ -93,7 +93,7 @@ def test_summarize_with_file_upload_and_model_call(mocker):
     call_kwargs = fakes.llm_client.run.call_args.kwargs
     assert call_kwargs["model_id"] == "gemini-3.5-flash-lite"
     assert call_kwargs["target_language"] == "English"
-    assert call_kwargs["thinking_level"] == "MINIMAL"
+    assert call_kwargs["thinking_level"] == "minimal"
     prompt, uploaded = call_kwargs["content"]
     assert "detailed summary" in prompt
     assert uploaded == "uploaded-file-sentinel"
@@ -120,7 +120,7 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
             target_language="English",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
 
@@ -141,7 +141,7 @@ def test_summarize_text_from_webpage(mocker):
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "Webpage summary."
@@ -172,7 +172,7 @@ def test_summarize_text_drops_the_content_part_when_text_is_blank(mocker, blank)
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert fakes.llm_client.run.call_args.kwargs["content"] == [
@@ -196,7 +196,7 @@ def test_summarize_with_file_upload_failure(mocker):
             target_language="English",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
 
@@ -219,7 +219,7 @@ def test_summarize_model_api_exception(mocker):
             target_language="English",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
 
@@ -254,7 +254,7 @@ def test_summarize_with_document_polling(mocker):
         mime_type="application/pdf",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "Document summary"
@@ -285,7 +285,7 @@ def test_summarize_with_document_cleans_up_on_failed_processing(mocker):
             mime_type="application/pdf",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
     mock_clean_up.assert_called_once_with(file="temp_doc.pdf")
@@ -316,7 +316,7 @@ def test_summarize_youtube_transcript_carries_the_backend_prefix(mocker, prefix)
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == f"{prefix}\n\n- first point\n- second point"
@@ -328,7 +328,7 @@ def test_summarize_youtube_transcript_carries_the_backend_prefix(mocker, prefix)
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
 
@@ -353,7 +353,7 @@ def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
             target_language="English",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
     fakes.downloader.download_yt.assert_not_called()
@@ -393,7 +393,7 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "File summary"
@@ -431,7 +431,7 @@ def test_summarize_fallback_to_transcription(mocker):
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result.startswith("📝")
@@ -470,7 +470,7 @@ def test_summarize_routes_audio_around_a_model_that_cannot_read_it(mocker):
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "📝\n\n- transcript point"
@@ -511,7 +511,7 @@ def test_summarize_with_document_routes_audio_document_to_transcription(mocker):
         mime_type="audio/ogg",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "📝\n\n- transcript point"
@@ -553,7 +553,7 @@ def test_summarize_with_document_falls_back_when_model_takes_no_file(mocker, cap
             mime_type="application/pdf",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
     assert result == "Document summary"
@@ -588,7 +588,7 @@ def test_summarize_with_document_keeps_a_model_that_takes_files(mocker):
         mime_type="application/pdf",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert fakes.llm_client.run.call_args.kwargs["model_id"] == "gemini-3.6-flash"
@@ -615,7 +615,7 @@ def test_summarize_fallback_cleans_up_temp_file_when_compress_fails(mocker):
             target_language="English",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
     mock_clean_up.assert_any_call(file="temp.ogg")
@@ -641,7 +641,7 @@ def test_summarize_castro(mocker):
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "Castro summary"
@@ -671,7 +671,7 @@ def test_summarize_castro_www_host(mocker):
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "Castro summary"
@@ -704,7 +704,7 @@ def test_summarize_youtube_uppercase_host_uses_transcript(mocker):
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "📺\n\nYT summary"
@@ -725,7 +725,7 @@ def test_summarize_preflight_blocks_before_download(mocker):
             target_language="English",
             user_id=1,
             daily_limit=0,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
     fakes.quota_manager.check_quota.assert_called_once_with(
@@ -756,7 +756,7 @@ def test_summarize_with_file_deletes_gemini_file_when_quota_check_fails(mocker):
             target_language="English",
             user_id=1,
             daily_limit=5,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
     assert fakes.quota_manager.check_quota.call_count == 2
@@ -787,7 +787,7 @@ def test_summarize_with_document_preflight_blocks_before_download(mocker):
             mime_type="application/pdf",
             user_id=1,
             daily_limit=0,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
     fakes.quota_manager.check_quota.assert_called_once_with(
@@ -819,7 +819,7 @@ def test_summarize_with_file_logs_warning_on_delete_failure(mocker):
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "summary text"
@@ -842,7 +842,7 @@ def test_summarize_text_raises_on_empty_response(mocker):
             target_language="English",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
 
@@ -871,7 +871,7 @@ def test_summarize_with_document_raises_when_upload_metadata_incomplete(mocker):
             mime_type="application/pdf",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
     fakes.gemini_helper.delete_file.assert_not_called()
@@ -901,7 +901,7 @@ def test_summarize_with_document_raises_on_empty_response(mocker):
             mime_type="application/pdf",
             user_id=123,
             daily_limit=10,
-            thinking_level="MINIMAL",
+            thinking_level="minimal",
         )
 
 
@@ -929,7 +929,7 @@ def test_summarize_with_document_logs_warning_on_delete_failure(mocker):
         mime_type="application/pdf",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "document summary"
@@ -957,7 +957,7 @@ def test_summarize_with_telegram_file(mocker):
         target_language="English",
         user_id=123,
         daily_limit=10,
-        thinking_level="MINIMAL",
+        thinking_level="minimal",
     )
 
     assert result == "Telegram file summary"


### PR DESCRIPTION
## What

Two changes that both land in `config.py` and share one Alembic data migration.

**Thinking levels move off Google's enum.** The allow-list was literally `google.genai.types.ThinkingLevel` (`MINIMAL|LOW|MEDIUM|HIGH`) — a provider's vocabulary sitting in `config.py`, the coupling the `MODEL_SPECS` seam exists to remove. It becomes pydantic-ai's `ThinkingEffort` (`minimal|low|medium|high|xhigh`), and `build_settings` loses its Google branch entirely:

```python
def build_settings(self, thinking_level: str) -> ModelSettings:
    return ModelSettings(thinking=cast("ThinkingLevel", thinking_level))
```

No dict, no `.upper()`, no per-provider branch, and `model_id` drops off the signature since nothing used it. pydantic-ai does all the translation. `xhigh` is added as a fifth user-selectable level.

**`gemini-3.5-flash` is dropped**, superseded by `gemini-3.6-flash`. Both defaults move — model to `gemini-3.6-flash`, thinking level to `medium`. The registry goes 11 → 10 rows.

This is the follow-up agreed in #1029 and deliberately kept out of it, because it needs a data migration and shifts Langfuse's `thinking_level` trace metadata mid-history.

## Two trade-offs, both deliberate

Both were decisions in #1029 with pinning tests. Both are knowingly reversed, and the tests are rewritten to pin the new behaviour rather than deleted — so a future change is equally loud.

1. **Gemini now receives `include_thoughts=True`.** It is hard-coded beside the level in pydantic-ai's Google translation (`models/google.py:_translate_thinking`); there is no way to reach that map without it. Gemini generates thought summaries `run()` discards. Reintroducing `google_thinking_config` to dodge this would put the mapping back in this codebase, which is the thing being removed.
2. **An unrecognized stored level now raises `KeyError` as the request is built**, rather than reaching the provider to rule on. `summary.py`'s `@retry` decorators are typed and do not catch `KeyError`, so it surfaces to Sentry on the first attempt instead of being retried. Only a stale `users.thinking_level` can reach it, and the migration leaves none.

## Migration

`12d7c48a6e14`, on head `96da01ef8da4`. Lowercases every stored level — **keeping each user's explicit choice**, only the column default moves to `medium` — and moves `gemini-3.5-flash` rows onto `gemini-3.6-flash`.

The downgrade collapses `xhigh` onto `HIGH` rather than uppercasing blindly: `XHIGH` is absent from the restored allow-list and rejected by Gemini, and nothing would heal it but re-picking a level.

**Migrate before deploying.** Dropping the lenient path makes a pre-migration level a hard failure on every message. The reverse order is safe (old code reads lowercase fine — genai's `ThinkingLevel` is a `CaseInSensitiveEnum`), but deploying first fails every request for every user until the migration lands.

## Verification

- 303 tests pass; coverage stays at 100% (1123 statements, down from 1125).
- Migration applied to the live database. Before: one row on `gemini-3.5-flash`/`MINIMAL`, one on `gemini-3.6-flash`/`MEDIUM`. After: both on `gemini-3.6-flash`, levels `minimal` and `medium` — choices preserved. 0 stale rows, both column defaults in place.
- **Real API calls on both providers**: `xhigh` and `medium` accepted by `gemini-3.6-flash` and `z-ai/glm-5.2`, all four returning clean prose. This is the proof that `xhigh → HIGH` is a valid Gemini enum value and that `include_thoughts=True` does not leak thought text into `result.output`.
- Keyboards: 5 thinking buttons ending in "Extra High", 10 model buttons with no "Gemini 3.5 Flash".

## Reviewer notes

- A new test pins `ALLOWED_THINKING_LEVELS` to `get_args(ThinkingEffort)` by set equality — that is what keeps the vocabulary pydantic-ai's rather than ours, and makes a library bump that adds or drops an effort fail loudly.
- `DEFAULT_MODEL_ID_FOR_SUMMARY` doubles as the document fallback for `supports_files=False` models, so this also moves document routing from `gemini-3.5-flash-lite` to `gemini-3.6-flash`.
- **Langfuse `thinking_level` metadata changes vocabulary mid-history** (`HIGH` before, `high` after). Saved filters or evaluation datasets built on the old values need updating by hand.
- `xhigh` is indistinguishable from `high` on both registered providers today; it is there for a provider that distinguishes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for standardized thinking levels, including Minimal, Low, Medium, High, and Extra High.
  * Thinking-level settings now work consistently across supported providers.
  * Gemini thought summaries are supported where available.

* **Updates**
  * Replaced Gemini 3.5 Flash with Gemini 3.6 Flash as the available and default summary model.
  * Thinking levels are now stored and displayed in lowercase, with Medium as the default.

* **Documentation**
  * Updated architecture documentation to describe unified thinking-level behavior and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->