### PR TITLE
docs: tighten agent instructions around actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Start Each Session
 
-Do not load handoffs automatically. When the user explicitly asks to continue previous work, load every handoff they name. If they do not name a handoff, ask which one to load. Then load each handoff's Files to Load Next Session and skip its What NOT to Re-Read list.
+Load handoffs from `docs/summaries/` or `docs/archive/` only when the user points to previous work. Read every handoff they name, load its Files to Load Next Session, and skip its What NOT to Re-Read list. Otherwise, treat handoffs as work logs, not session context.
 
 Before touching code, read `docs/context/architecture.md`. Before writing code, also read `docs/context/style-guide.md` for conventions Ruff does not enforce. Skip both for docs-only work.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,31 +1,36 @@
 # AGENTS.md
 
-## Session Start
+## Start Each Session
 
-Handoffs in `docs/summaries/` and `docs/archive/` are a work log, not session context — never load one on your own. When the user points at previous work, read every handoff they name, then follow each one's Files to Load Next Session and skip whatever its What NOT to Re-Read lists.
+Load handoffs from `docs/summaries/` or `docs/archive/` only when the user points to previous work. Read every handoff they name, load its Files to Load Next Session, and skip its What NOT to Re-Read list. Otherwise, treat handoffs as work logs, not session context.
 
-Read `docs/context/architecture.md` before touching code, and `docs/context/style-guide.md` before writing code, for the conventions Ruff does not enforce. Docs-only work needs neither.
+Before touching code, read `docs/context/architecture.md`. Before writing code, also read `docs/context/style-guide.md` for conventions Ruff does not enforce. Skip both for docs-only work.
 
-Then state what you plan to do this session and any open questions.
+State the session plan and any open questions.
 
-Before your first edit to a tracked file, branch off `main` (`git checkout -b <scope>-<short-desc>`, matching the commit scope convention in `docs/context/git-guide.md`). A `PreToolUse` hook enforces this; gitignored files such as handoffs in `docs/summaries/` are exempt.
+Before the first tracked-file edit, branch from `main` with `git checkout -b <scope>-<short-desc>`; follow the commit scope convention in `docs/context/git-guide.md`. A `PreToolUse` hook enforces this for repo files; gitignored handoffs are exempt.
 
 ## Rules
 
-1. **The handoff is a history log, written on demand.** Do not create or update it while work is in progress — write it only when the user asks, by following `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly).
+1. **Write handoffs only on request.** Treat the handoff as a history log, not an in-progress record, and follow `.claude/commands/handoff.md` (the `/handoff` command, or its steps directly).
 2. **Surface every open question.** Mark unresolved items OPEN or ASSUMED in the final answer, and in the handoff when one is written. Before delivering output, verify exact numbers are preserved and claims are backed by specific data.
 3. Before running any Python command or modifying dependencies, read `docs/context/uv-guide.md`.
-4. Commit per `docs/context/git-guide.md`, which also covers the pre-commit hooks and the coverage report. Never bypass hooks with `--no-verify`. Follow-up fixes go into new commits — never amend, rebase, or otherwise rewrite an existing commit unless the user asks for that directly. Under `docs/`, stage only `docs/context/` — the rest is gitignored.
+4. Follow the commit, hook, and coverage process in `docs/context/git-guide.md`. Never bypass hooks with `--no-verify`. Put follow-up fixes in new commits; never amend, rebase, or otherwise rewrite an existing commit unless the user asks directly. Under `docs/`, stage only `docs/context/`; the rest is gitignored.
 5. **Never `git push` unprompted** — a `/create-pr` invocation or direct user request authorizes exactly one push. It does not create standing permission. Otherwise, commit locally and report the branch as ready.
-6. **Work carries its own documentation, while it is still in flight.** Any work — code, docs, or dependencies — updates every `docs/context/` doc it invalidates, in the same PR: a rename or a moved responsibility falsifies the component map in `architecture.md` even though it establishes nothing new, and a dependency bump can retire a documented workaround the same way. A code change additionally updates its tests. Beyond that, promote every durable fact the work establishes into the tracked doc that owns it: `architecture.md` for the component map, gotchas, and standing choices, `style-guide.md` for conventions Ruff does not enforce, `git-guide.md` for commit and hook process, `uv-guide.md` for dependencies and running the project, `AGENTS.md` for session process. A durable fact is anything a later session must not get wrong — an external-service constraint, a settled choice, a rejected review finding, a convention. Do this as part of the work, not at handoff time: the handoff is a work log, it is gitignored, and agent-local memory is not portable. Treat all of it as mandatory — skipping any of it is equivalent to bypassing the pre-commit hooks.
+6. **Keep documentation and tests current in the same PR.**
+   - Update every `docs/context/` file the work invalidates. A rename or moved responsibility invalidates the component map; a dependency bump can retire a documented workaround.
+   - Update tests for every code change.
+   - Record every durable fact the work establishes in its tracked owner: `architecture.md` for the component map, gotchas, and standing choices; `style-guide.md` for conventions Ruff does not enforce; `git-guide.md` for commit and hook process; `uv-guide.md` for dependencies and running the project; `AGENTS.md` for session process.
+
+   A durable fact is anything a later session must not get wrong, such as an external-service constraint, settled choice, rejected review finding, or convention. Record it during the work; gitignored handoffs and agent-local memory are not substitutes. Treat these updates as mandatory, like the pre-commit hooks.
 
 ## Where Things Live
 
-- `docs/summaries/` — session outputs: handoffs (`handoff-*.md`, work log). **(gitignored)**
-- `docs/context/` — reusable domain knowledge, available to every agent; load only the documents the task needs. Agent-local memory is not portable and is not a substitute, so anything a later session must not get wrong belongs here. **(tracked)**
+- `docs/summaries/` — requested handoffs (`handoff-*.md`). **(gitignored)**
+- `docs/context/` — reusable domain knowledge. Load only what the task needs; record durable facts here, not in agent-local memory. **(tracked)**
   - `architecture.md` — component map and data flow; update only on architectural change
   - `style-guide.md` — coding conventions Ruff does not enforce
   - `git-guide.md` — commit format, pre-commit hooks, coverage
   - `uv-guide.md` — running the project and managing dependencies
-- `docs/archive/` — superseded handoffs, flat, no subdirectories. Do not read unless explicitly told. **(gitignored)**
+- `docs/archive/` — superseded handoffs, kept flat. Read only when explicitly told. **(gitignored)**
 - `.claude/commands/handoff.md` — the `/handoff` routine and its template; agents without slash commands follow its steps directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Before touching code, read `docs/context/architecture.md`. Before writing code, 
 
 State the session plan and any open questions.
 
-Before the first tracked-file edit, branch from `main` with `git checkout -b <scope>-<short-desc>`; follow the commit scope convention in `docs/context/git-guide.md`. A `PreToolUse` hook enforces this for repo files; gitignored handoffs are exempt.
+Before the first tracked-file edit, branch from `main` with `git checkout -b <scope>-<short-desc>`; follow the commit scope convention in `docs/context/git-guide.md`. A `PreToolUse` hook enforces this for repo files; gitignored files such as handoffs in `docs/summaries/` are exempt.
 
 ## Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Start Each Session
 
-Load handoffs from `docs/summaries/` or `docs/archive/` only when the user points to previous work. Read every handoff they name, load its Files to Load Next Session, and skip its What NOT to Re-Read list. Otherwise, treat handoffs as work logs, not session context.
+Do not load handoffs automatically. When the user explicitly asks to continue previous work, load every handoff they name. If they do not name a handoff, ask which one to load. Then load each handoff's Files to Load Next Session and skip its What NOT to Re-Read list.
 
 Before touching code, read `docs/context/architecture.md`. Before writing code, also read `docs/context/style-guide.md` for conventions Ruff does not enforce. Skip both for docs-only work.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Start Each Session
 
-Load handoffs from `docs/summaries/` or `docs/archive/` only when the user points to previous work. Read every handoff they name, load its Files to Load Next Session, and skip its What NOT to Re-Read list. Otherwise, treat handoffs as work logs, not session context.
+Load handoffs from `docs/summaries/` or `docs/archive/` only when the user points to previous work. Read every handoff they name, load its Files to Load Next Session, and skip everything listed under What NOT to Re-Read. Otherwise, treat handoffs as work logs, not session context.
 
 Before touching code, read `docs/context/architecture.md`. Before writing code, also read `docs/context/style-guide.md` for conventions Ruff does not enforce. Skip both for docs-only work.
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -1,15 +1,13 @@
 # Architecture
 
-High-level component map and data flow for orientation at session start. **Stable** —
-update only on a real architectural change (new component, new flow, routing/fallback
-rewrite) or a durable external-service gotcha (→ Cross-cutting patterns), not every
-handoff. Not a source mirror: read the source for function
-signatures, dependencies, and env vars.
+Use this stable document for high-level orientation. Update it only for an architectural
+change (a new component, flow, or routing/fallback rewrite) or a durable external-service
+gotcha (see *Cross-cutting patterns*), not for every handoff. Read the source for function
+signatures, dependencies, and environment variables; do not mirror them here.
 
-State facts inline, never as a reference to go and fetch — an issue id, PR number, or
-dashboard link resolves to nothing for an agent without access to that system. Provider
-behaviour this repo cannot demonstrate still belongs here (that is what a gotcha is);
-name it as the provider's, so a reader does not go looking for it in the source.
+State facts inline instead of pointing to an issue, PR, or dashboard a reader may not be
+able to access. Record provider behaviour the repo cannot demonstrate as the provider's
+gotcha, so readers do not search for it in the source.
 
 - Stack → `pyproject.toml` + `README.md`
 

--- a/docs/context/style-guide.md
+++ b/docs/context/style-guide.md
@@ -82,12 +82,11 @@ is the entire public surface.
 
 ## Prompt Strings
 
-`src/prompts.py` keeps its indented triple-quoted strings raw. `src/summary.py` already
-calls `dedent(...).strip()` at every call site, so cleaning them at definition time is
-redundant — and worse than redundant: `prompt_version` hashes the raw string, so
-pre-cleaning shifts every digest at once. No test pins a literal digest, so the suite
-stays green while traces recorded either side of the change appear to use different
-prompt versions.
+Keep the indented triple-quoted strings in `src/prompts.py` raw; do not clean them at
+definition time. `src/summary.py` already calls `dedent(...).strip()` at every call site,
+and `prompt_version` hashes the raw string. Pre-cleaning therefore shifts every digest
+at once while the suite stays green because no test pins a literal digest, making traces
+recorded before and after the change appear to use different prompt versions.
 
 ## Documentation Paths
 


### PR DESCRIPTION
## Summary

- rewrite the session-start and documentation-maintenance guidance in `AGENTS.md` as direct actions
- tighten the stable-document preamble in `docs/context/architecture.md`
- lead the prompt-string convention in `docs/context/style-guide.md` with its required action
- preserve the full `git check-ignore` exemption and clarify that agents skip the files listed under `What NOT to Re-Read`

## Why

The reusable documentation mixed concise instructions with repeated or passive explanation. This keeps every existing policy and technical rationale while making the required actions easier to identify. The reusable instruction set drops from 5,136 to 5,000 words.

## Impact

This is documentation-only. Agent behavior should be easier to follow without changing project behavior, dependency state, or runtime code.

## Validation

- reviewed the complete diff against `origin/main`
- `git diff --check`
- documentation-scoped pre-commit hooks passed on every commit
- Python, type-checking, and test hooks correctly skipped because no executable files changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified session guidance, including documentation and test requirements, planning, branching, handoffs, and durable-fact recording.
  * Refined the architecture guide to distinguish stable architectural references from implementation details.
  * Documented prompt formatting requirements to preserve consistent prompt versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->