### PR TITLE
config: drop three openrouter models

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Modal Image Builder Version required to be `2025.06`. Set in Settings -> Image B
 
 ## Summarizing models
 
-`/set_summarizing_model` offers models from two providers: Gemini directly, and text-only models through [OpenRouter](https://openrouter.ai/) (DeepSeek, GPT-5.6, GLM, MiniMax, Qwen, Muse Spark, Inkling). Both `GEMINI_API_KEY` and `OPENROUTER_API_KEY` are required — the bot will not start without either.
+`/set_summarizing_model` offers models from two providers: Gemini directly, and text-only models through [OpenRouter](https://openrouter.ai/) (GPT-5.6, MiniMax, Qwen, Muse Spark, Inkling). Both `GEMINI_API_KEY` and `OPENROUTER_API_KEY` are required — the bot will not start without either.
 
 The OpenRouter models are registered as text-only on purpose: OpenRouter has no file API,
 so a file would have to be base64-inlined, which a 20MB Telegram file does not fit inside.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Modal Image Builder Version required to be `2025.06`. Set in Settings -> Image B
 
 ## Summarizing models
 
-`/set_summarizing_model` offers models from two providers: Gemini directly, and text-only models through [OpenRouter](https://openrouter.ai/) (GPT-5.6, MiniMax, Qwen, Muse Spark, Inkling). Both `GEMINI_API_KEY` and `OPENROUTER_API_KEY` are required — the bot will not start without either.
+`/set_summarizing_model` offers models from two providers: Gemini directly, and text-only models through [OpenRouter](https://openrouter.ai/). Both `GEMINI_API_KEY` and `OPENROUTER_API_KEY` are required — the bot will not start without either.
 
 The OpenRouter models are registered as text-only on purpose: OpenRouter has no file API,
 so a file would have to be base64-inlined, which a 20MB Telegram file does not fit inside.

--- a/migrations/versions/d4e81f60c2ab_drop_three_openrouter_models.py
+++ b/migrations/versions/d4e81f60c2ab_drop_three_openrouter_models.py
@@ -1,0 +1,44 @@
+"""drop three openrouter models
+
+Revision ID: d4e81f60c2ab
+Revises: c7a2e5b0913f
+Create Date: 2026-08-07 21:20:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e81f60c2ab"
+down_revision: Union[str, None] = "c7a2e5b0913f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # An id no longer in MODEL_SPECS is a KeyError in llm.build_model on every
+    # message, so stored rows move to the nearest surviving model. Only
+    # thinkingmachines still has one; the other two vendors are gone from the
+    # registry entirely, so those rows take the default.
+    #
+    # Runs after b3f9c1d47a20, which parks deepseek/deepseek-v4-pro rows on
+    # deepseek/deepseek-v4-flash-0731 — an id this revision then drops. The
+    # order is what makes that safe: those rows are caught here.
+    op.execute(
+        "UPDATE users SET summarizing_model = CASE summarizing_model "
+        "WHEN 'thinkingmachines/inkling-small' THEN 'thinkingmachines/inkling' "
+        "ELSE 'gemini-3.6-flash' END "
+        "WHERE summarizing_model IN ("
+        "'deepseek/deepseek-v4-flash-0731', 'thinkingmachines/inkling-small', "
+        "'z-ai/glm-5.2')",
+    )
+
+
+def downgrade() -> None:
+    # Not reversed: the three ids are gone from MODEL_SPECS, so restoring them
+    # would leave users on an unselectable id. Same choice as 6bb4ed473ffd,
+    # 12d7c48a6e14, b3f9c1d47a20 and c7a2e5b0913f.
+    pass

--- a/src/config.py
+++ b/src/config.py
@@ -107,12 +107,6 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=True,
         supports_files=True,
     ),
-    "deepseek/deepseek-v4-flash-0731": ModelSpec(
-        label="DeepSeek V4 Flash 0731",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
     "meta/muse-spark-1.2": ModelSpec(
         label="Meta Muse Spark 1.2",
         provider="openrouter",
@@ -139,18 +133,6 @@ MODEL_SPECS: dict[str, ModelSpec] = {
     ),
     "thinkingmachines/inkling": ModelSpec(
         label="Thinking Machines Inkling",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
-    "thinkingmachines/inkling-small": ModelSpec(
-        label="Thinking Machines Inkling Small",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
-    "z-ai/glm-5.2": ModelSpec(
-        label="GLM 5.2",
         provider="openrouter",
         supports_audio=False,
         supports_files=False,

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -41,11 +41,11 @@ def test_build_model_returns_openrouter_model(mocker):
     provider = OpenRouterProvider(api_key="mock_openrouter_key")
     client = LLMClient(mocker.MagicMock(), provider)
 
-    model = client.build_model("deepseek/deepseek-v4-flash-0731")
+    model = client.build_model("openai/gpt-5.6-luna")
 
     assert isinstance(model, OpenRouterCostReporter)
     assert isinstance(model.wrapped, OpenRouterModel)
-    assert model.model_name == "deepseek/deepseek-v4-flash-0731"
+    assert model.model_name == "openai/gpt-5.6-luna"
     assert model.system == "openrouter"
 
 
@@ -53,7 +53,7 @@ def test_build_model_asks_openrouter_for_usage_accounting(mocker):
     """Test the OpenRouter model requests the usage that carries the cost."""
     client = LLMClient(mocker.MagicMock(), OpenRouterProvider(api_key="mock_key"))
 
-    model = client.build_model("z-ai/glm-5.2")
+    model = client.build_model("minimax/minimax-m3")
 
     assert model.settings == {"openrouter_usage": {"include": True}}
 
@@ -173,10 +173,10 @@ def test_build_model_caches_across_providers(mocker):
     client = LLMClient(mocker.MagicMock(), OpenRouterProvider(api_key="mock_key"))
 
     google = client.build_model("gemini-3.6-flash")
-    openrouter = client.build_model("z-ai/glm-5.2")
+    openrouter = client.build_model("minimax/minimax-m3")
 
     assert client.build_model("gemini-3.6-flash") is google
-    assert client.build_model("z-ai/glm-5.2") is openrouter
+    assert client.build_model("minimax/minimax-m3") is openrouter
     assert google is not openrouter
 
 

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -465,7 +465,7 @@ def test_summarize_routes_audio_around_a_model_that_cannot_read_it(mocker):
 
     result = summarizer.summarize(
         data="local_audio.ogg",
-        model="z-ai/glm-5.2",
+        model="minimax/minimax-m3",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         user_id=123,
@@ -505,7 +505,7 @@ def test_summarize_with_document_routes_audio_document_to_transcription(mocker):
 
     result = summarizer.summarize_with_document(
         file=mock_tg_file,
-        model="z-ai/glm-5.2",
+        model="minimax/minimax-m3",
         prompt_key="basic_prompt_for_transcript",
         target_language="English",
         mime_type="audio/ogg",


### PR DESCRIPTION
## What

Removes `deepseek/deepseek-v4-flash-0731`, `thinkingmachines/inkling-small` and `z-ai/glm-5.2`.

`MODEL_SPECS` is left with **6 ids: 1 Google + 5 OpenRouter** — `gemini-3.6-flash`, `meta/muse-spark-1.2`, `minimax/minimax-m3`, `openai/gpt-5.6-luna`, `qwen/qwen3.8-max`, `thinkingmachines/inkling`. (Counted by parsing the dict, not by eye — an earlier PR body in this series got that number wrong.)

## Migration

`d4e81f60c2ab` moves stored rows onto the nearest survivor. Only `thinkingmachines` still has one, so `inkling-small` rows go to `thinkingmachines/inkling`; the other two vendors are gone from the registry entirely, so those rows take the default. An id that has left `MODEL_SPECS` is a `KeyError` in `llm.build_model` on every message that user sends. The downgrade does not restore the three ids, following every model drop before it.

**Revision order matters here.** `b3f9c1d47a20` parks `deepseek/deepseek-v4-pro` rows on `deepseek/deepseek-v4-flash-0731` — an id this revision drops. Because `d4e81f60c2ab` runs after it and matches that id, those rows are swept up rather than stranded. There is a comment saying so; reordering the chain would break it.

## Test and docs fallout

- The dropped ids stood in for "some OpenRouter model" across the suite. `tests/test_llm.py` now names `openai/gpt-5.6-luna` (build_model) and `minimax/minimax-m3` (usage accounting, cache); `tests/test_summary.py`'s audio-routing tests take `minimax/minimax-m3`.
- The README's parenthetical brand list is removed entirely rather than edited again (second commit). It was a prose copy of `MODEL_SPECS` and went stale three times in one day, once per registry change; `/set_summarizing_model` shows the live list.

## Reviewer notes

- 308 tests pass, `src/` stays at 100% line coverage over 1132 statements. `uv run alembic heads` reports one head, `d4e81f60c2ab`.
- **Three migrations are now pending and none has been applied**: `b3f9c1d47a20` (#1033), `c7a2e5b0913f` (#1034) and `d4e81f60c2ab` (here). One `uv run alembic upgrade head` runs them in order before the next deploy. No live database was touched in any of the three PRs.
- Still true from #1034, unfixed: `test_summarize_with_document_keeps_a_model_that_takes_files` (`tests/test_summary.py:569`) cannot fail — it asserts a file-capable model is not substituted while passing the id substitution would produce. One Google model remains, so making it meaningful needs a fabricated spec patched into `summary.MODEL_SPECS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed retired model options from the available model list.
  * Automatically migrated existing configurations using discontinued models to supported alternatives.
  * Updated audio transcription and model-related workflows to use current model options.

* **Documentation**
  * Simplified model configuration guidance while retaining provider and API-key requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->