### PR TITLE
config: add inkling-small, drop gemini-3.5-flash-lite

### DIFF
--- a/migrations/versions/c7a2e5b0913f_drop_gemini_3_5_flash_lite.py
+++ b/migrations/versions/c7a2e5b0913f_drop_gemini_3_5_flash_lite.py
@@ -1,0 +1,34 @@
+"""drop gemini-3.5-flash-lite
+
+Revision ID: c7a2e5b0913f
+Revises: b3f9c1d47a20
+Create Date: 2026-08-07 20:35:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "c7a2e5b0913f"
+down_revision: Union[str, None] = "b3f9c1d47a20"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # gemini-3.6-flash is the only Google model left, and already the column's
+    # server_default since 12d7c48a6e14, so no default has to move with it.
+    op.execute(
+        "UPDATE users SET summarizing_model = 'gemini-3.6-flash' "
+        "WHERE summarizing_model = 'gemini-3.5-flash-lite'",
+    )
+
+
+def downgrade() -> None:
+    # Not reversed: gemini-3.5-flash-lite is gone from MODEL_SPECS, so restoring
+    # it would leave users on an unselectable id. Same choice as 6bb4ed473ffd,
+    # 12d7c48a6e14 and b3f9c1d47a20.
+    pass

--- a/src/config.py
+++ b/src/config.py
@@ -107,12 +107,6 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=True,
         supports_files=True,
     ),
-    "gemini-3.5-flash-lite": ModelSpec(
-        label="Gemini 3.5 Flash Lite",
-        provider="google",
-        supports_audio=True,
-        supports_files=True,
-    ),
     "deepseek/deepseek-v4-flash-0731": ModelSpec(
         label="DeepSeek V4 Flash 0731",
         provider="openrouter",
@@ -145,6 +139,12 @@ MODEL_SPECS: dict[str, ModelSpec] = {
     ),
     "thinkingmachines/inkling": ModelSpec(
         label="Thinking Machines Inkling",
+        provider="openrouter",
+        supports_audio=False,
+        supports_files=False,
+    ),
+    "thinkingmachines/inkling-small": ModelSpec(
+        label="Thinking Machines Inkling Small",
         provider="openrouter",
         supports_audio=False,
         supports_files=False,

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -30,9 +30,9 @@ def llm_client(mocker):
 
 def test_build_model_returns_google_model(llm_client):
     """Test build_model wires a registered Gemini id to a GoogleModel."""
-    model = llm_client.build_model("gemini-3.5-flash-lite")
+    model = llm_client.build_model("gemini-3.6-flash")
     assert isinstance(model, GoogleModel)
-    assert model.model_name == "gemini-3.5-flash-lite"
+    assert model.model_name == "gemini-3.6-flash"
     assert model.system == "google"
 
 
@@ -164,7 +164,12 @@ def test_cost_reporter_writes_to_the_live_generation_span():
 
 
 def test_build_model_caches_across_providers(mocker):
-    """Test the cache is keyed by id alone, so both providers share one dict."""
+    """Test the cache is keyed by id alone, so both providers share one dict.
+
+    Also the whole of the caching contract: one object per id, and distinct
+    ids never collide. There is a single Gemini id left in the registry, so a
+    same-provider version of the second half has nothing to compare against.
+    """
     client = LLMClient(mocker.MagicMock(), OpenRouterProvider(api_key="mock_key"))
 
     google = client.build_model("gemini-3.6-flash")
@@ -173,16 +178,6 @@ def test_build_model_caches_across_providers(mocker):
     assert client.build_model("gemini-3.6-flash") is google
     assert client.build_model("z-ai/glm-5.2") is openrouter
     assert google is not openrouter
-
-
-def test_build_model_is_cached_per_id(llm_client):
-    """Test build_model reuses one model object per id, so clients are shared."""
-    assert llm_client.build_model("gemini-3.6-flash") is llm_client.build_model(
-        "gemini-3.6-flash",
-    )
-    assert llm_client.build_model("gemini-3.6-flash") is not llm_client.build_model(
-        "gemini-3.5-flash-lite",
-    )
 
 
 def test_build_model_rejects_unregistered_model(llm_client):
@@ -369,7 +364,7 @@ def test_run_builds_the_expected_gemini_request_config(
     therefore generates thought summaries that run() drops, which is the price
     of owning no mapping. If a bump ever separates the two, this test says so.
     """
-    model = llm_client.build_model("gemini-3.5-flash-lite")
+    model = llm_client.build_model("gemini-3.6-flash")
     settings = llm_client.build_settings(thinking_level=thinking_level)
     messages = [ModelRequest(parts=[UserPromptPart(content="hello")])]
     settings, params = model.prepare_request(settings, ModelRequestParameters())

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -72,7 +72,7 @@ def test_summarize_with_file_upload_and_model_call(mocker):
 
     result = summarizer.summarize_with_file(
         file="test_audio.ogg",
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -87,11 +87,11 @@ def test_summarize_with_file_upload_and_model_call(mocker):
     )
     fakes.gemini_helper.delete_file.assert_called_once_with("files/mock123")
     fakes.llm_client.build_uploaded_file.assert_called_once_with(
-        model_id="gemini-3.5-flash-lite",
+        model_id="gemini-3.6-flash",
         file=mock_uploaded_file,
     )
     call_kwargs = fakes.llm_client.run.call_args.kwargs
-    assert call_kwargs["model_id"] == "gemini-3.5-flash-lite"
+    assert call_kwargs["model_id"] == "gemini-3.6-flash"
     assert call_kwargs["target_language"] == "English"
     assert call_kwargs["thinking_level"] == "minimal"
     prompt, uploaded = call_kwargs["content"]
@@ -115,7 +115,7 @@ def test_summarize_with_file_retries_on_empty_response(mocker):
     with pytest.raises(RetryError):
         summarizer.summarize_with_file(
             file="test_audio.ogg",
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             user_id=123,
@@ -136,7 +136,7 @@ def test_summarize_text_from_webpage(mocker):
 
     result = summarizer.summarize_text(
         text="Parsed page content.",
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -151,7 +151,7 @@ def test_summarize_text_from_webpage(mocker):
     prompt, content = call_kwargs["content"]
     assert content == "Parsed page content."
     assert prompt == dedent(PROMPTS["basic_prompt_for_transcript"]).strip()
-    assert call_kwargs["model_id"] == "gemini-3.5-flash-lite"
+    assert call_kwargs["model_id"] == "gemini-3.6-flash"
 
 
 @pytest.mark.parametrize("blank", ["", "   \n  "])
@@ -167,7 +167,7 @@ def test_summarize_text_drops_the_content_part_when_text_is_blank(mocker, blank)
 
     summarizer.summarize_text(
         text=blank,
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -191,7 +191,7 @@ def test_summarize_with_file_upload_failure(mocker):
     with pytest.raises(Exception, match="Upload failed"):
         summarizer.summarize_with_file(
             file="test_audio.ogg",
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             user_id=123,
@@ -207,14 +207,14 @@ def test_summarize_model_api_exception(mocker):
     fakes.quota_manager.check_quota.return_value = True
     fakes.llm_client.run.side_effect = ModelHTTPError(
         status_code=400,
-        model_name="gemini-3.5-flash-lite",
+        model_name="gemini-3.6-flash",
         body={"error": {"message": "Model unavailable"}},
     )
 
     with pytest.raises(RetryError):
         summarizer.summarize_text(
             text="Hello",
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             user_id=123,
@@ -248,7 +248,7 @@ def test_summarize_with_document_polling(mocker):
 
     result = summarizer.summarize_with_document(
         file=mock_tg_file,
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         mime_type="application/pdf",
@@ -262,7 +262,7 @@ def test_summarize_with_document_polling(mocker):
     _, uploaded = fakes.llm_client.run.call_args.kwargs["content"]
     assert uploaded == "uploaded-file-sentinel"
     fakes.llm_client.build_uploaded_file.assert_called_once_with(
-        model_id="gemini-3.5-flash-lite",
+        model_id="gemini-3.6-flash",
         file=mock_file_active,
     )
 
@@ -279,7 +279,7 @@ def test_summarize_with_document_cleans_up_on_failed_processing(mocker):
     with pytest.raises(ValueError, match="FAILED"):
         summarizer.summarize_with_document(
             file=mocker.MagicMock(),
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             mime_type="application/pdf",
@@ -311,7 +311,7 @@ def test_summarize_youtube_transcript_carries_the_backend_prefix(mocker, prefix)
 
     result = summarizer.summarize(
         data=url,
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -323,7 +323,7 @@ def test_summarize_youtube_transcript_carries_the_backend_prefix(mocker, prefix)
     fakes.yt_transcriber.get_transcript.assert_called_once_with(url)
     mock_sum_transcript.assert_called_once_with(
         text="YT Transcript content",
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -348,7 +348,7 @@ def test_summarize_youtube_transcript_summary_retry_does_not_fall_back(mocker):
     with pytest.raises(RetryError):
         summarizer.summarize(
             data=url,
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             user_id=123,
@@ -388,7 +388,7 @@ def test_summarize_youtube_transcript_failure_falls_back_to_download(
 
     result = summarizer.summarize(
         data=url,
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -426,7 +426,7 @@ def test_summarize_fallback_to_transcription(mocker):
 
     result = summarizer.summarize(
         data="local_audio.ogg",
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -610,7 +610,7 @@ def test_summarize_fallback_cleans_up_temp_file_when_compress_fails(mocker):
     with pytest.raises(RuntimeError):
         summarizer.summarize(
             data="local_audio.ogg",
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             user_id=123,
@@ -636,7 +636,7 @@ def test_summarize_castro(mocker):
 
     result = summarizer.summarize(
         data=url,
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -666,7 +666,7 @@ def test_summarize_castro_www_host(mocker):
 
     result = summarizer.summarize(
         data="https://www.castro.fm/episode/123",
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -699,7 +699,7 @@ def test_summarize_youtube_uppercase_host_uses_transcript(mocker):
 
     result = summarizer.summarize(
         data=url,
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -720,7 +720,7 @@ def test_summarize_preflight_blocks_before_download(mocker):
     with pytest.raises(LimitExceededError):
         summarizer.summarize(
             data="https://castro.fm/episode/123",
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             user_id=1,
@@ -751,7 +751,7 @@ def test_summarize_with_file_deletes_gemini_file_when_quota_check_fails(mocker):
     with pytest.raises(LimitExceededError):
         summarizer.summarize_with_file(
             file="test_audio.ogg",
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             user_id=1,
@@ -781,7 +781,7 @@ def test_summarize_with_document_preflight_blocks_before_download(mocker):
     with pytest.raises(LimitExceededError):
         summarizer.summarize_with_document(
             file=mocker.MagicMock(),
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             mime_type="application/pdf",
@@ -814,7 +814,7 @@ def test_summarize_with_file_logs_warning_on_delete_failure(mocker):
 
     result = summarizer.summarize_with_file(
         file="test_audio.ogg",
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -837,7 +837,7 @@ def test_summarize_text_raises_on_empty_response(mocker):
     with pytest.raises(RetryError):
         summarizer.summarize_text(
             text="Hello world",
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             user_id=123,
@@ -865,7 +865,7 @@ def test_summarize_with_document_raises_when_upload_metadata_incomplete(mocker):
     with pytest.raises(RetryError):
         summarizer.summarize_with_document(
             file=mocker.MagicMock(),
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             mime_type="application/pdf",
@@ -895,7 +895,7 @@ def test_summarize_with_document_raises_on_empty_response(mocker):
     with pytest.raises(RetryError):
         summarizer.summarize_with_document(
             file=mocker.MagicMock(),
-            model="gemini-3.5-flash-lite",
+            model="gemini-3.6-flash",
             prompt_key="basic_prompt_for_transcript",
             target_language="English",
             mime_type="application/pdf",
@@ -923,7 +923,7 @@ def test_summarize_with_document_logs_warning_on_delete_failure(mocker):
 
     result = summarizer.summarize_with_document(
         file=mocker.MagicMock(),
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         mime_type="application/pdf",
@@ -952,7 +952,7 @@ def test_summarize_with_telegram_file(mocker):
 
     result = summarizer.summarize(
         data=mock_tg_file,
-        model="gemini-3.5-flash-lite",
+        model="gemini-3.6-flash",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,


### PR DESCRIPTION
## What

Registers `thinkingmachines/inkling-small` beside `thinkingmachines/inkling`, with `supports_audio` and `supports_files` both `False` like every other OpenRouter entry, and drops `gemini-3.5-flash-lite`.

The registry is now 8 rows: `gemini-3.6-flash` plus 7 OpenRouter models.

## Migration

`c7a2e5b0913f` moves rows still on `gemini-3.5-flash-lite` to `gemini-3.6-flash` — an id that has left `MODEL_SPECS` is a `KeyError` in `llm.build_model` on every message that user sends. No `server_default` travels with the removal: the column has defaulted to `gemini-3.6-flash` since `12d7c48a6e14`. The downgrade does not restore the dropped id, following `b3f9c1d47a20`, `12d7c48a6e14` and `6bb4ed473ffd`.

Chains on `b3f9c1d47a20` (merged in #1033), so `alembic heads` stays single-headed.

## Test fallout

`gemini-3.5-flash-lite` was the stand-in Gemini id across the suite — 54 occurrences, 33 in `tests/test_summary.py` and 21 in `tests/test_llm.py`. All now name `gemini-3.6-flash`.

That left `test_build_model_is_cached_per_id` broken rather than merely stale: its second assertion proved *different* ids build different objects, and with one Gemini id left both sides became the same id, inverting it into a guaranteed failure. `test_build_model_caches_across_providers` already asserts both halves of the caching contract with real ids from both providers, so the redundant test is removed and the surviving one's docstring records that it now carries that case.

## Reviewer notes

- 308 tests pass (309 minus the removed one), `src/` stays at 100% line coverage over 1132 statements. `uv run alembic heads` reports one head, `c7a2e5b0913f`.
- **`uv run alembic upgrade head` was not run** — no live database was touched. Apply it before deploying.
- No docs changed: README's OpenRouter brand list names "Inkling", which covers the Small variant, and never enumerates Gemini ids; `docs/context/architecture.md`'s only model id is `meta/muse-spark-1.2`.
- Pre-existing, not introduced here, but now unfixable in place: `test_summarize_with_document_keeps_a_model_that_takes_files` (`tests/test_summary.py:569`) asserts a file-capable model is not substituted, using the id that substitution would produce anyway — so it cannot fail. It has used the default id since #1030, and with `gemini-3.5-flash-lite` gone there is no second file-capable model to write it against. Making it meaningful needs a fabricated spec patched into `summary.MODEL_SPECS`; happy to do that here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Thinking Machines Inkling Small model as an available option.
  - Inkling Small does not support audio or file inputs.

- **Changes**
  - Replaced the unavailable Gemini 3.5 Flash Lite model with Gemini 3.6 Flash for summarization.
  - Updated related model behavior and validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->