### PR TITLE
docs: make the pre-commit hook scopes in git-guide accurate

### DIFF
--- a/docs/context/git-guide.md
+++ b/docs/context/git-guide.md
@@ -28,7 +28,26 @@ ci: update codecov action
 
 ## Pre-Commit Checks
 
-Hooks run automatically at commit time, each scoped to the files it matches — the ruff hooks to any staged Python file, `ty` and `pytest` to `src/`, `tests/`, `pyproject.toml`, and `uv.lock` — so a docs-only commit skips all four. Do not run them manually first, and never bypass them with `--no-verify`. If a hook fails or modifies files, fix, re-stage, and commit again.
+Hooks run automatically at commit time, each scoped to the files it matches. Never bypass them with
+`--no-verify`. If a hook fails or modifies files, fix, re-stage, and commit again.
+
+The hygiene hooks — `gitleaks`, `end-of-file-fixer`, `trailing-whitespace`, the `check-*` hooks,
+`detect-private-key`, `uv-lock` — run on **every** commit, docs-only ones included, and
+`end-of-file-fixer` rewrites files rather than just rejecting them. The Python hooks are narrower,
+and their scopes are not identical:
+
+| Hook | Matches |
+|------|---------|
+| `ruff-check`, `ruff-format` | any staged Python file |
+| `pytest` | `src/`, `tests/`, `pyproject.toml`, `uv.lock` |
+| `ty` | `src/`, `pyproject.toml`, `uv.lock` — **not** `tests/` |
+
+So a test-only change is never type-checked at commit time; run `uvx ty check .` yourself if the
+change could affect types.
+
+Do not pre-run the hook suite as a gate before committing — that is the hook's job, and it is
+already what runs. Running `uv run pytest --cov` while iterating on code is a different thing and is
+expected; see `docs/context/uv-guide.md`.
 
 **Coverage:** The project is at 100% line coverage — keep it there by covering new or changed code in the same commit. There is no `--cov-fail-under` gate; review the report printed by the pytest hook and make sure your commit does not introduce new uncovered lines. CI separately uploads branch coverage to Codecov.
 

--- a/docs/context/git-guide.md
+++ b/docs/context/git-guide.md
@@ -31,19 +31,27 @@ ci: update codecov action
 Hooks run automatically at commit time, each scoped to the files it matches. Never bypass them with
 `--no-verify`. If a hook fails or modifies files, fix, re-stage, and commit again.
 
-The hygiene hooks — `gitleaks`, `end-of-file-fixer`, `trailing-whitespace`, the `check-*` hooks,
-`detect-private-key`, `uv-lock` — run on **every** commit, docs-only ones included, and
-`end-of-file-fixer` rewrites files rather than just rejecting them. The Python hooks are narrower,
-and their scopes are not identical:
+Only `gitleaks` runs unconditionally; every other hook is file-scoped, and barely any two share a
+scope. Half the filters live in `.pre-commit-config.yaml`, half in the upstream
+`.pre-commit-hooks.yaml` of each pinned repo — check both before claiming a hook covered something:
 
 | Hook | Matches |
 |------|---------|
-| `ruff-check`, `ruff-format` | any staged Python file |
+| `gitleaks` | every commit — `pass_filenames: false`, it scans the staged diff itself |
+| `check-added-large-files` | every staged file |
+| `end-of-file-fixer`, `check-merge-conflict`, `detect-private-key` | every staged text file |
+| `trailing-whitespace` | every staged text file **except** `*.py` — ruff owns Python formatting |
+| `check-yaml` / `check-toml` | staged `.yaml`/`.yml` / `.toml` files |
+| `uv-lock` | `uv.lock`, `pyproject.toml`, `uv.toml` |
+| `ruff-check`, `ruff-format` | staged `.py`, `.pyi`, `.ipynb` |
 | `pytest` | `src/`, `tests/`, `pyproject.toml`, `uv.lock` |
 | `ty` | `src/`, `pyproject.toml`, `uv.lock` — **not** `tests/` |
 
-So a test-only change is never type-checked at commit time; run `uvx ty@latest check .` yourself if
-the change could affect types — `@latest` per *Always `@latest`* below, which the hook honours too.
+Two consequences worth holding onto. A test-only change is never type-checked at commit time, so run
+`uvx ty@latest check .` yourself when it could affect types — `@latest` per *Always `@latest`*
+below, which the hook honours too. And `end-of-file-fixer`, `trailing-whitespace`, and
+`ruff-check --fix` *rewrite* files instead of merely rejecting them, so a "failed" commit has often
+already fixed itself and only needs re-staging.
 
 Do not pre-run the hook suite as a gate before committing — that is the hook's job, and it is
 already what runs. Running `uv run pytest --cov` while iterating on code is a different thing and is

--- a/docs/context/git-guide.md
+++ b/docs/context/git-guide.md
@@ -38,9 +38,9 @@ scope. Half the filters live in `.pre-commit-config.yaml`, half in the upstream
 | Hook | Matches |
 |------|---------|
 | `gitleaks` | every commit — `pass_filenames: false`, it scans the staged diff itself |
-| `check-added-large-files` | every staged file |
+| `check-added-large-files` | files staged for **addition** only — no `--enforce-all`, so edits to existing files are never size-checked |
 | `end-of-file-fixer`, `check-merge-conflict`, `detect-private-key` | every staged text file |
-| `trailing-whitespace` | every staged text file **except** `*.py` — ruff owns Python formatting |
+| `trailing-whitespace` | every staged text file **except** `*.py` — `ruff-format` owns those. `.pyi` and `.ipynb` are *not* excluded, so they get both |
 | `check-yaml` / `check-toml` | staged `.yaml`/`.yml` / `.toml` files |
 | `uv-lock` | `uv.lock`, `pyproject.toml`, `uv.toml` |
 | `ruff-check`, `ruff-format` | staged `.py`, `.pyi`, `.ipynb` |
@@ -49,8 +49,9 @@ scope. Half the filters live in `.pre-commit-config.yaml`, half in the upstream
 
 Two consequences worth holding onto. A test-only change is never type-checked at commit time, so run
 `uvx ty@latest check .` yourself when it could affect types — `@latest` per *Always `@latest`*
-below, which the hook honours too. And `end-of-file-fixer`, `trailing-whitespace`, and
-`ruff-check --fix` *rewrite* files instead of merely rejecting them, so a "failed" commit has often
+below, which the hook honours too. And five hooks *rewrite* files instead of merely rejecting them —
+`end-of-file-fixer`, `trailing-whitespace`, `ruff-check --fix`, `ruff-format` (it formats in place;
+there is no `--check`), and `uv-lock` (it regenerates `uv.lock`) — so a "failed" commit has often
 already fixed itself and only needs re-staging.
 
 Do not pre-run the hook suite as a gate before committing — that is the hook's job, and it is

--- a/docs/context/git-guide.md
+++ b/docs/context/git-guide.md
@@ -42,8 +42,8 @@ and their scopes are not identical:
 | `pytest` | `src/`, `tests/`, `pyproject.toml`, `uv.lock` |
 | `ty` | `src/`, `pyproject.toml`, `uv.lock` — **not** `tests/` |
 
-So a test-only change is never type-checked at commit time; run `uvx ty check .` yourself if the
-change could affect types.
+So a test-only change is never type-checked at commit time; run `uvx ty@latest check .` yourself if
+the change could affect types — `@latest` per *Always `@latest`* below, which the hook honours too.
 
 Do not pre-run the hook suite as a gate before committing — that is the hook's job, and it is
 already what runs. Running `uv run pytest --cov` while iterating on code is a different thing and is

--- a/docs/context/uv-guide.md
+++ b/docs/context/uv-guide.md
@@ -17,10 +17,15 @@ uv add --group dev package-name      # add a dev dependency
 uv lock --upgrade                    # update dependencies
 ```
 
-`uv run pytest --cov` is the whole test command — `[tool.coverage.run]` already pins `source` and
-`[tool.coverage.report]` already sets `show_missing`, so `--cov=src` and `--cov-report=term-missing`
-add nothing. It is also what the pre-commit hook runs (plus `-q`); see
+`uv run pytest --cov` needs no extra flags for the usual case — `[tool.coverage.run]` already pins
+`source` and `[tool.coverage.report]` already sets `show_missing`, so `--cov=src` and
+`--cov-report=term-missing` add nothing. It is also what the pre-commit hook runs (plus `-q`); see
 `docs/context/git-guide.md` for how that gate works.
+
+The one flag that is *not* redundant is `--cov-branch`. `[tool.coverage.run]` sets no `branch`, so
+the command above measures lines only, while CI runs `uv run pytest --cov --cov-branch
+--cov-report=xml` and uploads branch coverage to Codecov. To reproduce anything Codecov flags, add
+`--cov-branch` locally or the numbers will not match.
 
 Use `uv add` rather than hand-editing `pyproject.toml`. Keep production dependencies in
 `[project.dependencies]`; everything else goes in the appropriate group under `[dependency-groups]`.

--- a/docs/context/uv-guide.md
+++ b/docs/context/uv-guide.md
@@ -5,6 +5,7 @@ command through `uv run`; never bare `python`, `pip`, `poetry`, or `conda`.
 
 ```bash
 uv sync                              # install deps (dev + test by default)
+uv run pytest --cov                  # run the tests with the coverage report
 uv run python src/main.py            # run the bot
 uv run python scripts/db.py          # bootstrap the users table
 uv run alembic upgrade head          # apply migrations
@@ -15,6 +16,11 @@ uv add package-name                  # add a production dependency
 uv add --group dev package-name      # add a dev dependency
 uv lock --upgrade                    # update dependencies
 ```
+
+`uv run pytest --cov` is the whole test command — `[tool.coverage.run]` already pins `source` and
+`[tool.coverage.report]` already sets `show_missing`, so `--cov=src` and `--cov-report=term-missing`
+add nothing. It is also what the pre-commit hook runs (plus `-q`); see
+`docs/context/git-guide.md` for how that gate works.
 
 Use `uv add` rather than hand-editing `pyproject.toml`. Keep production dependencies in
 `[project.dependencies]`; everything else goes in the appropriate group under `[dependency-groups]`.


### PR DESCRIPTION
## What changed

`docs/context/git-guide.md` — the *Pre-Commit Checks* section now lists every hook with its real file filter in a table, replacing prose that described four of the thirteen and got one of those wrong.

`docs/context/uv-guide.md` — added `uv run pytest --cov` to the command block (it was absent entirely), plus a note that `--cov-branch` is the one flag that is *not* redundant.

## Why

Both files are load-bearing for agents: `AGENTS.md` routes every Python command through `uv-guide.md` and every commit through `git-guide.md`. Three claims in them did not match the config.

- **`ty`'s scope was stated wrong.** The doc said `ty` and `pytest` both match `src/`, `tests/`, `pyproject.toml`, `uv.lock`. `ty`'s hook is `files: ^src/|^(pyproject\.toml|uv\.lock)$` — no `tests/`. A test-only change was never type-checked, while the doc said it was.
- **"a docs-only commit skips all four" implied nothing runs.** Six hooks run on a markdown-only commit, and `end-of-file-fixer` *rewrites* files rather than rejecting them.
- **`uv-guide.md` had no test command**, so sessions were synthesising divergent forms from old handoffs — `--cov`, `--cov=src`, `-q`, `--tb=no -q` all appear in `docs/archive/`.
- **Local coverage is line-only.** `[tool.coverage.run]` sets no `branch`, while `.github/workflows/codecov.yml:33` runs `--cov-branch`. Nothing said so, so a Codecov branch-coverage finding could not be reproduced by following the docs.

## For the reviewer

The first commit fixed the original errors but introduced three new ones of the same kind — it listed `uv-lock`, `check-yaml`, and `check-toml` as always-running when all three are file-scoped, and missed `trailing-whitespace`'s `exclude: \.py$`. A review pass caught these and the third commit corrects them.

The root cause is worth knowing before reviewing the table: **hook filters live in two places.** This repo's `.pre-commit-config.yaml` declares some, and each pinned repo's upstream `.pre-commit-hooks.yaml` declares the rest — `check-yaml` carries `types: [yaml]` upstream and nothing locally, which is exactly what made it look unrestricted. Every row in the final table was read from both sources. The doc now says this explicitly so the next editor does not repeat it.

Worth verifying: the table against `.pre-commit-config.yaml` plus `~/.cache/pre-commit/*/.pre-commit-hooks.yaml`. No code or dependency changes — Python hooks skip this commit, per the table it adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded pre-commit guidance with hook coverage, secret scanning, type-checking caveats, auto-fixing behavior, and commit workflow clarifications.
  * Added coverage-enabled testing instructions, including branch coverage requirements for matching CI results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->