### PR TITLE
config: swap five openrouter models for qwen3.8-max

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Modal Image Builder Version required to be `2025.06`. Set in Settings -> Image B
 
 ## Summarizing models
 
-`/set_summarizing_model` offers models from two providers: Gemini directly, and text-only models through [OpenRouter](https://openrouter.ai/) (DeepSeek, GPT-5.6, GLM, MiniMax, MiMo, Hy3). Both `GEMINI_API_KEY` and `OPENROUTER_API_KEY` are required — the bot will not start without either.
+`/set_summarizing_model` offers models from two providers: Gemini directly, and text-only models through [OpenRouter](https://openrouter.ai/) (DeepSeek, GPT-5.6, GLM, MiniMax, Qwen, Muse Spark, Inkling). Both `GEMINI_API_KEY` and `OPENROUTER_API_KEY` are required — the bot will not start without either.
 
 The OpenRouter models are registered as text-only on purpose: OpenRouter has no file API,
 so a file would have to be base64-inlined, which a 20MB Telegram file does not fit inside.

--- a/migrations/versions/b3f9c1d47a20_drop_five_openrouter_models.py
+++ b/migrations/versions/b3f9c1d47a20_drop_five_openrouter_models.py
@@ -1,0 +1,41 @@
+"""drop five openrouter models
+
+Revision ID: b3f9c1d47a20
+Revises: 12d7c48a6e14
+Create Date: 2026-08-07 19:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b3f9c1d47a20"
+down_revision: Union[str, None] = "12d7c48a6e14"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # An id no longer in MODEL_SPECS is a KeyError in llm.build_model on every
+    # message, so stored rows move to the nearest surviving model: the same
+    # vendor where one is left, the default otherwise.
+    op.execute(
+        "UPDATE users SET summarizing_model = CASE summarizing_model "
+        "WHEN 'deepseek/deepseek-v4-pro' THEN 'deepseek/deepseek-v4-flash-0731' "
+        "WHEN 'openai/gpt-5.6-terra' THEN 'openai/gpt-5.6-luna' "
+        "WHEN 'qwen/qwen3.7-flash' THEN 'qwen/qwen3.8-max' "
+        "ELSE 'gemini-3.6-flash' END "
+        "WHERE summarizing_model IN ("
+        "'deepseek/deepseek-v4-pro', 'openai/gpt-5.6-terra', "
+        "'qwen/qwen3.7-flash', 'tencent/hy3', 'xiaomi/mimo-v2.5')",
+    )
+
+
+def downgrade() -> None:
+    # Not reversed: the five ids are gone from MODEL_SPECS, so restoring them
+    # would leave users on an unselectable id. Same choice as 6bb4ed473ffd and
+    # 12d7c48a6e14, which dropped the previous legacy models.
+    pass

--- a/src/config.py
+++ b/src/config.py
@@ -119,12 +119,6 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=False,
         supports_files=False,
     ),
-    "deepseek/deepseek-v4-pro": ModelSpec(
-        label="DeepSeek V4 Pro",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
     "meta/muse-spark-1.2": ModelSpec(
         label="Meta Muse Spark 1.2",
         provider="openrouter",
@@ -143,32 +137,14 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=False,
         supports_files=False,
     ),
-    "openai/gpt-5.6-terra": ModelSpec(
-        label="GPT-5.6 Terra",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
-    "qwen/qwen3.7-flash": ModelSpec(
-        label="Qwen3.7 Flash",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
-    "tencent/hy3": ModelSpec(
-        label="Tencent Hy3",
+    "qwen/qwen3.8-max": ModelSpec(
+        label="Qwen3.8 Max",
         provider="openrouter",
         supports_audio=False,
         supports_files=False,
     ),
     "thinkingmachines/inkling": ModelSpec(
         label="Thinking Machines Inkling",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
-    "xiaomi/mimo-v2.5": ModelSpec(
-        label="Xiaomi MiMo-V2.5",
         provider="openrouter",
         supports_audio=False,
         supports_files=False,

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -41,11 +41,11 @@ def test_build_model_returns_openrouter_model(mocker):
     provider = OpenRouterProvider(api_key="mock_openrouter_key")
     client = LLMClient(mocker.MagicMock(), provider)
 
-    model = client.build_model("deepseek/deepseek-v4-pro")
+    model = client.build_model("deepseek/deepseek-v4-flash-0731")
 
     assert isinstance(model, OpenRouterCostReporter)
     assert isinstance(model.wrapped, OpenRouterModel)
-    assert model.model_name == "deepseek/deepseek-v4-pro"
+    assert model.model_name == "deepseek/deepseek-v4-flash-0731"
     assert model.system == "openrouter"
 
 


### PR DESCRIPTION
## What

Drops five OpenRouter models from `MODEL_SPECS` — `deepseek/deepseek-v4-pro`, `openai/gpt-5.6-terra`, `qwen/qwen3.7-flash`, `tencent/hy3`, `xiaomi/mimo-v2.5` — and registers `qwen/qwen3.8-max` in their place, with `supports_audio` and `supports_files` both `False` like every other OpenRouter entry. The flags describe what this bot can deliver, not what the catalog advertises; there is still no inline path for files or Opus audio.

## Migration

A `summarizing_model` value that is no longer in `MODEL_SPECS` is a `KeyError` in `llm.build_model` on every message that user sends, so `b3f9c1d47a20` moves stored rows onto the nearest surviving model:

| Dropped | Moves to |
|---|---|
| `deepseek/deepseek-v4-pro` | `deepseek/deepseek-v4-flash-0731` |
| `openai/gpt-5.6-terra` | `openai/gpt-5.6-luna` |
| `qwen/qwen3.7-flash` | `qwen/qwen3.8-max` |
| `tencent/hy3`, `xiaomi/mimo-v2.5` | `gemini-3.6-flash` (default) |

Same vendor where one is left, the default otherwise. `downgrade` does not restore the dropped ids — they are gone from the registry, so restoring them would leave users on an unselectable id. That follows `6bb4ed473ffd` and `12d7c48a6e14`.

## Also

- `tests/test_llm.py` — the OpenRouter `build_model` test named one of the dropped ids; it now uses `deepseek/deepseek-v4-flash-0731`.
- `README.md` — the brand list in "Summarizing models" is refreshed to match the registry; it had also gone stale for the three models added in #1032.
- `docs/context/architecture.md` needed no change: its only model id is `meta/muse-spark-1.2`, which stays registered.

## Reviewer notes

- 309 tests pass, `src/` stays at 100% line coverage. `uv run alembic heads` reports a single head (`b3f9c1d47a20`).
- **`uv run alembic upgrade head` was not run** — no live database was touched. Apply it before deploying.
- The successor mapping in the table is a judgment call, not something the code forces. Sending all five to `gemini-3.6-flash`, or leaving the rows untouched, are both reasonable alternatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Qwen3.8 Max model through OpenRouter.
* **Changes**
  * Updated the available model list by removing several retired models.
  * Existing user selections for retired models are automatically mapped to supported alternatives or a default model.
  * Updated documentation to reflect the current model options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->