### PR TITLE
handoff: record the session goal and delivery verdict

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -13,7 +13,9 @@ Under Goal, **Asked** is the request that opened the session, in the user's fram
 
 ```markdown
 # Handoff: [Topic]
-**Date:** [YYYY-MM-DD]  **Branch:** [branch — plus state: active / merged as `sha` / abandoned]  **PR/Issue:** [PR number and/or Linear issue] or None
+**Date:** [YYYY-MM-DD]
+**Branch:** [branch — plus state: active / merged as `sha` / abandoned]
+**PR/Issue:** [PR number and/or Linear issue] or None
 
 ## Goal
 - **Asked:** [the request that opened the session, in the user's framing]

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -9,9 +9,16 @@ Steps:
 
 Under What NOT to Re-Read list the handoffs, plans, and analyses this session actually opened that a later reader should skip, naming what replaces each — a reason to *read* something belongs in Files to Load instead.
 
+Under Goal, **Asked** is the request that opened the session, in the user's framing — recover it from their first message; do not back-fill it from what got built. **Delivered** is one of DELIVERED / PARTIAL / BLOCKED (stopped by something outside the session) / DROPPED (called off), followed by what is true now and the evidence that proves it — a merged sha, a passing suite, a verified output. A session whose deliverable is an answer is DELIVERED when the answer is in the file. It must agree with Unfinished Work: DELIVERED only when nothing left undone blocks the goal; PARTIAL and BLOCKED each point at the numbered Unfinished Work item covering the gap. **Scope changes** records work added or abandoned after the ask, with the reason — a session that grew shows it here, not silently inside What Was Accomplished.
+
 ```markdown
 # Handoff: [Topic]
-**Date:** [YYYY-MM-DD]  **Branch:** [branch]  **Focus:** [one sentence]
+**Date:** [YYYY-MM-DD]  **Branch:** [branch — plus state: active / merged as `sha` / abandoned]  **PR/Issue:** [#1031, STG-133] or None
+
+## Goal
+- **Asked:** [the request that opened the session, in the user's framing]
+- **Delivered:** [DELIVERED/PARTIAL/BLOCKED/DROPPED] — [what is true now; for anything but DELIVERED, the gap and the Unfinished Work item that covers it] — evidence: [the check that proves it]
+- **Scope changes:** [work added or abandoned after the ask, and why] or None
 
 ## What Was Accomplished
 - [task] → `[file:line]`
@@ -31,7 +38,7 @@ Under What NOT to Re-Read list the handoffs, plans, and analyses this session ac
 - [OPEN/ASSUMED item] or None
 
 ## Unfinished Work
-- [ordered, specific action with paths] or None
+1. [ordered, specific action with paths] or None
 
 ## Files to Load Next Session
 - `[path]` — [what it holds and when it matters; add `~L[start]-[end]` if only one region does]

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -9,11 +9,11 @@ Steps:
 
 Under What NOT to Re-Read list the handoffs, plans, and analyses this session actually opened that a later reader should skip, naming what replaces each — a reason to *read* something belongs in Files to Load instead.
 
-Under Goal, **Asked** is the request that opened the session, in the user's framing — recover it from their first message; do not back-fill it from what got built. **Delivered** is one of DELIVERED / PARTIAL / BLOCKED (stopped by something outside the session) / DROPPED (called off), followed by what is true now and the evidence that proves it — a merged sha, a passing suite, a verified output. A session whose deliverable is an answer is DELIVERED when the answer is in the file. It must agree with Unfinished Work: DELIVERED only when nothing left undone blocks the goal; PARTIAL and BLOCKED each point at the numbered Unfinished Work item covering the gap. **Scope changes** records work added or abandoned after the ask, with the reason — a session that grew shows it here, not silently inside What Was Accomplished.
+Under Goal, **Asked** is the request that opened the session, in the user's framing — recover it from their first message; do not back-fill it from what got built. If that message is no longer in context, reconstruct it from the session summary and mark the line ASSUMED. **Delivered** is one of DELIVERED / PARTIAL / BLOCKED (stopped by something outside the session) / DROPPED (called off), followed by what is true now and the evidence that proves it — a merged sha, a passing suite, a verified output. A session whose deliverable is an answer is DELIVERED when the answer is in the file. It must agree with Unfinished Work: DELIVERED only when nothing left undone blocks the goal; PARTIAL and BLOCKED each point at the numbered Unfinished Work item covering the gap; DROPPED still records the state the abandoned work was left in — an uncommitted branch, an unapplied migration — because the next session inherits it. **Scope changes** records work added or abandoned after the ask, with the reason — a session that grew shows it here, not silently inside What Was Accomplished.
 
 ```markdown
 # Handoff: [Topic]
-**Date:** [YYYY-MM-DD]  **Branch:** [branch — plus state: active / merged as `sha` / abandoned]  **PR/Issue:** [#1031, STG-133] or None
+**Date:** [YYYY-MM-DD]  **Branch:** [branch — plus state: active / merged as `sha` / abandoned]  **PR/Issue:** [PR number and/or Linear issue] or None
 
 ## Goal
 - **Asked:** [the request that opened the session, in the user's framing]


### PR DESCRIPTION
## What

Adds a `## Goal` block to the handoff template in `.claude/commands/handoff.md`, holding three lines: the original ask, a delivery verdict with its evidence, and any scope change. The retrospective `Focus:` header field is removed — `Asked` takes over its job — and `PR/Issue:` is added alongside the branch state.

## Why

Two things a later reader cannot recover from a handoff today:

- **What was asked.** `Focus:` is written after the fact as a description of what happened, so there is no way to distinguish "the session did the ask" from "the session grew into something else."
- **Whether it was delivered.** The reader has to diff *What Was Accomplished* against *Unfinished Work* and guess. `handoff-2026-08-07-model-registry-cleanup.md` reports three merged PRs *and* three migrations never applied to production; `handoff-2026-08-07-openrouter-cost-tracking.md` shipped #1031 whose central claim was never verified in the Langfuse UI. Both scan as clean successes.

The gap was already being improvised into fields with no slot for it: `Focus:` lines carry outcomes ("shipped", "deferred", "without writing any code"), and one `Branch:` field was hand-extended to "`config-drop-three-openrouter-models` (merged; local `main` is 1 behind `origin/main`)".

## The rule that gives the verdict teeth

`Delivered` is one of DELIVERED / PARTIAL / BLOCKED / DROPPED and must agree with Unfinished Work — DELIVERED only when nothing left undone blocks the goal, PARTIAL and BLOCKED each pointing at the numbered item covering the gap. Without that cross-check, "DELIVERED" can sit above three open steps, which is exactly the current failure mode. `Unfinished Work` switches from `-` to `1.` so the reference is possible; every existing handoff already numbers it in practice.

## Verification

Dry-rendered against the two sessions above (scratchpad only, neither file rewritten). Both filled cleanly from existing content and both came out **PARTIAL** — the registry cleanup on its three unapplied migrations, the cost-tracking one on the never-verified Langfuse claim. Neither could honestly have been written DELIVERED.

## Reviewer notes

- Second commit applies three findings from a review of the first: the `PR/Issue:` placeholder held real ids (`#1031`, `STG-133`) that could be copied verbatim into an unrelated handoff; `Asked` had no fallback for when the opening message has been summarized out of context (now reconstructs from the session summary and marks the line ASSUMED, reusing the OPEN/ASSUMED convention from AGENTS.md Rule 2); and the cross-check omitted DROPPED, letting an abandoned session record `Unfinished Work: None` and lose the state the next session inherits.
- Deliberately **not** in scope, at the author's direction: the `Files Modified` table's ~80% duplication of `What Was Accomplished`, and its constant "archived the previous handoff" row. This PR adds only.
- No `AGENTS.md` change needed. Line 5 routes readers via *Files to Load Next Session* / *What NOT to Re-Read*, both untouched; Rule 1 points at this command file, which stays authoritative.
- Markdown only. Nothing mechanical parses handoffs — no hook, script, or CI step — so removing `Focus:` breaks no tooling, and the docs-only commits skip all four pre-commit hooks per `docs/context/git-guide.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the handoff template with dedicated fields for the original request, delivery status, supporting evidence, and scope changes.
  * Added guidance for archiving previous handoffs and creating uniquely named, dated handoff records.
  * Added instructions to report the resulting file path and contents.
  * Clarified how to document materials that should not be re-read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->