### PR TITLE
ci: pin setup-uv to latest-known and keep its cache default

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
         with:
+          version: "latest-known"
           enable-cache: true
 
       - name: Set up Python

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,7 +20,7 @@ jobs:
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
         with:
           version: "latest-known"
-          enable-cache: true
+          enable-cache: "auto"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -22,7 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
         with:
           version: "latest-known"
-          enable-cache: true
+          enable-cache: "auto"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7

--- a/.github/workflows/typechecking.yml
+++ b/.github/workflows/typechecking.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
         with:
+          version: "latest-known"
           enable-cache: true
 
       - name: Set up Python

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Before the first tracked-file edit, branch from `main` with `git checkout -b <sc
 6. **Keep documentation and tests current in the same PR.**
    - Update every `docs/context/` file the work invalidates. A rename or moved responsibility invalidates the component map; a dependency bump can retire a documented workaround.
    - Update tests for every code change.
-   - Record every durable fact the work establishes in its tracked owner: `architecture.md` for the component map, gotchas, and standing choices; `style-guide.md` for conventions Ruff does not enforce; `git-guide.md` for commit and hook process; `uv-guide.md` for dependencies and running the project; `AGENTS.md` for session process.
+   - Record every durable fact the work establishes in its tracked owner: `architecture.md` for the component map, gotchas, and standing choices; `style-guide.md` for conventions Ruff does not enforce; `git-guide.md` for commit, hook, and CI-workflow process; `uv-guide.md` for dependencies and running the project; `AGENTS.md` for session process.
 
    A durable fact is anything a later session must not get wrong, such as an external-service constraint, settled choice, rejected review finding, or convention. Record it during the work; gitignored handoffs and agent-local memory are not substitutes. Treat these updates as mandatory, like the pre-commit hooks.
 
@@ -30,7 +30,7 @@ Before the first tracked-file edit, branch from `main` with `git checkout -b <sc
 - `docs/context/` — reusable domain knowledge. Load only what the task needs; record durable facts here, not in agent-local memory. **(tracked)**
   - `architecture.md` — component map and data flow; update only on architectural change
   - `style-guide.md` — coding conventions Ruff does not enforce
-  - `git-guide.md` — commit format, pre-commit hooks, coverage
+  - `git-guide.md` — commit format, pre-commit hooks, coverage, CI workflows
   - `uv-guide.md` — running the project and managing dependencies
 - `docs/archive/` — superseded handoffs, kept flat. Read only when explicitly told. **(gitignored)**
 - `.claude/commands/handoff.md` — the `/handoff` routine and its template; agents without slash commands follow its steps directly.

--- a/docs/context/git-guide.md
+++ b/docs/context/git-guide.md
@@ -66,12 +66,22 @@ expected; see `docs/context/uv-guide.md`.
 
 ## CI Workflows
 
-`astral-sh/setup-uv` is pinned to `version: "latest-known"` in `typechecking.yml` and `codecov.yml`.
-That is deliberate and different from the uvx rule above: `latest-known` installs the newest uv whose
-checksum ships inside the action, so the install is verified and needs no GitHub API lookup at run
-time. Leaving `version` unset would fall through to `latest` — the project pins no uv version in
-`pyproject.toml` and has no `.tool-versions` — which resolves over the API and skips that checksum.
-Do not "upgrade" it to `latest`.
+`astral-sh/setup-uv` is pinned to `version: "latest-known"` in `typechecking.yml` and `codecov.yml`,
+deliberately and unlike the uvx rule above. Left unset, `version` searches for a pinned uv in
+`uv.toml` then `pyproject.toml` and falls through to `latest`; this project pins none — no
+`required-version` under `[tool.uv]`, no `.tool-versions` — so `latest` is what both workflows would
+otherwise get.
+
+What separates the two is **checksum verification, not where the version number comes from**. Both
+read the same `astral-sh/versions` manifest, and `latest-known` still fetches it for the download
+URL, so neither saves a network round-trip. The action verifies a download against `KNOWN_CHECKSUMS`,
+a table baked into the action at the commit you pinned — and when the version is absent from that
+table it **silently skips verification**: `validateChecksum` logs at debug level and returns
+(`src/download/checksum/checksum.ts`, v10.0.0). It will not fall back to the manifest's own `sha256`
+either; `download-version.ts` forwards that value only when a custom `manifest-url` is set, which we
+do not set. `latest-known` resolves to the newest version *inside* the table, so a checksum always
+exists. `latest` resolves to the newest published uv — exactly the case the table cannot cover once
+uv releases past the pinned action, which is most of the time. Do not "upgrade" it to `latest`.
 
 `enable-cache: "auto"` is spelled out in both, which is also the v10 default — written explicitly so
 the choice is visible at the call site and survives a future change of default. `auto` caches on

--- a/docs/context/git-guide.md
+++ b/docs/context/git-guide.md
@@ -63,3 +63,20 @@ expected; see `docs/context/uv-guide.md`.
 **Ruff:** the hooks auto-fix and format, so no manual run is needed. They see only your staged files — a green commit is not a green tree, and only CI sweeps the rest.
 
 **Always `@latest`:** every uvx call site pins it — both ruff hooks, the `ty` hook, and `.github/workflows/typechecking.yml`. Bare `uvx <tool>` reuses a `uv tool install`ed copy that may lag behind CI.
+
+## CI Workflows
+
+`astral-sh/setup-uv` is pinned to `version: "latest-known"` in `typechecking.yml` and `codecov.yml`.
+That is deliberate and different from the uvx rule above: `latest-known` installs the newest uv whose
+checksum ships inside the action, so the install is verified and needs no GitHub API lookup at run
+time. Leaving `version` unset would fall through to `latest` — the project pins no uv version in
+`pyproject.toml` and has no `.tool-versions` — which resolves over the API and skips that checksum.
+Do not "upgrade" it to `latest`.
+
+`enable-cache: true` is also explicit in both. Since v10 the default is `auto`, which caches on
+GitHub-hosted runners *except* on `release`, tag-push, `pull_request_target`, and `workflow_run`
+events (cache-poisoning guard). Neither workflow uses those triggers, except that `codecov.yml` runs
+on bare `on: push`, so it also fires on tag pushes — where the explicit `true` opts back into
+caching that `auto` would have skipped. Harmless here (no untrusted input reaches those runs), but
+drop the line and take `auto` if that ever changes. No `cache-dependency-glob` is needed: the default
+already covers `uv.lock` and `pyproject.toml`.

--- a/docs/context/git-guide.md
+++ b/docs/context/git-guide.md
@@ -73,10 +73,16 @@ time. Leaving `version` unset would fall through to `latest` — the project pin
 `pyproject.toml` and has no `.tool-versions` — which resolves over the API and skips that checksum.
 Do not "upgrade" it to `latest`.
 
-`enable-cache: true` is also explicit in both. Since v10 the default is `auto`, which caches on
+`enable-cache: "auto"` is spelled out in both, which is also the v10 default — written explicitly so
+the choice is visible at the call site and survives a future change of default. `auto` caches on
 GitHub-hosted runners *except* on `release`, tag-push, `pull_request_target`, and `workflow_run`
-events (cache-poisoning guard). Neither workflow uses those triggers, except that `codecov.yml` runs
-on bare `on: push`, so it also fires on tag pushes — where the explicit `true` opts back into
-caching that `auto` would have skipped. Harmless here (no untrusted input reaches those runs), but
-drop the line and take `auto` if that ever changes. No `cache-dependency-glob` is needed: the default
-already covers `uv.lock` and `pyproject.toml`.
+events. That exclusion is a cache-poisoning guard: those events run with the base repo's permissions
+or produce published artifacts, so a cache entry written by a less-trusted run must not flow into
+them. **Do not set `enable-cache: true`** — it opts out of the guard for no gain. The only run it
+would change today is `codecov.yml` on a tag push (its trigger is bare `on: push`), and skipping the
+cache there costs a few seconds of cold install.
+
+The uv cache is a real trust boundary, not just a speed knob: `uv sync` verifies downloads against
+the hashes in `uv.lock`, but a restored cache holds *already-unpacked* wheels that are not re-checked
+against those hashes. No `cache-dependency-glob` is needed — the default already covers `uv.lock` and
+`pyproject.toml`.


### PR DESCRIPTION
Follow-up to #1074, which took `astral-sh/setup-uv` to v10.0.0. This tunes two of the action's inputs in `typechecking.yml` and `codecov.yml`.

## `version: "latest-known"`

Unset, `version` searches `uv.toml` then `pyproject.toml` for a pinned uv and falls through to `latest`. This project pins none — no `required-version` under `[tool.uv]`, no `.tool-versions` — so `latest` is what both workflows were getting.

The difference between the two is **checksum verification**, not where the version number comes from: both read the same `astral-sh/versions` manifest, and `latest-known` still fetches it for the download URL, so neither saves a round-trip.

Reading v10.0.0's source, the action verifies a download against `KNOWN_CHECKSUMS`, a table baked into the action at the pinned commit — and when the version is absent from that table it *silently skips verification*, with `validateChecksum` logging at debug level and returning (`src/download/checksum/checksum.ts`). It does not fall back to the manifest's own `sha256`: `download-version.ts` forwards that value only when a custom `manifest-url` is set, which we do not set.

So `latest-known` resolves to the newest version *inside* the table and is always verified, while `latest` resolves to the newest published uv — precisely the case the table cannot cover once uv releases past the pinned action, which is most of the time.

## `enable-cache: "auto"`

Both workflows carried an explicit `enable-cache: true`, written before v10 changed the default to `auto`. `auto` caches on GitHub-hosted runners *except* on `release`, tag-push, `pull_request_target`, and `workflow_run` events — a cache-poisoning guard, since those events either run with the base repo's permissions or produce published artifacts, and a cache entry written by a less-trusted run should not reach them. Forcing `true` opts out of that guard and buys nothing back.

The one run this changes today is `codecov.yml` on a tag push (its trigger is bare `on: push`, so it fires on tags too); it now does a cold uv install there, a few seconds.

Spelled out as `"auto"` rather than dropping the input, so the choice is visible at the call site.

Worth knowing for review: the uv cache is a real trust boundary, not only a speed knob. `uv sync` verifies downloads against the hashes in `uv.lock`, but a restored cache holds already-unpacked wheels that are not re-checked against those hashes.

## Docs

Per AGENTS.md rule 6, both decisions are recorded in a new **CI Workflows** section of `docs/context/git-guide.md`, including an explicit "do not set `enable-cache: true`" — otherwise the *Always `@latest`* rule directly above it reads like it contradicts pinning `latest-known`. `AGENTS.md`'s two descriptors for `git-guide.md` now mention CI workflows.

No source or test changes; nothing to run beyond the workflows themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)