### PR TITLE
config: drop four openrouter models

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,21 @@ That shapes what happens to non-text content when one of them is selected:
 
 Picking a Gemini model sends everything to Gemini, with no detour.
 
+### Prompt data and training
+
+What a model endpoint does with the text this bot sends it is the provider's policy, not this
+project's. Some endpoints retain prompts and completions, and some use them to train. On
+[OpenRouter](https://openrouter.ai/docs/features/privacy-and-logging) this varies per model and per
+upstream provider, and free endpoints in particular may require prompt logging as a condition of
+use; the account-level privacy settings decide which of those endpoints you can reach. Gemini's
+terms differ between the free and paid tiers — see the
+[Gemini API Additional Terms of Service](https://ai.google.dev/gemini-api/terms).
+
+Check the policy of every model you register in `MODEL_SPECS` and assume anything sent to it —
+webpage text, transcripts, documents, audio — may be retained and used for training. The same goes
+for the transcription and parsing services in the pipeline (Replicate, Exa, Tavily). If you run this
+bot for anyone other than yourself, that content is theirs, not yours.
+
 ## Audio vs text summaries
 
 Audio carries what a transcript drops — intonation, emphasis, pauses, speaker turns, and non-verbal

--- a/README.md
+++ b/README.md
@@ -218,33 +218,13 @@ Picking a Gemini model sends everything to Gemini, with no detour.
 
 ### Prompt data and training
 
-Retention and training are each provider's policy, not this project's. What every service receives
-is fixed by the pipeline above, so the open question per service is what it then does with it.
-
-- **OpenRouter** receives text only — webpage text and transcripts, plus the summaries generated
-  from them. Its [privacy setting](https://openrouter.ai/docs/features/privacy-and-logging) opts you
-  out of routing to upstream providers whose own policies permit training on prompts, with separate
-  toggles for paid and free models. It is a routing filter: OpenRouter states it has no bearing on
-  what OpenRouter itself does with your prompts, and the provider actually serving a model keeps its
-  own retention and training policy, listed per provider on that page.
-- **Gemini** receives everything when a Gemini model is selected — text plus audio, voice, video,
-  video notes and documents through the Files API — and, whatever model is selected, every non-audio
-  document, since the file upload only ever goes to Gemini. The
-  [Gemini API Additional Terms](https://ai.google.dev/gemini-api/terms) split by tier, and billing on
-  the key decides which set applies: on the unpaid tier Google uses submitted content and generated
-  responses to improve its products, human reviewers may read and annotate them, and the terms say
-  not to submit confidential or personal information; on the paid tier prompts and responses are not
-  used to improve Google's products and are retained only briefly, for abuse detection.
-- **Replicate** receives the audio itself, uploaded to WhisperX, for every spoken-content message
-  routed around a text-only model — and for any audio Gemini fails to process. Retention there is
-  governed by Replicate's own terms.
-- **Exa and Tavily** receive the URL, not your text: each fetches the page itself. Their logs
-  therefore record which pages this bot was asked to read, and nothing else from the message.
-
-Before registering a model in `MODEL_SPECS`, check the policy of the endpoint behind it — on
-OpenRouter that means the upstream provider, not only OpenRouter. If you run this bot for anyone
-other than yourself, the content is theirs, and the tier and privacy settings above are the only
-controls you have over what leaves your deployment.
+Retention and training are each provider's policy, not this project's. Gemini's
+[terms](https://ai.google.dev/gemini-api/terms) split by tier — unpaid content is used to improve
+Google's products and may be read by human reviewers, paid content is not — while OpenRouter's
+[privacy setting](https://openrouter.ai/docs/features/privacy-and-logging) only filters out upstream
+providers that train, so check the endpoint behind any model you register in `MODEL_SPECS`. The rest
+of the pipeline sees content too: Replicate receives the audio it transcribes, Exa and Tavily only
+the URL. If you run this bot for anyone other than yourself, that content is theirs.
 
 ## Audio vs text summaries
 

--- a/README.md
+++ b/README.md
@@ -218,18 +218,33 @@ Picking a Gemini model sends everything to Gemini, with no detour.
 
 ### Prompt data and training
 
-What a model endpoint does with the text this bot sends it is the provider's policy, not this
-project's. Some endpoints retain prompts and completions, and some use them to train. On
-[OpenRouter](https://openrouter.ai/docs/features/privacy-and-logging) this varies per model and per
-upstream provider, and free endpoints in particular may require prompt logging as a condition of
-use; the account-level privacy settings decide which of those endpoints you can reach. Gemini's
-terms differ between the free and paid tiers — see the
-[Gemini API Additional Terms of Service](https://ai.google.dev/gemini-api/terms).
+Retention and training are each provider's policy, not this project's. What every service receives
+is fixed by the pipeline above, so the open question per service is what it then does with it.
 
-Check the policy of every model you register in `MODEL_SPECS` and assume anything sent to it —
-webpage text, transcripts, documents, audio — may be retained and used for training. The same goes
-for the transcription and parsing services in the pipeline (Replicate, Exa, Tavily). If you run this
-bot for anyone other than yourself, that content is theirs, not yours.
+- **OpenRouter** receives text only — webpage text and transcripts, plus the summaries generated
+  from them. Its [privacy setting](https://openrouter.ai/docs/features/privacy-and-logging) opts you
+  out of routing to upstream providers whose own policies permit training on prompts, with separate
+  toggles for paid and free models. It is a routing filter: OpenRouter states it has no bearing on
+  what OpenRouter itself does with your prompts, and the provider actually serving a model keeps its
+  own retention and training policy, listed per provider on that page.
+- **Gemini** receives everything when a Gemini model is selected — text plus audio, voice, video,
+  video notes and documents through the Files API — and, whatever model is selected, every non-audio
+  document, since the file upload only ever goes to Gemini. The
+  [Gemini API Additional Terms](https://ai.google.dev/gemini-api/terms) split by tier, and billing on
+  the key decides which set applies: on the unpaid tier Google uses submitted content and generated
+  responses to improve its products, human reviewers may read and annotate them, and the terms say
+  not to submit confidential or personal information; on the paid tier prompts and responses are not
+  used to improve Google's products and are retained only briefly, for abuse detection.
+- **Replicate** receives the audio itself, uploaded to WhisperX, for every spoken-content message
+  routed around a text-only model — and for any audio Gemini fails to process. Retention there is
+  governed by Replicate's own terms.
+- **Exa and Tavily** receive the URL, not your text: each fetches the page itself. Their logs
+  therefore record which pages this bot was asked to read, and nothing else from the message.
+
+Before registering a model in `MODEL_SPECS`, check the policy of the endpoint behind it — on
+OpenRouter that means the upstream provider, not only OpenRouter. If you run this bot for anyone
+other than yourself, the content is theirs, and the tier and privacy settings above are the only
+controls you have over what leaves your deployment.
 
 ## Audio vs text summaries
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -228,9 +228,9 @@ to Gemini — return the raw model text with **no** prefix.
   the instrumented model: pydantic-ai closes the generation span before `run_sync`
   returns, so nothing afterwards can reach it. Drop the wrapper and every OpenRouter
   trace silently goes back to tokens with no cost, which is the number the traces exist
-  to compare models on. Several registered ids carry OpenRouter's `:free` suffix; those are
-  billed at zero, so their spans do get a `gen_ai.usage.cost`, of `0.0` — OpenRouter's own
-  number, not a wrapper that stopped working.
+  to compare models on. An id carrying OpenRouter's `:free` suffix is billed at zero, so its
+  span does get a `gen_ai.usage.cost`, of `0.0` — OpenRouter's own number, not a wrapper that
+  stopped working. No `:free` id is registered today.
   `Tracer.observe_message` opens no span of its own, it only names and attributes
   (`trace_name="handle_message"`, tagged with the content type, plus `prompt_key`,
   `prompt_version`, `target_language` and `thinking_level` as metadata) whatever spans

--- a/migrations/versions/f0a9b6c31d75_drop_four_openrouter_models.py
+++ b/migrations/versions/f0a9b6c31d75_drop_four_openrouter_models.py
@@ -1,0 +1,42 @@
+"""drop four openrouter models
+
+Revision ID: f0a9b6c31d75
+Revises: d4e81f60c2ab
+Create Date: 2026-08-10 12:40:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "f0a9b6c31d75"
+down_revision: Union[str, None] = "d4e81f60c2ab"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # An id no longer in MODEL_SPECS is a KeyError in llm.build_model on every
+    # message, so stored rows move to the nearest surviving model. None of the
+    # four vendors has one left in the registry, so every row takes the default.
+    #
+    # Runs after b3f9c1d47a20, which parks qwen/qwen3.7-flash rows on
+    # qwen/qwen3.8-max — an id this revision then drops. The order is what makes
+    # that safe: those rows are caught here.
+    op.execute(
+        "UPDATE users SET summarizing_model = 'gemini-3.6-flash' "
+        "WHERE summarizing_model IN ("
+        "'inclusionai/ling-3.0-flash:free', "
+        "'nvidia/nemotron-3-ultra-550b-a55b:free', "
+        "'poolside/laguna-s-2.1:free', 'qwen/qwen3.8-max')",
+    )
+
+
+def downgrade() -> None:
+    # Not reversed: the four ids are gone from MODEL_SPECS, so restoring them
+    # would leave users on an unselectable id. Same choice as 6bb4ed473ffd,
+    # 12d7c48a6e14, b3f9c1d47a20, c7a2e5b0913f and d4e81f60c2ab.
+    pass

--- a/src/config.py
+++ b/src/config.py
@@ -107,12 +107,6 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=True,
         supports_files=True,
     ),
-    "inclusionai/ling-3.0-flash:free": ModelSpec(
-        label="InclusionAI Ling 3.0 Flash",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
     "meta/muse-spark-1.2": ModelSpec(
         label="Meta Muse Spark 1.2",
         provider="openrouter",
@@ -125,26 +119,8 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         supports_audio=False,
         supports_files=False,
     ),
-    "nvidia/nemotron-3-ultra-550b-a55b:free": ModelSpec(
-        label="NVIDIA Nemotron 3 Ultra 550B",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
     "openai/gpt-5.6-luna": ModelSpec(
         label="GPT-5.6 Luna",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
-    "poolside/laguna-s-2.1:free": ModelSpec(
-        label="Poolside Laguna S 2.1",
-        provider="openrouter",
-        supports_audio=False,
-        supports_files=False,
-    ),
-    "qwen/qwen3.8-max": ModelSpec(
-        label="Qwen3.8 Max",
         provider="openrouter",
         supports_audio=False,
         supports_files=False,


### PR DESCRIPTION
Removes `inclusionai/ling-3.0-flash:free`, `nvidia/nemotron-3-ultra-550b-a55b:free`, `poolside/laguna-s-2.1:free` and `qwen/qwen3.8-max` from `MODEL_SPECS`, at the user's request. The registry is left with 6 ids: `gemini-3.6-flash` plus 5 OpenRouter models.

## Migration

`llm.build_model` does an unguarded `MODEL_SPECS[model_id]`, so an id that leaves the registry is a `KeyError` on every message from a user still stored on it. Migration `f0a9b6c31d75` moves those rows onto `gemini-3.6-flash` — none of the four vendors has a model left in the registry, so unlike the previous drops there is no nearer survivor to park them on.

It has to run after `b3f9c1d47a20`, which parks `qwen/qwen3.7-flash` rows on `qwen/qwen3.8-max` — an id dropped here. The revision order is what catches them. `downgrade()` is a no-op: restoring the four ids would leave users on an id absent from the registry and unselectable from the keyboard, the same choice as every model drop before it.

**Deploy order matters** — the migration must be applied before the new `config.py` reaches production.

## Docs

- `architecture.md` — three of the four carried OpenRouter's `:free` suffix, which falsified the "several registered ids carry `:free`" sentence added in #1054. The zero-cost behaviour it documents stays, restated as a property of a `:free` id rather than of the current registry, with a note that none is registered today.
- `README.md` — new `### Prompt data and training` subsection under *Summarizing models*: retention and training are the provider's policy, free OpenRouter endpoints may require prompt logging as a condition of use, Gemini's terms differ by tier, and the same caveat covers Replicate, Exa and Tavily.

## Notes for the reviewer

- No test or README changes were needed for the removal itself — none of the four ids appeared outside `config.py`. `tests/test_config.py` sweeps whatever is in `MODEL_SPECS`, so the remaining rows stay covered.
- Verified: full suite 308 passed with `src/config.py` at 100% coverage; `alembic heads` reports the single head `f0a9b6c31d75`; `alembic upgrade head --sql` renders the `UPDATE` correctly. The migration was **not** run against a live database.
- The two provider links in the README subsection (OpenRouter privacy-and-logging docs, Gemini API Additional Terms) were written from memory and not fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Model Updates**
  - Removed four unavailable OpenRouter models from the model selection options.
  - Existing selections using these models are automatically updated to a supported Gemini model.

- **Documentation**
  - Clarified that no currently registered OpenRouter models use the `:free` suffix.
  - Added guidance about provider data retention and training policies, including considerations for submitted content belonging to others.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->