### PR TITLE
config: add three openrouter models

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -44,9 +44,10 @@ otherwise; reverse one only as a deliberate decision, not incidental cleanup.
   `supports_files` both False, which is about what this bot can *deliver*, not what the
   models read. OpenRouter has no file API, so a file would have to be base64-inlined —
   the same limit that keeps Gemini on its Files API — and pydantic-ai only accepts
-  wav/mp3 audio inline, while this pipeline produces Opus `.ogg`. Upstream,
-  `xiaomi/mimo-v2.5` does read audio and both GPT-5.6 models do read files; matching the
-  flags to the catalog without first building an inline path breaks the routing.
+  wav/mp3 audio inline, while this pipeline produces Opus `.ogg`. Upstream, several
+  registered models advertise audio or file input — `meta/muse-spark-1.2` advertises
+  both; matching the flags to the catalog without first building an inline path breaks
+  the routing.
 - **Thinking levels are pydantic-ai's, translated by pydantic-ai** — the allow-list is
   its `ThinkingEffort` (`minimal|low|medium|high|xhigh`), passed to the unified `thinking`
   setting, and each provider's model maps it. This codebase owns no mapping, which is what

--- a/src/config.py
+++ b/src/config.py
@@ -89,8 +89,8 @@ class ModelSpec:
     `supports_files` False sends documents to `DEFAULT_MODEL_ID_FOR_SUMMARY`
     instead. Every OpenRouter model is registered with both False on purpose:
     OpenRouter has no file API, so files would have to be inlined as base64,
-    and `xiaomi/mimo-v2.5` (audio) and the two GPT-5.6 models (files) do read
-    those modalities upstream. Correcting the flags to match the catalog
+    and several registered models — `meta/muse-spark-1.2` advertises both — do
+    read those modalities upstream. Correcting the flags to match the catalog
     without first building an inline path breaks the routing.
     """
 
@@ -125,6 +125,12 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=False,
         supports_files=False,
     ),
+    "meta/muse-spark-1.2": ModelSpec(
+        label="Meta Muse Spark 1.2",
+        provider="openrouter",
+        supports_audio=False,
+        supports_files=False,
+    ),
     "minimax/minimax-m3": ModelSpec(
         label="MiniMax M3",
         provider="openrouter",
@@ -143,8 +149,20 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=False,
         supports_files=False,
     ),
+    "qwen/qwen3.7-flash": ModelSpec(
+        label="Qwen3.7 Flash",
+        provider="openrouter",
+        supports_audio=False,
+        supports_files=False,
+    ),
     "tencent/hy3": ModelSpec(
         label="Tencent Hy3",
+        provider="openrouter",
+        supports_audio=False,
+        supports_files=False,
+    ),
+    "thinkingmachines/inkling": ModelSpec(
+        label="Thinking Machines Inkling",
         provider="openrouter",
         supports_audio=False,
         supports_files=False,


### PR DESCRIPTION
## What

Registers three new OpenRouter models in `config.MODEL_SPECS`:

| Slug | Label |
|---|---|
| `meta/muse-spark-1.2` | Meta Muse Spark 1.2 |
| `qwen/qwen3.7-flash` | Qwen3.7 Flash |
| `thinkingmachines/inkling` | Thinking Machines Inkling |

Each is slotted into the existing ordering (Google first, then OpenRouter
alphabetical by key), since that order is what the `/set_summarizing_model`
keyboard shows. The registry goes from 10 to 13 models.

## Why the flags are both False

All three are registered with `supports_audio=False` and `supports_files=False`,
matching every other OpenRouter entry — even though two of them are more capable
upstream than that suggests:

| Slug | OpenRouter `input_modalities` |
|---|---|
| `meta/muse-spark-1.2` | text, image, video, **file**, **audio** |
| `thinkingmachines/inkling` | text, image, **audio** |
| `qwen/qwen3.7-flash` | text, image, video |

The flags describe what this bot can *deliver*, not what the catalog advertises,
and nothing has changed on the delivery side: OpenRouter has no file API, and
pydantic-ai only inlines wav/mp3 while this pipeline produces Opus `.ogg`.
Flipping either flag without first building an inline path would send the
request down the native-upload branch and raise in `build_uploaded_file`, which
serves Gemini only.

So all three take the Replicate transcription route for spoken content, and
documents fall back to `DEFAULT_MODEL_ID_FOR_SUMMARY` — same behaviour as every
OpenRouter model already registered.

## Docs

Adding these made one sentence stale in two places: the `ModelSpec` docstring
and `architecture.md` both enumerated which OpenRouter models read these
modalities upstream (`xiaomi/mimo-v2.5` for audio, the two GPT-5.6 models for
files). Audio is now also Muse Spark and Inkling, files also Muse Spark.
Replaced the enumeration with a phrasing that does not need editing on the next
addition.

## Notes for review

- **No migration.** `DEFAULT_MODEL_ID_FOR_SUMMARY` is untouched, so the
  `users.summarizing_model` server default stays valid and no stored value goes
  stale.
- **No new tests.** The registry invariants in `tests/test_config.py` sweep the
  whole of `MODEL_SPECS` — label uniqueness, default-accepts-files, no spec with
  audio-but-not-files — so the new rows are covered as soon as they exist.
- **No `llm.py` change.** `provider="openrouter"` already dispatches.
- All three slugs were verified against
  `https://openrouter.ai/api/v1/models/{slug}/endpoints` before being written.

## Verification

`uv run pytest --cov` — 309 passed, coverage 100% (`src/config.py` 77/77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional OpenRouter models, including Meta Muse Spark 1.2, Qwen3.7 Flash, and Thinking Machines Inkling.
  * Updated model information to reflect available upstream audio and file capabilities.

* **Documentation**
  * Refreshed architecture and model documentation with current OpenRouter examples and capability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->