### PR TITLE
config: register four more openrouter models

### DIFF
--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -228,7 +228,9 @@ to Gemini — return the raw model text with **no** prefix.
   the instrumented model: pydantic-ai closes the generation span before `run_sync`
   returns, so nothing afterwards can reach it. Drop the wrapper and every OpenRouter
   trace silently goes back to tokens with no cost, which is the number the traces exist
-  to compare models on.
+  to compare models on. Several registered ids carry OpenRouter's `:free` suffix; those are
+  billed at zero, so their spans do get a `gen_ai.usage.cost`, of `0.0` — OpenRouter's own
+  number, not a wrapper that stopped working.
   `Tracer.observe_message` opens no span of its own, it only names and attributes
   (`trace_name="handle_message"`, tagged with the content type, plus `prompt_key`,
   `prompt_version`, `target_language` and `thinking_level` as metadata) whatever spans

--- a/src/config.py
+++ b/src/config.py
@@ -107,6 +107,12 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=True,
         supports_files=True,
     ),
+    "inclusionai/ling-3.0-flash:free": ModelSpec(
+        label="InclusionAI Ling 3.0 Flash",
+        provider="openrouter",
+        supports_audio=False,
+        supports_files=False,
+    ),
     "meta/muse-spark-1.2": ModelSpec(
         label="Meta Muse Spark 1.2",
         provider="openrouter",
@@ -119,14 +125,32 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=False,
         supports_files=False,
     ),
+    "nvidia/nemotron-3-ultra-550b-a55b:free": ModelSpec(
+        label="NVIDIA Nemotron 3 Ultra 550B",
+        provider="openrouter",
+        supports_audio=False,
+        supports_files=False,
+    ),
     "openai/gpt-5.6-luna": ModelSpec(
         label="GPT-5.6 Luna",
         provider="openrouter",
         supports_audio=False,
         supports_files=False,
     ),
+    "poolside/laguna-s-2.1:free": ModelSpec(
+        label="Poolside Laguna S 2.1",
+        provider="openrouter",
+        supports_audio=False,
+        supports_files=False,
+    ),
     "qwen/qwen3.8-max": ModelSpec(
         label="Qwen3.8 Max",
+        provider="openrouter",
+        supports_audio=False,
+        supports_files=False,
+    ),
+    "stepfun/step-3.7-flash": ModelSpec(
+        label="StepFun Step 3.7 Flash",
         provider="openrouter",
         supports_audio=False,
         supports_files=False,


### PR DESCRIPTION
## What changed

Four rows added to `MODEL_SPECS` in `src/config.py`, kept in the file's existing alphabetical-by-id order:

| Id | Label |
|---|---|
| `inclusionai/ling-3.0-flash:free` | InclusionAI Ling 3.0 Flash |
| `nvidia/nemotron-3-ultra-550b-a55b:free` | NVIDIA Nemotron 3 Ultra 550B |
| `poolside/laguna-s-2.1:free` | Poolside Laguna S 2.1 |
| `stepfun/step-3.7-flash` | StepFun Step 3.7 Flash |

All four are `provider="openrouter"` with `supports_audio=False, supports_files=False` — the same as every other OpenRouter row. The flags say what this bot can *deliver*, not what the provider's catalog advertises: OpenRouter has no file API, so a file would have to be base64-inlined.

`docs/context/architecture.md` picks up one new fact in its tracing section: three of the four ids carry OpenRouter's `:free` suffix and bill at zero, so `OpenRouterCostReporter` writes a genuine `gen_ai.usage.cost` of `0.0` onto their spans.

## Why

Widens the `/set_summarizing_model` choice. Adding a model from an already-registered provider is a registry row and nothing else — the ids flow into `MODEL_LABELS`, the reply keyboard and `ALLOWED_MODELS_FOR_SUMMARY` on their own.

## Notes for a reviewer

- **No migration.** Adding an id invalidates no stored `summarizing_model` value; only dropping one does.
- **Label choice.** `nvidia/nemotron-3-ultra-550b-a55b:free` is labelled `NVIDIA Nemotron 3 Ultra 550B`, dropping the `a55b` active-parameter suffix for keyboard readability. Say the word if it should mirror the id exactly.
- **Ids are unverified against OpenRouter's live catalog** — they were taken as given. A wrong id surfaces only at request time, inside `build_model`.
- Full suite passes: 308 tests, coverage still 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for four additional OpenRouter models:
    - InclusionAI Ling 3.0 Flash
    - NVIDIA Nemotron 3 Ultra 550B
    - Poolside Laguna S 2.1
    - StepFun Step 3.7 Flash
  - Newly added models do not support native audio or file inputs.

- **Documentation**
  - Clarified that free OpenRouter models report a usage cost of `0.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->